### PR TITLE
feat(pitwall): give the DATA window a band-1 status strip

### DIFF
--- a/src/arcade/app.py
+++ b/src/arcade/app.py
@@ -60,6 +60,7 @@ from src.arcade.overlays import (
     ProgressBar,
     RaceEventsPanel,
     WeatherPanel,
+    track_status_label,
 )
 from src.arcade.track import Track
 
@@ -743,6 +744,10 @@ class F1ArcadeView(arcade.View):
             # two unrelated parts of the race into one trace.
             "dropped": dropped,
         }
+        track_status = (
+            self._session.track_status_by_lap.get(int(main_frame.lap), "") if main_frame else ""
+        )
+        status_label = track_status_label(track_status)
         return {
             "gp_name": self._session.gp_name,
             # FastF1's authoritative Location. `gp_name` is whatever the
@@ -775,9 +780,15 @@ class F1ArcadeView(arcade.View):
             # the arcade's own pill reads. "" when the loader has no entry for
             # that lap, which a consumer renders as clear - the same collapse
             # the arcade already makes.
-            "track_status": (
-                self._session.track_status_by_lap.get(int(main_frame.lap), "") if main_frame else ""
-            ),
+            "track_status": track_status,
+            # And the same digits DECODED, for the same reason `driver_colors`
+            # is here: the priority order (red > SC > VSC > yellow) and the
+            # four labels are a project rule, and a consumer decoding the
+            # digits itself would be a second copy of it in another language.
+            # `None` when the loader has no entry, which is NOT the same as a
+            # green track and must not render as one.
+            "track_status_label": status_label[0] if status_label else None,
+            "track_status_color": list(status_label[1]) if status_label else None,
             # Circuit length lets the telemetry window anchor the X axis
             # once and forget — without it the charts would autorange to
             # the current sample's max and shift every broadcast.

--- a/src/arcade/overlays.py
+++ b/src/arcade/overlays.py
@@ -32,6 +32,7 @@ from src.arcade.config import (
     LEGEND_X,
     PROGRESS_BAR_BOTTOM,
     PROGRESS_BAR_HEIGHT,
+    SUCCESS,
     TEXT_PRIMARY,
     TEXT_SECONDARY,
     TEXT_TERTIARY,
@@ -617,6 +618,53 @@ class LeaderboardPanel:
         return ranked + unknown
 
 
+def track_status_banner(code: str) -> tuple[str, tuple[int, int, int]] | None:
+    """Map a FastF1 multi-digit ``TrackStatus`` to (label, RGB), or None if clear.
+
+    Priority red > SC > VSC > yellow > clear, matching how race control
+    announces concurrent events: a red flag wins even if a yellow was
+    already out in another sector.
+
+    Module level rather than a method because two surfaces read it. It used
+    to be ``RaceEventsPanel._status_for``, and a second consumer arriving in
+    TypeScript would have forked the priority order and the four labels
+    across two languages - the defect ``driver_colors`` rides on the wire to
+    prevent.
+
+    --- WHERE TO CHANGE IF THE STATUS CODES CHANGE ---
+    ``src/arcade/app.py`` publishes the decoded form on the broadcast, so
+    PITWALL's status strip renders whatever this returns.
+    """
+    if not code:
+        return None
+    digits = set(code)
+    if "5" in digits:
+        return ("RED FLAG", (239, 68, 68))
+    if "4" in digits:
+        return ("SAFETY CAR", (255, 140, 0))
+    if "6" in digits or "7" in digits:
+        return ("VSC", (245, 158, 11))
+    if "2" in digits:
+        return ("YELLOW FLAG", (250, 204, 21))
+    return None
+
+
+def track_status_label(code: str) -> tuple[str, tuple[int, int, int]] | None:
+    """The banner, but with the clear case named instead of hidden.
+
+    The arcade's pill HIDES itself on a clear track, so it never had to tell
+    "clear" apart from "the loader has no entry for this lap" - both are the
+    absence of a pill. A timing strip always shows a track status, so the
+    two have to separate: ``""`` is unknown and returns None, ``"1"`` is
+    green and says so. Conflating them would put a confident GREEN on a lap
+    whose status nobody knows, which is the sentinel class this repo keeps
+    paying for.
+    """
+    if not code:
+        return None
+    return track_status_banner(code) or ("GREEN", SUCCESS)
+
+
 class RaceEventsPanel:
     """Coloured pill that announces non-clear track status under the leaderboard.
 
@@ -672,7 +720,7 @@ class RaceEventsPanel:
         the same value it already passes to ``F1ArcadeView.on_update``.
         Pass an empty string / ``None`` for clear.
         """
-        status = self._status_for(track_status or "")
+        status = track_status_banner(track_status or "")
         if status is None:
             self._target_alpha = 0.0
         else:
@@ -694,26 +742,6 @@ class RaceEventsPanel:
         self._text.text = self._label
         self._text.color = (255, 255, 255, alpha)
         self._text.draw()
-
-    @staticmethod
-    def _status_for(code: str) -> tuple[str, tuple[int, int, int]] | None:
-        """Map a FastF1 multi-digit ``TrackStatus`` to (label, RGB).
-
-        Priority red > SC > VSC > yellow > clear.  Returns ``None`` when the
-        status is empty / unknown / pure clear so the panel hides itself.
-        """
-        if not code:
-            return None
-        digits = set(code)
-        if "5" in digits:
-            return ("RED FLAG", (239, 68, 68))
-        if "4" in digits:
-            return ("SAFETY CAR", (255, 140, 0))
-        if "6" in digits or "7" in digits:
-            return ("VSC", (245, 158, 11))
-        if "2" in digits:
-            return ("YELLOW FLAG", (250, 204, 21))
-        return None
 
     def _tick_alpha(self, dt: float) -> None:
         delta = self.FADE_PER_SECOND * max(dt, 0.0)

--- a/src/pitwall/host.py
+++ b/src/pitwall/host.py
@@ -44,7 +44,16 @@ class PitwallHost:
         self._client = client
         self._windows_open = window_count
         self._agents = AgentsViewBuilder()
+        # The last label AGENTS was served, so that view can return on a
+        # connection change with no new tick. NOT the memory the label itself
+        # needs - see `_ever_connected`.
         self._agents_connection: str | None = None
+        # Has the socket EVER been up? This is what separates "Connecting..."
+        # from "Disconnected", and it belongs to the host because both windows
+        # ask. It used to be inferred from `_agents_connection`, which made the
+        # answer depend on whether the AGENTS window had polled: with only the
+        # DATA window open, a producer that died read "Connecting..." forever.
+        self._ever_connected = False
         # The BULK channel's state. `_bulk_reveal` is the last map served, so
         # the revision can advance on a rewind as readily as on a completed
         # lap; `_session_key` is what makes pointing the arcade at another
@@ -86,16 +95,29 @@ class PitwallHost:
             return payload
         return None
 
-    def _connection_label(self) -> str:
-        """The three states `HeaderBar.set_connection` paints.
+    def get_connection(self) -> str:
+        """The three states both windows paint: Connected / Connecting... / Disconnected.
 
-        "Disconnected" needs a memory: before the first tick the socket is
-        retrying and the honest word is "Connecting...", while after one
-        the same state means the arcade went away.
+        "Disconnected" needs a memory, because the socket looks identical
+        before the arcade has ever spoken and after it has gone away. The
+        honest word for the first is "Connecting...".
+
+        The memory is `_ever_connected` and it is read from the CLIENT, not
+        from what some window was last served: DATA's band-1 strip is the
+        second caller, and a per-window memory would have told it
+        "Connecting..." about a producer that had been up for an hour and
+        died, whenever the AGENTS window was closed.
+
+        Public because the strip polls it directly. It cannot be derived on
+        the client side from tick freshness: a PAUSED replay stops sending
+        ticks while the socket stays perfectly up, and the strip renders the
+        pause right next to this - so the freshness heuristic would put
+        "Disconnected" beside "PAUSED" and be wrong.
         """
         if self._client.connected:
+            self._ever_connected = True
             return "Connected"
-        return "Disconnected" if self._agents_connection else "Connecting..."
+        return "Disconnected" if self._ever_connected else "Connecting..."
 
     def get_agents_view(self, since_seq: int = -1) -> dict | None:
         """The whole AGENTS window, already formatted, or None when nothing changed.
@@ -112,7 +134,7 @@ class PitwallHost:
         advancing and a purely sequence-driven view would keep rendering
         the last frame of a dead race with a green "Connected" chip.
         """
-        connection = self._connection_label()
+        connection = self.get_connection()
         payload = self.get_tick(since_seq)
         if payload is None:
             if connection == self._agents_connection:

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -118,6 +118,11 @@ function tick(
       driver_colors:
         colors ?? Object.fromEntries(Object.keys(field).map((code) => [code, [255, 128, 0]])),
       track_status: "1",
+      // Decoded by the producer, never by the renderer. The pair is null
+      // together when the loader has no entry for the lap, which band 1 must
+      // render as unknown rather than as a green track.
+      track_status_label: "GREEN",
+      track_status_color: [16, 185, 129],
       telemetry: { main, rival: rivalSpan, rewound, dropped },
     },
     playback: { speed: 1, paused: false, frame_index: 1000 + seq, total_frames: 154173 },
@@ -174,6 +179,7 @@ await page.addInitScript((payload) => {
         }
         return window.__ticks[window.__cursor];
       },
+      get_connection: async () => "Connected",
     },
   };
 }, tick(1));
@@ -192,6 +198,32 @@ check((await page.locator(".driver-chip").count()) === 2, "main and rival chips"
 check(
   (await page.locator(".trace-tier").first().innerText()).trim() === "BROADCAST",
   "the rival legend is labelled broadcast tier",
+);
+
+// --- Band 1: the status strip -----------------------------------------------
+
+check(
+  (await page.locator(".strip-lap").innerText()).replace(/\s+/g, "") === "L24/57",
+  "band 1 carries the lap out of the total",
+);
+check(
+  (await page.locator(".strip-chip").first().innerText()).trim() === "GREEN",
+  "the track status is the label the PRODUCER decoded, not one re-derived here",
+);
+// The clock is `t + global_t_min` - the FastF1 SessionTime the parquets are
+// keyed on. `t` alone is `frame_index * DT`, which means nothing off this
+// process. The stub sets t=1400 and global_t_min=0.
+check(
+  (await page.locator(".strip-field-value").first().innerText()).trim() === "0:23:20",
+  "the session clock is SessionTime and not replay seconds",
+);
+check(
+  (await page.locator(".strip-chip.is-connected").innerText()).trim() === "Connected",
+  "the connection comes from the host's socket, not from tick freshness",
+);
+check(
+  (await page.locator(".strip-chip.is-provisional").count()) === 0,
+  "no PROVISIONAL chip once the running field has completed a lap",
 );
 
 // Qt stretches both columns and both rows equally (`setColumnStretch(_, 1)`).
@@ -595,6 +627,56 @@ check(
 );
 
 await stillCtx.close();
+
+// --- Scenario E: PROVISIONAL is about the opening lap, not about retirements -
+//
+// The delivery plan words the rule as "until `laps_completed >= 1` for every
+// driver", and read literally it never switches off on the race this window
+// is developed against: SAI, DOO and HAD crashed on lap 1, so their
+// `laps_completed` is 0 for the whole race. Measured on the live wire at lap
+// 23, three of twenty drivers were under one lap and all three were OUT - the
+// chip built to mark the opening lap was still lit an hour in, which says
+// nothing at all. So the test is over the cars still IN the race.
+const RETIRED = { laps_completed: 0, progress: 0.4, active: false, has_finished: false };
+
+async function provisionalChips(field) {
+  const context = await browser.newContext({ viewport: { width: 1500, height: 950 } });
+  const scenarioPage = await context.newPage();
+  scenarioPage.on("pageerror", (error) => failures.push(`pageerror(provisional): ${error.message}`));
+  await scenarioPage.addInitScript((payload) => {
+    window.pywebview = {
+      api: {
+        get_tick: async (sinceSeq) => (sinceSeq === payload.seq ? null : payload),
+        get_connection: async () => "Connected",
+      },
+    };
+  }, tick(1, { drivers: field }));
+  await scenarioPage.goto(url, { waitUntil: "domcontentloaded" });
+  await scenarioPage.waitForSelector(".status-strip", { timeout: 5000 });
+  await scenarioPage.waitForTimeout(300);
+  const count = await scenarioPage.locator(".strip-chip.is-provisional").count();
+  await context.close();
+  return count;
+}
+
+check(
+  (await provisionalChips({
+    NOR: driver({ laps_completed: 23 }),
+    PIA: driver({ laps_completed: 23 }),
+    SAI: driver(RETIRED),
+    DOO: driver(RETIRED),
+    HAD: driver(RETIRED),
+  })) === 0,
+  "three lap-1 retirements do NOT keep the tower provisional for the whole race",
+);
+check(
+  (await provisionalChips({
+    NOR: driver({ laps_completed: 0, progress: 0.6 }),
+    PIA: driver({ laps_completed: 0, progress: 0.5 }),
+  })) === 1,
+  "and the opening lap, which the chip exists for, still marks itself",
+);
+
 await browser.close();
 server.close();
 

--- a/src/pitwall/ui/src/features/data/DataWindow.tsx
+++ b/src/pitwall/ui/src/features/data/DataWindow.tsx
@@ -1,25 +1,30 @@
 /**
- * PITWALL · DATA - the four-band shell.
+ * PITWALL · DATA - band 1 over two columns.
  *
- * Band 4 (the own-car traces, and the ring beside them) lands first: it is
- * the only band with an existing original to port, so its fidelity is
- * checkable field by field against `telemetry_panel.py` instead of being a
- * matter of taste. Bands 1 and 2 (status strip, timing table, bests) follow
- * in sprint 5 and band 3 (race pace) in sprint 6; the order changed on
- * 2026-08-09 and this docstring used to teach the old one.
+ * **The four bands are not four stacked rows, and the arithmetic is why.**
+ * This window's real client area is 1485 x 833 logical px, not the 1500 x 950
+ * `WindowSpec` asks for: `place()` clamps the height to the screen and the
+ * title bar takes 37 more. Minus the status bar and the body padding, 790 px
+ * are left. A full 20-row timing tower is 439 and band 4 stops being a chart
+ * below about 420 - stacked with band 1 and the gaps that is 908, over budget
+ * by 118 px with band 3 still at zero, on the largest screen in the fleet.
+ * Rendered at the 303 px actually left, band 4's axis labels collide and its
+ * traces are ribbons.
  *
- * **The status bar knows two states, not Qt's four.** `TelemetryWindow` also
- * paints "Stream connected" and "Disconnected — retrying…", which it gets
- * from its own client's signals. PITWALL's client is shared and owned by the
- * host, which surfaces its connection label only through `get_agents_view`.
- * Rather than grow a host method for one string, connection state waits for
- * the band-1 STATUS STRIP in sprint 5, where it belongs next to the flag and
- * the track status. What is here is honest about what this window can know:
- * it is waiting, or the producer spoke within the last second and a half.
+ * So band 1 stays full width and the rest becomes two columns: the all-cars
+ * world on the left (tower over bests, sprints 5) and the own-car world on
+ * the right (band 4, and band 3 as a tab of it in sprint 6). That split is
+ * not a compromise imposed by the pixels - it is the zoning a real wall
+ * uses, where the two worlds sit on physically different surfaces.
+ *
+ * The measured budget is in `~/.claude/plans/pitwall-sprint5/
+ * band-height-budget.md`; the drawn layout is in the project's memory.
  */
 
 import { OwnCarTraces } from "./OwnCarTraces";
+import { StatusStrip } from "./StatusStrip";
 import { TrackRing } from "./TrackRing";
+import { useConnection } from "../../lib/useConnection";
 import { useStatusText } from "../../lib/useStatusText";
 import { useTick } from "../../lib/useTick";
 
@@ -27,6 +32,7 @@ const WAITING = { text: "Waiting for arcade stream…", transient: false } as co
 
 export function DataWindow() {
   const { tick, discontinuity, live } = useTick();
+  const connection = useConnection();
   // Qt re-arms `showMessage(f"lap {lap} · live", 1500)` on every broadcast,
   // so the line stays up while streaming and clears 1.5 s after the producer
   // stops. `useStatusText` is keyed on the sequence for that reason.
@@ -36,7 +42,13 @@ export function DataWindow() {
   return (
     <main className="data-window">
       <div className="data-body">
+        <StatusStrip tick={live ? tick : null} connection={connection} />
         {live && tick ? (
+          // Band 4 still spans the body. The 620 px left column arrives in the
+          // same change as the tower that fills it: an empty column of that
+          // width does not read as "reserved", it reads as a panel that failed
+          // to load - which is the note the gate wrote about the run of empty
+          // space under the ring.
           <div className="band4">
             <OwnCarTraces tick={tick} discontinuity={discontinuity} />
             <TrackRing arcade={tick.arcade} />

--- a/src/pitwall/ui/src/features/data/StatusStrip.tsx
+++ b/src/pitwall/ui/src/features/data/StatusStrip.tsx
@@ -1,0 +1,140 @@
+/**
+ * Band 1: the slim strip that says what moment the rest of the window shows.
+ *
+ * Lap, track status, session clock, playback, connection. Everything but the
+ * last rides on the tick already; the connection is a property of the socket
+ * rather than of the stream, so it is polled separately (`useConnection`).
+ *
+ * **The PROVISIONAL chip is the plan's rule, not decoration.** `race_order`
+ * is meaningless until every car has completed a lap: on frame 0 the field is
+ * ordered by millimetres of accumulated distance (HUL "leads" by 6 mm,
+ * measured) and through lap 1 each car's fraction is normalised by its OWN
+ * first-lap length, which biases the back of the grid so hard that a car
+ * starting P7 reads P2. `gaps.py` says as much - "excluding the opening lap,
+ * where no classification exists yet" - and the wire publishes the order
+ * anyway. A broadcast timing tower marks exactly this state; so does this.
+ */
+
+import type { Tick } from "../../lib/bridge";
+import { driverStatus } from "../../lib/driverStatus";
+
+interface StatusStripProps {
+  tick: Tick | null;
+  connection: string | null;
+}
+
+export function StatusStrip({ tick, connection }: StatusStripProps) {
+  const arcade = tick?.arcade;
+  const playback = tick?.playback;
+
+  return (
+    <header className="status-strip card">
+      <span className="strip-lap">
+        {arcade?.lap ? `L ${arcade.lap}` : "L —"}
+        <span className="strip-lap-total">/{arcade?.total_laps || "—"}</span>
+      </span>
+
+      <TrackStatusChip
+        label={arcade?.track_status_label ?? null}
+        colour={arcade?.track_status_color ?? null}
+      />
+
+      {arcade && isProvisional(arcade.drivers) ? (
+        <span className="strip-chip is-provisional" title="No classification exists until every car has completed a lap">
+          PROVISIONAL
+        </span>
+      ) : null}
+
+      <span className="strip-spacer" />
+
+      <StripField label="SESSION" value={sessionClock(arcade)} />
+      <StripField label="PLAYBACK" value={playbackLabel(playback)} />
+      <span className={`strip-chip ${connectionClass(connection)}`}>{connection ?? "—"}</span>
+    </header>
+  );
+}
+
+function StripField({ label, value }: { label: string; value: string }) {
+  return (
+    <span className="strip-field">
+      <span className="strip-field-label">{label}</span>
+      <span className="strip-field-value">{value}</span>
+    </span>
+  );
+}
+
+/**
+ * The decoded status, or an explicit unknown.
+ *
+ * A null label means the loader has no TrackStatus entry for this lap, which
+ * is NOT a green track. Rendering it as GREEN would be a confident answer to
+ * a question nobody asked the data.
+ */
+function TrackStatusChip({
+  label,
+  colour,
+}: {
+  label: string | null;
+  colour: [number, number, number] | null;
+}) {
+  if (!label || !colour) return <span className="strip-chip is-unknown">NO STATUS</span>;
+  const rgb = `rgb(${colour[0]}, ${colour[1]}, ${colour[2]})`;
+  return (
+    <span className="strip-chip" style={{ color: rgb, borderColor: rgb }}>
+      {label}
+    </span>
+  );
+}
+
+/**
+ * True while a car that is still IN the race has yet to complete a lap.
+ *
+ * **The retired cars have to come out, and the real race is what says so.**
+ * The delivery plan words the rule as "until `laps_completed >= 1` for every
+ * driver", and read literally that never becomes false on Melbourne 2025:
+ * SAI, DOO and HAD crashed on lap 1 and their `laps_completed` is 0 for the
+ * whole race, so the chip measured against all 20 drivers was still lit at
+ * lap 23 - checked against the live wire, 3 of 20 under one lap and all
+ * three OUT. A permanent PROVISIONAL says nothing, which is worse than not
+ * having it: the state it exists to mark is the opening lap.
+ *
+ * What the rule is really asking is whether a classification exists yet, and
+ * a car that stopped will never contribute one.
+ */
+function isProvisional(drivers: Tick["arcade"]["drivers"]): boolean {
+  const contenders = Object.values(drivers).filter((car) => driverStatus(car) !== "out");
+  if (!contenders.length) return false;
+  return contenders.some((car) => car.laps_completed < 1);
+}
+
+/**
+ * FastF1 SessionTime as `H:MM:SS`.
+ *
+ * `t` alone is `frame_index * DT`, which is replay time and means nothing
+ * outside this process; `t + global_t_min` is the clock laps.parquet,
+ * intervals.parquet and the weather table are all keyed on, which is the one
+ * a strategist can compare against anything else.
+ */
+function sessionClock(arcade: Tick["arcade"] | undefined): string {
+  if (!arcade) return "—";
+  const total = Math.max(0, Math.floor(arcade.t + arcade.global_t_min));
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const seconds = total % 60;
+  return `${hours}:${pad(minutes)}:${pad(seconds)}`;
+}
+
+function playbackLabel(playback: Tick["playback"] | undefined): string {
+  if (!playback) return "—";
+  return playback.paused ? "PAUSED" : `${playback.speed}x`;
+}
+
+function connectionClass(connection: string | null): string {
+  if (connection === "Connected") return "is-connected";
+  if (connection === "Disconnected") return "is-lost";
+  return "is-unknown";
+}
+
+function pad(value: number): string {
+  return value.toString().padStart(2, "0");
+}

--- a/src/pitwall/ui/src/lib/bridge.ts
+++ b/src/pitwall/ui/src/lib/bridge.ts
@@ -59,6 +59,18 @@ export interface ArcadeState {
   driver_colors: Record<string, [number, number, number]>;
   /** FastF1 TrackStatus digits for the lap on screen; "" when the loader has no entry, rendered as clear. */
   track_status: string;
+  /**
+   * The same digits decoded by the arcade's own rule: GREEN / YELLOW FLAG /
+   * VSC / SAFETY CAR / RED FLAG. **Null means the loader has no entry for
+   * that lap, which is NOT a green track** and must not render as one.
+   *
+   * Decoded by the producer for the same reason `driver_colors` is: the
+   * priority order and the four labels are a project rule, and decoding the
+   * digits here would be a second copy of it in another language.
+   */
+  track_status_label: string | null;
+  /** The label's RGB, from the arcade's own palette. Null exactly when the label is. */
+  track_status_color: [number, number, number] | null;
   telemetry: {
     /** Every sample the replay clock crossed since the previous tick, oldest first. */
     main: TelemetrySample[];
@@ -238,6 +250,27 @@ export async function getBulk(sinceRev: number): Promise<Bulk | null> {
   if (api?.get_bulk) return api.get_bulk(sinceRev);
   if (IN_A_WINDOW) return null;
   return fetchJson<Bulk>("/api/bulk", sinceRev);
+}
+
+/**
+ * The socket's state as a word: Connected / Connecting... / Disconnected.
+ *
+ * No revision, because there is nothing to be current with: when the arcade
+ * dies the ticks stop and this is the only thing left that changes. Null only
+ * when the transport itself failed, which the caller renders as unknown
+ * rather than inventing a state.
+ */
+export async function getConnection(): Promise<string | null> {
+  const api = window.pywebview?.api as { get_connection?: () => Promise<string> };
+  if (api?.get_connection) return api.get_connection();
+  if (IN_A_WINDOW) return null;
+  try {
+    const response = await fetch("/api/connection", { cache: "no-store" });
+    if (!response.ok) return null;
+    return (await response.json()) as string;
+  } catch {
+    return null;
+  }
 }
 
 export async function getAgentsView<T>(sinceSeq: number): Promise<T | null> {

--- a/src/pitwall/ui/src/lib/useConnection.ts
+++ b/src/pitwall/ui/src/lib/useConnection.ts
@@ -1,0 +1,43 @@
+/**
+ * The socket's state, polled on its own slow timer.
+ *
+ * Separate from `useTick` on purpose: the tick loop learns nothing when the
+ * producer dies, because what a dead producer sends is nothing. This asks the
+ * host what its socket is doing, which is the only thing that still moves.
+ *
+ * One second rather than the tick's 100 ms. A connection label that lags a
+ * beat costs nothing; ten polls a second for a word that changes twice a
+ * session buys nothing.
+ */
+
+import { useEffect, useState } from "react";
+import { getConnection, whenBridgeReady } from "./bridge";
+
+const POLL_INTERVAL_MS = 1000;
+
+export function useConnection(): string | null {
+  const [connection, setConnection] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: number | undefined;
+
+    const poll = async () => {
+      const label = await getConnection();
+      if (cancelled) return;
+      setConnection(label);
+      timer = window.setTimeout(poll, POLL_INTERVAL_MS);
+    };
+
+    whenBridgeReady().then(() => {
+      if (!cancelled) poll();
+    });
+
+    return () => {
+      cancelled = true;
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
+  }, []);
+
+  return connection;
+}

--- a/src/pitwall/ui/src/styles/data.css
+++ b/src/pitwall/ui/src/styles/data.css
@@ -23,13 +23,100 @@
 }
 
 /* `QVBoxLayout(host).setContentsMargins(10, 10, 10, 10)` on the window's
- * central widget. */
+ * central widget.
+ *
+ * A grid of `auto` over `minmax(0, 1fr)`, not two flex children: band 1 must
+ * take exactly its content height and everything else must take the rest,
+ * and `minmax(0, ...)` is what stops the second row growing past the window
+ * on a client shorter than this one. Scrollbars are hidden globally
+ * (`qt-base.css`), so a row that overflows does not announce itself - it just
+ * silently stops showing its bottom. */
 .data-body {
   flex: 1 1 auto;
   min-height: 0;
   padding: 10px;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 10px;
+}
+
+/* --- Band 1: the status strip -------------------------------------------- */
+
+/* One row, 29 px of content at this type scale. The cheapest band there is,
+ * and no reason to make it taller: everything on it is a single value. */
+.status-strip {
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 5px 10px;
+  min-width: 0;
+}
+
+.strip-lap {
+  color: var(--qt-fg-1);
+  font-family: var(--qt-mono);
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: 1px;
+}
+
+.strip-lap-total {
+  color: var(--qt-fg-3);
+  font-size: 11px;
+  font-weight: 500;
+}
+
+/* Same chip language as `.driver-chip` in band 4: 1 px border in the chip's
+ * own colour, so the strip and the traces panel read as one system. */
+.strip-chip {
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 1px;
+  border: 1px solid currentColor;
+  border-radius: 8px;
+  padding: 1px 7px;
+  white-space: nowrap;
+}
+
+.strip-chip.is-connected {
+  color: #10b981;
+}
+.strip-chip.is-lost {
+  color: #ef4444;
+}
+/* Unknown is DIM, never a colour that means something. "Connecting..." and a
+ * missing track status are both absences, and an absence that borrows the
+ * green or the amber is a made-up answer. */
+.strip-chip.is-unknown {
+  color: var(--qt-fg-3);
+}
+.strip-chip.is-provisional {
+  color: #f59e0b;
+}
+
+.strip-spacer {
+  flex: 1 1 auto;
+}
+
+.strip-field {
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
+  white-space: nowrap;
+}
+
+.strip-field-label {
+  color: var(--qt-fg-3);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+}
+
+.strip-field-value {
+  color: var(--qt-fg-2);
+  font-family: var(--qt-mono);
+  font-size: 12px;
+  font-weight: 700;
 }
 
 .data-waiting {
@@ -48,7 +135,6 @@
  * shrink as the traces grow, which is backwards - the traces are the thing
  * that wants the room. */
 .band4 {
-  flex: 1 1 auto;
   min-height: 0;
   display: grid;
   grid-template-columns: 1fr 260px;

--- a/src/pitwall/webserver.py
+++ b/src/pitwall/webserver.py
@@ -66,11 +66,23 @@ class TickSource(Protocol):
 
     def get_bulk(self, since_rev: int = -1) -> dict[str, Any] | None: ...
 
+    def get_connection(self) -> str: ...
 
+
+# Readers that take "the revision I hold" and answer null when it is current.
 _READERS = {
     "/api/tick": "get_tick",
     "/api/agents": "get_agents_view",
     "/api/bulk": "get_bulk",
+}
+
+# Readers with no revision at all. The connection label is a property of the
+# socket rather than of the stream, so there is no sequence to be current
+# with: when the producer dies the ticks stop and this is the only thing that
+# still changes. Its own dict rather than a sentinel in the one above, so the
+# two contracts cannot be confused at the call site.
+_PLAIN_READERS = {
+    "/api/connection": "get_connection",
 }
 
 
@@ -122,6 +134,11 @@ def _handler(bundle: dict[str, tuple[bytes, str]], source: TickSource):
             reader = _READERS.get(route)
             if reader is not None:
                 self._send_json(getattr(source, reader)(_since(parsed.query)))
+                return
+
+            plain = _PLAIN_READERS.get(route)
+            if plain is not None:
+                self._send_json(getattr(source, plain)())
                 return
 
             if route in ("/", ""):

--- a/tests/surfaces/test_arcade_wire_contract.py
+++ b/tests/surfaces/test_arcade_wire_contract.py
@@ -283,6 +283,12 @@ GOLDEN_SHAPE = {
         },
         "total_laps": "int",
         "track_status": "str",
+        # The decoded form travels beside the digits so no consumer forks the
+        # priority order into a second language. Both are NoneType in the
+        # golden payload because its fixture lap has no TrackStatus entry -
+        # which is the case that must NOT render as a green track.
+        "track_status_color": "NoneType",
+        "track_status_label": "NoneType",
         "year": "int",
     },
     "playback": {
@@ -818,3 +824,42 @@ def test_the_reveal_carrier_is_per_driver_and_not_the_main_driver_lap():
     assert fast["laps_completed"] > slow["laps_completed"], (
         "one shared lap number cannot express this, which is why the rule is per driver"
     )
+
+
+# --- The track status, decoded once and published -------------------------
+
+
+def test_the_track_status_is_decoded_by_the_producer_and_not_by_each_consumer():
+    """The digits and their meaning travel together.
+
+    Two surfaces now render this status: the arcade's own pill and PITWALL's
+    band-1 strip. The priority order (red > SC > VSC > yellow) and the four
+    labels are a project rule, so a TypeScript consumer decoding the digits
+    itself would be that rule's second copy - which is precisely what
+    `driver_colors` rides on the wire to prevent.
+    """
+    from src.arcade.overlays import track_status_label
+
+    assert track_status_label("1") == ("GREEN", (16, 185, 129))
+    assert track_status_label("2") == ("YELLOW FLAG", (250, 204, 21))
+    assert track_status_label("4") == ("SAFETY CAR", (255, 140, 0))
+    assert track_status_label("6") == ("VSC", (245, 158, 11))
+    assert track_status_label("5") == ("RED FLAG", (239, 68, 68))
+    # Concurrent events: a red flag wins even with a yellow already out.
+    assert track_status_label("25")[0] == "RED FLAG"
+    assert track_status_label("24")[0] == "SAFETY CAR"
+
+
+def test_a_lap_with_no_track_status_entry_is_unknown_and_not_green():
+    """The one case the arcade's pill never had to tell apart.
+
+    The pill HIDES on a clear track, so "clear" and "the loader has no entry
+    for this lap" are the same absence to it. A strip always shows a status,
+    so conflating them would put a confident GREEN on a lap whose status
+    nobody knows - the sentinel class this repo keeps paying for, where a
+    default is a value the code can also legitimately find.
+    """
+    from src.arcade.overlays import track_status_label
+
+    assert track_status_label("") is None, "unknown is None, never GREEN"
+    assert track_status_label("1") is not None, "a real clear IS green and says so"

--- a/tests/surfaces/test_pitwall_host.py
+++ b/tests/surfaces/test_pitwall_host.py
@@ -330,3 +330,59 @@ def test_the_second_window_is_still_grabbable():
 
     origins = [spec.place(index, 1707, 960)[0] for index, spec in enumerate(WINDOWS)]
     assert len(set(origins)) == len(origins), f"two windows share an origin: {origins}"
+
+
+# --- The connection label, which band 1 renders ------------------------------
+
+
+class _ConnectableClient(_FakeClient):
+    """A fake that can also be up or down, which the base one cannot."""
+
+    def __init__(self, payload=None, connected: bool = True):
+        super().__init__(payload)
+        self.connected = connected
+
+
+def test_the_data_window_alone_still_learns_that_the_producer_died():
+    """The memory behind "Disconnected" belongs to the host, not to a window.
+
+    It used to be inferred from the last label the AGENTS view had been
+    served, so with only the DATA window open - the case band 1 exists for -
+    a producer that had been up for an hour and then died read
+    "Connecting..." forever, which is a lie about which direction the
+    session is going in.
+    """
+    client = _ConnectableClient(_tick(3), connected=True)
+    host = PitwallHost(client, window_count=1)
+
+    assert host.get_connection() == "Connected"
+
+    client.connected = False
+
+    assert host.get_connection() == "Disconnected", (
+        "the socket has been up once, so this is a loss and not a first attempt"
+    )
+
+
+def test_before_the_socket_has_ever_been_up_the_word_is_connecting():
+    """Retrying is not the same as having been dropped."""
+    host = PitwallHost(_ConnectableClient(None, connected=False), window_count=1)
+
+    assert host.get_connection() == "Connecting..."
+
+
+def test_both_windows_read_the_same_label_from_the_same_memory():
+    """One socket, one answer.
+
+    The AGENTS header and the DATA strip are on screen together, so two
+    labels disagreeing about whether the arcade is alive is the visible form
+    of the twin defect this repo keeps paying for.
+    """
+    client = _ConnectableClient(_tick(1), connected=True)
+    host = PitwallHost(client, window_count=2)
+    host.get_agents_view(-1)
+
+    client.connected = False
+
+    assert host.get_connection() == "Disconnected"
+    assert host.get_agents_view(1)["header"]["connection"] == "Disconnected"

--- a/tests/surfaces/test_pitwall_tokens.py
+++ b/tests/surfaces/test_pitwall_tokens.py
@@ -371,12 +371,16 @@ def test_the_data_stylesheets_raw_hexes_are_guarded_too():
         }
     )
 
-    assert raw == ["#3b82f6", "#f59e0b"], (
+    assert raw == ["#10b981", "#3b82f6", "#ef4444", "#f59e0b"], (
         f"a new raw hex entered the DATA stylesheet: {raw}. Either use a --qt-* token or add it "
         "here with the palette name it copies."
     )
-    assert raw[0] == _rgb_to_hex(palette.INFO), "the main driver chip copies INFO"
-    assert raw[1] == _rgb_to_hex(palette.WARNING), "the rival driver chip copies WARNING"
+    assert raw[0] == _rgb_to_hex(palette.SUCCESS), "band 1's Connected chip copies SUCCESS"
+    assert raw[1] == _rgb_to_hex(palette.INFO), "the main driver chip copies INFO"
+    assert raw[2] == _rgb_to_hex(palette.DANGER), "band 1's Disconnected chip copies DANGER"
+    assert raw[3] == _rgb_to_hex(palette.WARNING), (
+        "the rival driver chip and band 1's PROVISIONAL chip both copy WARNING"
+    )
 
 
 def test_the_two_raw_hexes_in_the_stylesheet_are_guarded_too():


### PR DESCRIPTION
Closes #921.

Sprint 5's first PR. Band 1 on screen, and the plumbing bands 2 and 3 will sit on.

## What is here

| | |
|---|---|
| **Band 1** | `StatusStrip.tsx` - lap X/Y, track status, session clock, playback, connection. |
| **The producer** | publishes `track_status_label` and `track_status_color` beside the digits. |
| **The host** | `get_connection()`, with the memory it needs, plus `/api/connection` on the loopback server. |
| **The shell** | `.data-body` becomes `grid-template-rows: auto minmax(0, 1fr)`. |

## Why the four bands became two columns

A design gate measured the window as it really opens, DPI-aware: the client area is
**1485.3 x 832.7 logical** (2228x1249 physical at 144 dpi), not the 1500x950 `WindowSpec` asks
for. Minus the status bar and the body padding, **790 px** are left. Stacked, band 1 (29) + a full
20-row tower (439) + band 4's floor (420) + gaps is **908** - over by 118 px with band 3 at zero,
on the largest screen in the fleet. Rendered at the 303 px actually left, band 4's axis labels
collide and its traces are ribbons.

So band 1 stays full width and the rest becomes two columns, which is also the zoning a real wall
uses: the all-cars world and the own-car world sit on physically different surfaces. Agreed with
Victor 2026-08-13. Report: `~/.claude/plans/pitwall-sprint5/band-height-budget.md`.

## Three decisions worth reading

**The track status is decoded once, by the producer.** `RaceEventsPanel._status_for` becomes the
module-level `track_status_banner`, and `app.py` publishes the decoded label and its RGB. A
TypeScript decoder would have forked the priority order and the four labels across two languages,
which is the defect `driver_colors` is on the wire to prevent.

**A lap with no TrackStatus entry is not a green track.** The arcade's pill hides itself on both,
so it never had to separate them. A strip always shows a status, and a confident GREEN on a lap
nobody has data for is the sentinel class this repo keeps paying for - so `""` is `None` and
renders NO STATUS, while `"1"` is GREEN and says so.

**The PROVISIONAL chip counts only the cars still in the race**, and the real race is what said
so. The plan words the rule as *until `laps_completed >= 1` for every driver*; read literally it
never switches off on Melbourne 2025, because SAI, DOO and HAD crashed on lap 1 and stay at zero
for the whole race. Checked against the live wire at lap 23: **three of twenty drivers under one
lap, all three OUT**. A chip that is permanently lit says nothing.

## Verification

**The real path, executed.** Real producer -> real TCP socket -> real host -> the real pywebview
window, captured DPI-aware at 2250x1305 physical:

```
GET /api/connection            -> "Connected"
GET /api/tick?since=-1         -> lap 23/57
  track_status       = '1'
  track_status_label = GREEN
  track_status_color = [16, 185, 129]
  drivers with laps_completed < 1: 3 of 20  (SAI, DOO, HAD - all three OUT)
```

The window renders `L 24/57  GREEN` on the left and `SESSION 1:53:05  PLAYBACK 2x  Connected`
on the right, with no PROVISIONAL chip at lap 24.

**Guards, each watched RED against its own defect** (on a copy, not on the tracked file):

- `test_a_lap_with_no_track_status_entry_is_unknown_and_not_green` - fails when the two absences
  are conflated.
- `test_the_data_window_alone_still_learns_that_the_producer_died` - fails when the memory is
  read off the AGENTS view again.
- `smoke-data`: *three lap-1 retirements do NOT keep the tower provisional for the whole race* -
  fails when retired cars are counted. The first attempt at this mutation did not compile, so the
  smoke ran against the previous bundle and passed; the red above is from a build that succeeded.

`tests/surfaces` 206 passed - `smoke-data` 50 checks - `smoke-agents` 18 checks - `tsc`
clean - ruff clean.

## Out of scope, deliberately

The band-4 trace title row wraps below ~330 px of cell width ("Delta Time (s)" goes to three
lines at 277 px). It is reworked in the next PR, where the column actually narrows - changing it
now would alter a shipped panel for a reason not yet visible on screen.