### PR TITLE
fix(pitwall): a best trap speed is the fastest, not the slowest

### DIFF
--- a/src/pitwall/session_data.py
+++ b/src/pitwall/session_data.py
@@ -136,6 +136,22 @@ def _lap_row(record: dict[str, Any]) -> dict[str, Any]:
     return row
 
 
+def _extremes(
+    rows: list[dict[str, Any]], fields: tuple[str, ...], pick: Any
+) -> dict[str, float | None]:
+    """`pick` over each field's known values, or None when a field has none.
+
+    None because the value is genuinely unknown, never a number: a zero would
+    win every speed ranking outright and lose every time ranking, which is the
+    sentinel collision this repo has a scar from.
+    """
+    chosen: dict[str, float | None] = {}
+    for field in fields:
+        values = [row[field] for row in rows if row[field] is not None]
+        chosen[field] = pick(values) if values else None
+    return chosen
+
+
 def _best_of(rows: list[dict[str, Any]]) -> dict[str, Any]:
     """The per-field minima the bests panel ranks, over countable rows only.
 
@@ -147,9 +163,13 @@ def _best_of(rows: list[dict[str, Any]]) -> dict[str, Any]:
     """
     countable = [row for row in rows if not row["deleted"] and not row["generated"]]
     best: dict[str, Any] = {"lap": None}
-    for field in (*_BEST_FIELDS, *_BEST_SPEED_FIELDS):
-        values = [row[field] for row in countable if row[field] is not None]
-        best[field] = min(values) if values else None
+    # A best TIME is the smallest and a best SPEED is the largest, and the two
+    # tuples exist to say so. They were once walked by one loop that minimised
+    # both, which served NOR's best speed-trap as 180 km/h against a real
+    # maximum of 289 - his slowest crawl through the trap, presented as his
+    # best of the session, on all four speed columns.
+    best.update(_extremes(countable, _BEST_FIELDS, min))
+    best.update(_extremes(countable, _BEST_SPEED_FIELDS, max))
     fastest = [row for row in countable if row["lap_time"] is not None]
     if fastest:
         quickest = min(fastest, key=lambda row: row["lap_time"])

--- a/tests/surfaces/test_pitwall_session_data.py
+++ b/tests/surfaces/test_pitwall_session_data.py
@@ -418,3 +418,59 @@ def test_no_tick_means_no_bulk():
     host = PitwallHost(_FakeClient(None), window_count=1)
 
     assert host.get_bulk(-1) is None
+
+
+def test_a_best_speed_is_the_fastest_and_not_the_slowest():
+    """The two tuples are two KINDS of quantity, and one loop treated them as one.
+
+    A best lap time is the smallest value in the column; a best trap speed is
+    the largest. Minimising both served, on the real race, NOR's best
+    speed-trap as 180 km/h against a real maximum of 289 - his slowest crawl
+    through the trap, presented as his best of the session, on all four speed
+    columns at once (#923).
+
+    Asserted against the maximum RECOMPUTED from the rows the same view
+    served, so this cannot pass by agreeing with a constant somebody typed.
+    """
+    session = _session_or_skip()
+    view = session.masked_view(_all_revealed(session), 0.0)
+
+    checked = 0
+    for code, driver in view["drivers"].items():
+        countable = [row for row in driver["laps"] if not row["deleted"] and not row["generated"]]
+        for field in ("v1", "v2", "vfl", "vst"):
+            values = [row[field] for row in countable if row[field] is not None]
+            if not values:
+                continue
+            assert driver["best"][field] == max(values), (
+                f"{code}'s best {field} is {driver['best'][field]} but its rows reach "
+                f"{max(values)} (min is {min(values)})"
+            )
+            checked += 1
+
+    assert checked >= 60, f"only {checked} speed bests compared; the fixture proves nothing"
+
+
+def test_a_best_lap_time_is_still_the_smallest():
+    """The twin of the case above, so the fix cannot swing the other way.
+
+    Separating the two loops is exactly the kind of change that fixes one
+    direction and breaks the other, and a test that only pinned the speeds
+    would be green through it.
+    """
+    session = _session_or_skip()
+    view = session.masked_view(_all_revealed(session), 0.0)
+
+    checked = 0
+    for code, driver in view["drivers"].items():
+        countable = [row for row in driver["laps"] if not row["deleted"] and not row["generated"]]
+        for field in ("lap_time", "s1", "s2", "s3"):
+            values = [row[field] for row in countable if row[field] is not None]
+            if not values:
+                continue
+            assert driver["best"][field] == min(values), (
+                f"{code}'s best {field} is {driver['best'][field]} but its rows reach {min(values)}"
+            )
+            checked += 1
+
+    assert checked >= 60, f"only {checked} time bests compared; the fixture proves nothing"


### PR DESCRIPTION
Closes #923.

`_best_of` walked both field tuples with one loop and minimised them all, so the four speed
columns served a driver's slowest crawl through the trap as his best of the session.

## Measured through the real path

Producer -> socket -> host -> `GET /api/bulk`, Melbourne 2025 at lap 26:

```
NOR, over its revealed rows (deleted and generated excluded):
  v1 : served best =  68.0   min= 68.0   max=268.0
  v2 : served best = 144.0   min=144.0   max=295.0
  vfl: served best = 247.0   min=247.0   max=285.0
  vst: served best = 180.0   min=180.0   max=289.0
```

## Why reading it did not catch it

```python
for field in (*_BEST_FIELDS, *_BEST_SPEED_FIELDS):
    best[field] = min(values) if values else None
```

The two tuples exist because the fields are different KINDS of quantity, and then the loop treats
them as one. The names are right and the code is wrong.

And nothing else caught it because `best` has **no consumer yet** - the bests panel is this
sprint's next-but-one PR. #918's 20 guards asserted the lap-time and sector minima, which were
correct, and never asserted a speed. A typed field that no consumer reads is a field nobody has
checked.

## The guards

Both recompute the extreme from the rows **the same view served**, so neither can pass by agreeing
with a constant somebody typed, and both refuse to run on a fixture too small to prove anything
(`checked >= 60`).

- `test_a_best_speed_is_the_fastest_and_not_the_slowest` - **watched RED** against `min`:
  `VER's best v1 is 66.0 but its rows reach 282.0`.
- `test_a_best_lap_time_is_still_the_smallest` - the twin, so separating the two loops cannot
  swing the other way and stay green.

`tests/surfaces/test_pitwall_session_data.py` 22 passed - ruff clean.