### PR TITLE
fix(pitwall): the AGENTS hover covered the card it belongs to

### DIFF
--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -86,7 +86,20 @@ const VIEW = {
       {
         headline: `${key} headline`,
         headline_colour: "#ffffff",
-        lines: [{ text: "a body line", colour: "#d1d5db" }],
+        // The PIT card is deliberately overfull. The scroll-reachability
+        // check below needs a body that overflows, and on CI nothing did:
+        // the runner's font metrics are shorter than a Windows desktop's, so
+        // the four cards that overflow by 14 px locally overflow by nothing
+        // there and the check failed its own precondition. A fixture that
+        // guarantees the condition beats one that happens to meet it on the
+        // machine you wrote it on.
+        lines:
+          key === "pit"
+            ? Array.from({ length: 40 }, (_, i) => ({
+                text: `body line ${i} - long enough that this card must scroll anywhere`,
+                colour: "#d1d5db",
+              }))
+            : [{ text: "a body line", colour: "#d1d5db" }],
         status: "OK",
         glyph: "●",
         glyph_colour: "#10b981",

--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -214,6 +214,20 @@ const clip = await page.evaluate(() => {
 check(clip.cut.length === 0, `nothing clips the tooltip (cut by ${clip.cut.join(", ")})`);
 check(clip.onScreen, "the tooltip stays inside the viewport");
 
+// ...and it must not cover the card it belongs to. The popup used to open at
+// the card's own left edge, 32 px down: measured at 68,877 px² of overlap on
+// a 216 px card, so hovering a card to read more HID the card. Asserted as
+// rendered geometry, because "the tooltip exists and is on screen" was
+// already true the whole time it was doing this.
+const overlap = await page.evaluate(() => {
+  const tip = document.querySelector(".agent-tooltip").getBoundingClientRect();
+  const card = document.querySelectorAll(".agent-card")[4].getBoundingClientRect();
+  const x = Math.max(0, Math.min(tip.right, card.right) - Math.max(tip.left, card.left));
+  const y = Math.max(0, Math.min(tip.bottom, card.bottom) - Math.max(tip.top, card.top));
+  return Math.round(x * y);
+});
+check(overlap === 0, `the tooltip does not cover its own card (${overlap} px2)`);
+
 // Qt's `showMessage(text, 1500)` clears itself. The port typed a
 // `transient` flag and read it nowhere until #871.
 // The scrollbars are HIDDEN, not deleted. Víctor asked for the bars inside

--- a/src/pitwall/ui/src/features/agents/AgentCard.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentCard.tsx
@@ -35,20 +35,49 @@ import type { AgentCardView } from "../../lib/agents";
  * top-level window clipped by nothing, and `position: fixed` in the body
  * is the same thing. The clamp keeps it on screen near either edge.
  */
+/** Breathing room between the card and the popup, and from the viewport edge. */
+const TOOLTIP_GAP = 10;
+
 function Tooltip({ html, anchor }: { html: string; anchor: DOMRect }) {
   const ref = useRef<HTMLSpanElement>(null);
-  const [left, setLeft] = useState(anchor.left);
+  const [box, setBox] = useState({ left: anchor.left, top: anchor.top + 32 });
 
   useLayoutEffect(() => {
-    const width = ref.current?.offsetWidth ?? 0;
-    setLeft(Math.max(8, Math.min(anchor.left, window.innerWidth - width - 8)));
-  }, [anchor]);
+    const node = ref.current;
+    if (!node) return;
+    const width = node.offsetWidth;
+    const height = node.offsetHeight;
+
+    // **BESIDE the card, never on top of it.** The popup used to open at the
+    // card's own left edge, 32 px down, which covered the thing you hovered
+    // to read: measured at 68,877 px² of overlap on a 216 px card, so the
+    // card was blanketed and the popup spilled below it. A tooltip that
+    // hides its own subject is worse than no tooltip.
+    //
+    // Right of the card by preference, left when there is no room, and only
+    // then below - which is the old behaviour kept as the last resort for a
+    // card that is wider than the space either side of it.
+    const roomRight = window.innerWidth - anchor.right - TOOLTIP_GAP;
+    const roomLeft = anchor.left - TOOLTIP_GAP;
+    let left: number;
+    if (roomRight >= width) left = anchor.right + TOOLTIP_GAP;
+    else if (roomLeft >= width) left = anchor.left - TOOLTIP_GAP - width;
+    else left = Math.max(TOOLTIP_GAP, Math.min(anchor.left, window.innerWidth - width - TOOLTIP_GAP));
+
+    // Vertically aligned with the card's top, then pulled up only as far as
+    // it must be to stay on screen.
+    const top = Math.max(
+      TOOLTIP_GAP,
+      Math.min(anchor.top, window.innerHeight - height - TOOLTIP_GAP),
+    );
+    setBox({ left, top });
+  }, [anchor, html]);
 
   return createPortal(
     <span
       ref={ref}
       className="agent-tooltip"
-      style={{ top: anchor.top + 32, left }}
+      style={box}
       dangerouslySetInnerHTML={{ __html: html }}
     />,
     document.body,

--- a/src/pitwall/ui/src/styles/agents.css
+++ b/src/pitwall/ui/src/styles/agents.css
@@ -182,10 +182,20 @@
    * unmounts the popup. */
   position: fixed;
   z-index: 10;
-  width: 30rem;
-  max-width: calc(100vw - 16px);
+  /* Sized to its content rather than a flat 30rem. A two-line tooltip used to
+   * be the same 502 px box as a twelve-line one, which reads as a panel that
+   * failed to fill rather than as a popup. */
+  width: max-content;
+  min-width: 18rem;
+  max-width: min(34rem, calc(100vw - 20px));
   max-height: 22rem;
-  overflow: auto;
+  overflow-y: auto;
+  /* The one place the hidden scrollbar has to come BACK. `qt-base.css` hides
+   * it everywhere, which is right for the persistent card chrome Víctor asked
+   * to clear - but this box has a hard height cap and a busy lap overruns it,
+   * so without a bar the transcript is cut with nothing saying so. A popup is
+   * transient, so its scrollbar is not clutter. */
+  scrollbar-width: thin;
   padding: 8px 10px;
   background: var(--qt-elevated);
   border: 1px solid var(--qt-border);
@@ -380,4 +390,19 @@
   width: 100%;
   height: 100%;
   min-height: 140px;
+}
+
+/* Opting the tooltip back INTO a scrollbar, against `qt-base.css`'s blanket
+ * hide. Chromium needs the pseudo-element re-declared; `display: none` there
+ * cannot be undone by `scrollbar-width` alone. */
+.agent-tooltip::-webkit-scrollbar {
+  display: block;
+  width: 6px;
+}
+.agent-tooltip::-webkit-scrollbar-thumb {
+  background: var(--qt-border);
+  border-radius: 3px;
+}
+.agent-tooltip::-webkit-scrollbar-track {
+  background: transparent;
 }


### PR DESCRIPTION
Closes #912. The hover Víctor pointed at.

I could not see the screenshot he sent — it was over the image size limit — so I measured the thing instead.

## The defect

The popup opened at the hovered card's **own left edge, 32 px down**. On a 216 px card that is **68,877 px² of overlap**: it blanketed the card and spilled below it.

You hover a card to read more, and the popup hides the thing you were reading.

| | before | after |
|---|---|---|
| overlap with its own card | **68,877 px²** | **0** |
| width | 502 px, flat | 397 px, sized to content |

It sits beside the card now — right by preference, left when there is no room, and only then below, which is the old behaviour kept as the last resort for a card wider than the space either side of it.

## Two more from the same measurement

- **The width was a flat 502 px whatever the content.** A two-line tooltip was the same box as a twelve-line one, which reads as a panel that failed to fill rather than as a popup.
- **A busy lap was being cut with nothing saying so.** The box has a hard 22rem cap and `overflow: auto`, and the scrollbar-hiding from #907 applies to it. Hiding the persistent chrome inside the cards was the right call; hiding it on a transient popup that can overrun is not — the transcript was silently truncated. The tooltip opts back in with a thin bar.

**That last one is a regression I introduced two PRs ago** — a fix landing on top of a fix, which is the shape this repo keeps hitting and worth naming rather than quietly repairing.

## Out of scope, deliberately

The tooltip still emits Qt's restricted rich-text dialect (`<b>`, `<br>`, `&nbsp;`) because the Python formatters are reused as-is. That is the debt sprint 3 took on knowingly and sprint 8 owns. This PR is placement and legibility, not a content-layer rewrite.

## Checks

```
npm run typecheck                       clean
npm run smoke                           smoke OK: 17 checks  (was 16) · smoke-data OK: 42
uv run pytest tests/surfaces            181 passed
uvx ruff@0.15.22 check . / format --check .   all checks passed / 191 files already formatted
```

The new guard asserts **rendered geometry**, because *"the tooltip exists and is on screen"* was already true — and green — the whole time it was covering the card. Watched red by forcing the beside-placement to fail:

```
smoke FAILED (1):
  - the tooltip does not cover its own card (15810 px2)
```
