### PR TITLE
feat(pitwall): rank the session bests and colour the tower's sectors

### DIFF
--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -179,6 +179,7 @@ await page.addInitScript((payload) => {
         }
         return window.__ticks[window.__cursor];
       },
+      get_bulk: async () => null,
       get_connection: async () => "Connected",
     },
   };
@@ -197,7 +198,7 @@ check(
 check((await page.locator(".driver-chip").count()) === 2, "main and rival chips");
 check(
   (await page.locator(".trace-tier").first().innerText()).trim() === "BROADCAST",
-  "the rival legend is labelled broadcast tier",
+  "the rival chip is labelled broadcast tier",
 );
 
 // --- Band 1: the status strip -----------------------------------------------
@@ -376,9 +377,12 @@ check(
   (await page.locator(".trace-placeholder").count()) === 0,
   "an empty buffer is not single-driver mode",
 );
+// One tag on the card header, not one per cell: the per-cell legends were
+// dropped when band 4 moved into the narrower right column, where the title
+// row wrapped onto three lines and ate the plot.
 check(
-  (await page.locator(".trace-tier").count()) === 4,
-  "the rival legend survives an empty buffer on all four charts",
+  (await page.locator(".trace-tier").count()) === 1,
+  "the broadcast-tier tag survives an empty buffer, on the header chip",
 );
 
 // The eviction ORDER, which the accumulator's own docstring calls
@@ -461,7 +465,13 @@ const soloPage = await solo.newPage();
 soloPage.on("pageerror", (error) => failures.push(`pageerror(solo): ${error.message}`));
 
 await soloPage.addInitScript((payload) => {
-  window.pywebview = { api: { get_tick: async (sinceSeq) => (sinceSeq === payload.seq ? null : payload) } };
+  window.pywebview = {
+    api: {
+      get_tick: async (sinceSeq) => (sinceSeq === payload.seq ? null : payload),
+      get_bulk: async () => null,
+      get_connection: async () => "Connected",
+    },
+  };
 }, tick(1, { rival: null, rivalSpan: [], mainDriver: { has_position: false, rel_dist: null } }));
 
 await soloPage.goto(url, { waitUntil: "domcontentloaded" });
@@ -615,6 +625,8 @@ await stillPage.addInitScript((payload) => {
       // never recompute, so the chart sits still whether or not it animates
       // and the check below would pass against the defect it exists for.
       get_tick: async () => ({ ...structuredClone(payload), seq: ++seq }),
+      get_bulk: async () => null,
+      get_connection: async () => "Connected",
     },
   };
 }, tick(1));
@@ -647,6 +659,7 @@ async function provisionalChips(field) {
     window.pywebview = {
       api: {
         get_tick: async (sinceSeq) => (sinceSeq === payload.seq ? null : payload),
+        get_bulk: async () => null,
         get_connection: async () => "Connected",
       },
     };
@@ -676,6 +689,197 @@ check(
   })) === 1,
   "and the opening lap, which the chip exists for, still marks itself",
 );
+
+// --- Scenario F: the timing tower --------------------------------------------
+//
+// Twenty rows, and the numbers hand-worked so a wrong branch cannot look
+// plausible. The bulk deliberately omits the three retired cars: SAI, DOO and
+// HAD have only `FastF1Generated` rows on the real race and reveal nothing, so
+// a tower keyed on what the BULK contains renders seventeen. It has to iterate
+// `race_order`, which always carries twenty.
+
+const TOWER_ORDER = [
+  "NOR", "PIA", "VER", "RUS", "LEC", "TSU", "ALB", "HAM", "GAS", "ALO",
+  "ANT", "STR", "HUL", "BOR", "LAW", "OCO", "BEA", "SAI", "DOO", "HAD",
+];
+const RETIRED_CODES = ["SAI", "DOO", "HAD"];
+/** Crossing times at lap 23, chosen so every interval is exact at 2 dp. */
+const CROSSING_AT_23 = { NOR: 2070.0, PIA: 2071.24, VER: 2073.07 };
+
+function towerField() {
+  const field = {};
+  TOWER_ORDER.forEach((code, index) => {
+    if (RETIRED_CODES.includes(code)) {
+      field[code] = driver({
+        laps_completed: 0,
+        progress: 0.4,
+        active: false,
+        has_finished: false,
+      });
+      return;
+    }
+    // LAW is a full lap down: the positional laps-down branch must fire for
+    // him instead of rendering tens of seconds as if he were racing.
+    const progress = code === "LAW" ? 22.3 : 23.9 - index * 0.01;
+    field[code] = driver({ laps_completed: code === "LAW" ? 22 : 23, progress });
+  });
+  return field;
+}
+
+function towerBulk() {
+  const drivers = {};
+  TOWER_ORDER.filter((code) => !RETIRED_CODES.includes(code)).forEach((code, index) => {
+    const revealed = code === "LAW" ? 22 : 23;
+    const crossings = {};
+    for (let lap = 1; lap <= revealed; lap += 1) {
+      crossings[lap] = CROSSING_AT_23[code] ?? 2070 + 5 * index - (23 - lap) * 90;
+    }
+    if (CROSSING_AT_23[code] !== undefined) crossings[revealed] = CROSSING_AT_23[code];
+    drivers[code] = {
+      number: String(index + 1),
+      laps_revealed: revealed,
+      stops: 2,
+      crossings,
+      laps: [
+        {
+          lap: revealed,
+          t: crossings[revealed],
+          lap_time: 85.744,
+          s1: 29.412,
+          s2: 30.128,
+          s3: 26.204,
+          v1: 301,
+          v2: 289,
+          vfl: 280,
+          vst: 321,
+          position: index + 1,
+          compound: "MEDIUM",
+          tyre_life: 12,
+          stint: 2,
+          track_status: "1",
+          pit_in: false,
+          pit_out: false,
+          deleted: false,
+          generated: false,
+          pb: false,
+        },
+      ],
+      best: {
+        lap: revealed,
+        lap_time: 85.744,
+        s1: 29.412,
+        s2: 30.128,
+        s3: 26.204,
+        v1: 301,
+        v2: 289,
+        vfl: 280,
+        vst: 321,
+        compound: "MEDIUM",
+      },
+      theoretical: 85.744,
+    };
+  });
+  return { rev: 1, available: true, race: { year: 2025, location: "Melbourne", total_laps: 57 }, drivers };
+}
+
+const towerCtx = await browser.newContext({ viewport: { width: 1485, height: 833 } });
+const towerPage = await towerCtx.newPage();
+towerPage.on("pageerror", (error) => failures.push(`pageerror(tower): ${error.message}`));
+await towerPage.addInitScript(
+  ([payload, bulk]) => {
+    window.pywebview = {
+      api: {
+        get_tick: async (sinceSeq) => (sinceSeq === payload.seq ? null : payload),
+        get_bulk: async (sinceRev) => (sinceRev === bulk.rev ? null : bulk),
+        get_connection: async () => "Connected",
+      },
+    };
+  },
+  [tick(1, { drivers: towerField(), order: TOWER_ORDER }), towerBulk()],
+);
+await towerPage.goto(url, { waitUntil: "domcontentloaded" });
+await towerPage.waitForSelector(".tower-row", { timeout: 5000 });
+await towerPage.waitForTimeout(700);
+
+// Tolerant on purpose. A defect that DROPS rows makes every later selector
+// miss, and a throwing helper kills the harness with a stack instead of
+// reporting the failures by name - so the one check that explains the cause
+// never gets printed. A missing cell is a named failure, not an exception.
+const cell = async (row, column) => {
+  try {
+    const text = await towerPage
+      .locator(`.tower-row:nth-child(${row}) td:nth-child(${column})`)
+      .innerText({ timeout: 1000 });
+    return text.trim();
+  } catch {
+    return "<no such cell>";
+  }
+};
+
+check((await towerPage.locator(".tower-row").count()) === 20, "twenty rows, not the bulk's seventeen");
+check((await cell(18, 3)) === "SAI", "a car with no revealed lap still holds its place in the order");
+
+// The four branches of the gap cell, each on the row that exercises it.
+check((await cell(1, 4)) === "LEADER", "the leader's GAP says so");
+check((await cell(1, 5)) === "—", "and the leader has no interval to anything");
+check((await cell(2, 4)) === "+1.24s", "GAP is measured to the LEADER");
+check((await cell(3, 4)) === "+3.07s", "and it accumulates down the order");
+check((await cell(3, 5)) === "+1.83s", "INT is measured to the car directly ahead");
+check((await cell(15, 4)) === "+1 LAP", "a lapped car reads in laps, not in tens of seconds");
+check((await cell(18, 4)) === "OUT", "a stopped car never shows a frozen interval");
+check((await cell(18, 9)) === "OUT", "and its LAST column says so in place of a lap time");
+
+// The row itself, on the leader.
+check((await cell(1, 3)) === "NOR", "the code column");
+check((await cell(1, 6)).replace(/\s+/g, " ") === "29.412 301", "the sector time and its trap speed, inline");
+check((await cell(1, 9)) === "1:25.744", "a lap time past the minute reads as m:ss.mmm");
+check((await cell(1, 10)) === "321", "ST is the speed trap");
+check((await cell(1, 11)) === "M 12", "the compound letter and the set's age");
+check((await cell(1, 12)) === "2", "the stop count");
+check((await cell(18, 11)) === "—", "a driver the bulk never revealed shows dashes, not zeros");
+
+// EFFECT, not a CSS property: all twenty rows are inside the card. Scrollbars
+// are hidden globally, so an overflowing tower does not announce itself - it
+// silently stops drawing P15 to P20 and looks complete.
+const towerFits = await towerPage.evaluate(() => {
+  const cardEl = document.querySelector(".tower");
+  const card = cardEl.getBoundingClientRect();
+  const rows = [...document.querySelectorAll(".tower-row")];
+  const last = rows[rows.length - 1].getBoundingClientRect();
+  // The table's NATURAL width against the card's content box. A rect assert
+  // on the rendered table is a mechanism check wearing an effect check's
+  // clothes: `width: 100%` pins the table to the card, so when the columns
+  // no longer fit they compress and their `nowrap` text spills into the
+  // padding while every rectangle still says "inside". Measured at a 600 px
+  // column: natural 597 against 578 of content box, and the text ends 5 px
+  // past the padding edge - a tower touching its own border.
+  const table = document.querySelector(".tower-table");
+  const applied = table.style.width;
+  table.style.width = "max-content";
+  const naturalWidth = table.getBoundingClientRect().width;
+  table.style.width = applied;
+  const style = getComputedStyle(cardEl);
+  const contentWidth =
+    cardEl.clientWidth - parseFloat(style.paddingLeft) - parseFloat(style.paddingRight);
+  return {
+    lastBottom: last.bottom,
+    cardBottom: card.bottom,
+    naturalWidth,
+    contentWidth,
+    visible: rows.filter((row) => row.getBoundingClientRect().height > 0).length,
+  };
+});
+check(
+  towerFits.lastBottom <= towerFits.cardBottom + 1,
+  `the last row is inside the card (${towerFits.lastBottom} vs ${towerFits.cardBottom})`,
+);
+check(
+  towerFits.naturalWidth <= towerFits.contentWidth,
+  `no column is compressed: the table wants ${towerFits.naturalWidth} and the card gives ${towerFits.contentWidth}`,
+);
+check(towerFits.visible === 20, `all twenty rows have height (${towerFits.visible})`);
+
+await towerCtx.close();
 
 await browser.close();
 server.close();

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -726,6 +726,24 @@ function towerField() {
   return field;
 }
 
+/**
+ * Per-driver bests, arranged so the three sector tones and the field ranking
+ * are all decidable by hand.
+ *
+ * - NOR owns S1 outright and his last lap MATCHES it       -> purple
+ * - PIA owns S2, and his last S1 equals his own best S1     -> green
+ * - VER owns S3, and his last S1 is slower than his own     -> yellow
+ *
+ * Theoretical = NOR's S1 + PIA's S2 + VER's S3 = 29.000 + 18.500 + 25.900.
+ * Every other driver is deliberately slower in all four fields, so the
+ * podium of each section is fixed.
+ */
+const TOWER_BESTS = {
+  NOR: { s1: 29.0, s2: 19.0, s3: 26.5, lap_time: 85.0, lastS1: 29.0 },
+  PIA: { s1: 29.5, s2: 18.5, s3: 26.4, lap_time: 85.4, lastS1: 29.5 },
+  VER: { s1: 29.8, s2: 19.2, s3: 25.9, lap_time: 85.9, lastS1: 30.2 },
+};
+
 function towerBulk() {
   const drivers = {};
   TOWER_ORDER.filter((code) => !RETIRED_CODES.includes(code)).forEach((code, index) => {
@@ -735,6 +753,14 @@ function towerBulk() {
       crossings[lap] = CROSSING_AT_23[code] ?? 2070 + 5 * index - (23 - lap) * 90;
     }
     if (CROSSING_AT_23[code] !== undefined) crossings[revealed] = CROSSING_AT_23[code];
+    const crafted = TOWER_BESTS[code];
+    const best = crafted ?? {
+      s1: 31 + index * 0.1,
+      s2: 21 + index * 0.1,
+      s3: 28 + index * 0.1,
+      lap_time: 90 + index * 0.1,
+      lastS1: 31 + index * 0.1,
+    };
     drivers[code] = {
       number: String(index + 1),
       laps_revealed: revealed,
@@ -745,7 +771,7 @@ function towerBulk() {
           lap: revealed,
           t: crossings[revealed],
           lap_time: 85.744,
-          s1: 29.412,
+          s1: best.lastS1,
           s2: 30.128,
           s3: 26.204,
           v1: 301,
@@ -766,17 +792,17 @@ function towerBulk() {
       ],
       best: {
         lap: revealed,
-        lap_time: 85.744,
-        s1: 29.412,
-        s2: 30.128,
-        s3: 26.204,
+        lap_time: best.lap_time,
+        s1: best.s1,
+        s2: best.s2,
+        s3: best.s3,
         v1: 301,
         v2: 289,
         vfl: 280,
         vst: 321,
         compound: "MEDIUM",
       },
-      theoretical: 85.744,
+      theoretical: best.s1 + best.s2 + best.s3,
     };
   });
   return { rev: 1, available: true, race: { year: 2025, location: "Melbourne", total_laps: 57 }, drivers };
@@ -831,7 +857,10 @@ check((await cell(18, 9)) === "OUT", "and its LAST column says so in place of a 
 
 // The row itself, on the leader.
 check((await cell(1, 3)) === "NOR", "the code column");
-check((await cell(1, 6)).replace(/\s+/g, " ") === "29.412 301", "the sector time and its trap speed, inline");
+check(
+  (await cell(1, 6)).replace(/\s+/g, " ") === "29.000 301",
+  "the sector time and its trap speed, inline",
+);
 check((await cell(1, 9)) === "1:25.744", "a lap time past the minute reads as m:ss.mmm");
 check((await cell(1, 10)) === "321", "ST is the speed trap");
 check((await cell(1, 11)) === "M 12", "the compound letter and the set's age");
@@ -878,6 +907,58 @@ check(
   `no column is compressed: the table wants ${towerFits.naturalWidth} and the card gives ${towerFits.contentWidth}`,
 );
 check(towerFits.visible === 20, `all twenty rows have height (${towerFits.visible})`);
+
+// --- The sector colour code, on the tower ------------------------------------
+//
+// Purple is fastest of the session outright, green is the driver's own best,
+// yellow is slower than his own. The fixture arranges all three on the S1
+// column: NOR owns it and matched it, PIA matched his own, VER did not.
+const tone = async (row) =>
+  towerPage.locator(`.tower-row:nth-child(${row}) td:nth-child(6)`).getAttribute("class");
+check((await tone(1)).includes("is-purple"), "the session's fastest sector is purple");
+check((await tone(2)).includes("is-green"), "a driver's own best is green");
+check((await tone(3)).includes("is-yellow"), "slower than his own best is yellow");
+check((await tone(18)).includes("is-plain"), "a sector nobody has set is not coloured at all");
+
+// --- Band 2 right: the bests panel -------------------------------------------
+
+const bestsRow = async (section, row) =>
+  (
+    await towerPage
+      .locator(`.bests-section:nth-child(${section}) .bests-row:nth-child(${row})`)
+      .innerText()
+  )
+    .replace(/\s+/g, " ")
+    .trim();
+
+check((await towerPage.locator(".bests-section").count()) === 4, "four ranked sections");
+check(
+  (await towerPage.locator(".bests-section:nth-child(1) .bests-row").count()) === 3,
+  "top three per section, because twenty would be 1,668 px of a 790 px body",
+);
+// S1 is NOR 29.000, PIA 29.500, VER 29.800 - ranked across the FIELD, not per
+// driver, and the delta is a percentage off the section's leader.
+check((await bestsRow(1, 2)).startsWith("1 NOR 29.000"), "the section leader, with no delta");
+check((await bestsRow(1, 3)) === "2 PIA 29.500 +1.72%", "second, with its percentage off the top");
+check((await bestsRow(1, 4)) === "3 VER 29.800 +2.76%", "and third");
+// S2 and S3 are owned by different drivers, so a panel reading one field for
+// all four sections would show NOR three times.
+check((await bestsRow(2, 2)).startsWith("1 PIA 18.500"), "S2 belongs to whoever set it");
+check((await bestsRow(3, 2)).startsWith("1 VER 25.900"), "and so does S3");
+check(
+  (await bestsRow(4, 2)).replace(/\s+$/, "") === "1 NOR 1:25.000 M",
+  "the LAP section carries the compound; the sector sections cannot and do not",
+);
+
+// 29.000 + 18.500 + 25.900 = 73.400, from three DIFFERENT drivers. A panel
+// summing one driver's own sectors would read 1:14.500 for NOR.
+const theoretical = (await towerPage.locator(".bests-theoretical").innerText())
+  .replace(/\s+/g, " ")
+  .trim();
+check(
+  theoretical === "THEORETICAL 1:13.400 NOR · PIA · VER",
+  `the ideal lap recombines the FIELD's best sectors (${theoretical})`,
+);
 
 await towerCtx.close();
 

--- a/src/pitwall/ui/src/features/data/BestsPanel.tsx
+++ b/src/pitwall/ui/src/features/data/BestsPanel.tsx
@@ -1,0 +1,107 @@
+/**
+ * Band 2, right: the session's best sectors and laps.
+ *
+ * Four ranked sections - S1, S2, S3, Lap - plus the theoretical lap, which is
+ * the shape the SBG/Catapult RaceX client uses: *four ranked lists plus
+ * Theoretical, each row rank / driver / time / % delta / compound*.
+ *
+ * **Top three, and that is a structural limit rather than a preference.** A
+ * fully ranked section is twenty rows, and four of those are 1,668 px of a
+ * window whose whole body is 790. Three rows per section fit the space left
+ * under the tower with room to spare, and the fourth-fastest S2 of the
+ * afternoon is not a number anybody reads off a live wall.
+ *
+ * The delta is a PERCENTAGE, not seconds. Across the four sections the
+ * absolute gaps differ by an order of magnitude - tenths in a sector,
+ * seconds over a lap - and a percentage is the one form that reads the same
+ * in all four.
+ */
+
+import type { Bulk } from "../../lib/bridge";
+import {
+  sessionBests,
+  theoreticalLap,
+  type BestEntry,
+  type BestField,
+} from "../../lib/sessionBests";
+
+/** How many rows a section shows. See the note above on why it is not twenty. */
+const RANKED = 3;
+
+const SECTIONS: { field: BestField; label: string }[] = [
+  { field: "s1", label: "S1" },
+  { field: "s2", label: "S2" },
+  { field: "s3", label: "S3" },
+  { field: "lap_time", label: "LAP" },
+];
+
+export function BestsPanel({ bulk }: { bulk: Bulk | null }) {
+  const bests = sessionBests(bulk);
+  const theoretical = theoreticalLap(bests);
+
+  return (
+    <section className="bests card">
+      <header className="bests-header">
+        <span className="bests-title">BESTS</span>
+        <span className="bests-subtitle">session, revealed laps only</span>
+      </header>
+
+      <div className="bests-sections">
+        {SECTIONS.map(({ field, label }) => (
+          <BestsSection key={field} label={label} entries={bests[field].slice(0, RANKED)} />
+        ))}
+      </div>
+
+      <footer className="bests-theoretical">
+        <span className="bests-field-label">THEORETICAL</span>
+        <span className="bests-theoretical-value">
+          {theoretical === null ? "—" : formatTime(theoretical)}
+        </span>
+        <span className="bests-theoretical-note">
+          {theoretical === null
+            ? "waiting for a sector nobody has set yet"
+            : `${bests.s1[0].code} · ${bests.s2[0].code} · ${bests.s3[0].code}`}
+        </span>
+      </footer>
+    </section>
+  );
+}
+
+function BestsSection({ label, entries }: { label: string; entries: BestEntry[] }) {
+  const leader = entries[0];
+
+  return (
+    <div className="bests-section">
+      <div className="bests-field-label">{label}</div>
+      {entries.length === 0 ? (
+        <div className="bests-empty">—</div>
+      ) : (
+        entries.map((entry, index) => (
+          <div key={entry.code} className={`bests-row ${index === 0 ? "is-purple" : ""}`}>
+            <span className="bests-rank">{index + 1}</span>
+            <span className="bests-code">{entry.code}</span>
+            <span className="bests-value">{formatTime(entry.value)}</span>
+            <span className="bests-delta">
+              {index === 0 ? "" : formatDelta(entry.value, leader.value)}
+            </span>
+            <span className="bests-compound">{entry.compound ? entry.compound[0] : ""}</span>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+/** `1:25.744` past the minute, `29.412` under it. */
+function formatTime(seconds: number): string {
+  if (seconds < 60) return seconds.toFixed(3);
+  const minutes = Math.floor(seconds / 60);
+  const rest = seconds - minutes * 60;
+  return `${minutes}:${rest.toFixed(3).padStart(6, "0")}`;
+}
+
+/** How far off the section's leader, as the percentage a timing screen shows. */
+function formatDelta(value: number, leader: number): string {
+  if (leader <= 0) return "";
+  return `+${(((value - leader) / leader) * 100).toFixed(2)}%`;
+}

--- a/src/pitwall/ui/src/features/data/DataWindow.tsx
+++ b/src/pitwall/ui/src/features/data/DataWindow.tsx
@@ -23,7 +23,9 @@
 
 import { OwnCarTraces } from "./OwnCarTraces";
 import { StatusStrip } from "./StatusStrip";
+import { TimingTower } from "./TimingTower";
 import { TrackRing } from "./TrackRing";
+import { useBulk } from "../../lib/useBulk";
 import { useConnection } from "../../lib/useConnection";
 import { useStatusText } from "../../lib/useStatusText";
 import { useTick } from "../../lib/useTick";
@@ -33,6 +35,7 @@ const WAITING = { text: "Waiting for arcade stream…", transient: false } as co
 export function DataWindow() {
   const { tick, discontinuity, live } = useTick();
   const connection = useConnection();
+  const bulk = useBulk();
   // Qt re-arms `showMessage(f"lap {lap} · live", 1500)` on every broadcast,
   // so the line stays up while streaming and clears 1.5 s after the producer
   // stops. `useStatusText` is keyed on the sequence for that reason.
@@ -44,14 +47,14 @@ export function DataWindow() {
       <div className="data-body">
         <StatusStrip tick={live ? tick : null} connection={connection} />
         {live && tick ? (
-          // Band 4 still spans the body. The 620 px left column arrives in the
-          // same change as the tower that fills it: an empty column of that
-          // width does not read as "reserved", it reads as a panel that failed
-          // to load - which is the note the gate wrote about the run of empty
-          // space under the ring.
-          <div className="band4">
-            <OwnCarTraces tick={tick} discontinuity={discontinuity} />
-            <TrackRing arcade={tick.arcade} />
+          <div className="data-main">
+            <div className="left-column">
+              <TimingTower arcade={tick.arcade} bulk={bulk} />
+            </div>
+            <div className="band4">
+              <OwnCarTraces tick={tick} discontinuity={discontinuity} />
+              <TrackRing arcade={tick.arcade} />
+            </div>
           </div>
         ) : (
           <p className="data-waiting">

--- a/src/pitwall/ui/src/features/data/DataWindow.tsx
+++ b/src/pitwall/ui/src/features/data/DataWindow.tsx
@@ -21,6 +21,7 @@
  * band-height-budget.md`; the drawn layout is in the project's memory.
  */
 
+import { BestsPanel } from "./BestsPanel";
 import { OwnCarTraces } from "./OwnCarTraces";
 import { StatusStrip } from "./StatusStrip";
 import { TimingTower } from "./TimingTower";
@@ -50,6 +51,7 @@ export function DataWindow() {
           <div className="data-main">
             <div className="left-column">
               <TimingTower arcade={tick.arcade} bulk={bulk} />
+              <BestsPanel bulk={bulk} />
             </div>
             <div className="band4">
               <OwnCarTraces tick={tick} discontinuity={discontinuity} />

--- a/src/pitwall/ui/src/features/data/OwnCarTraces.tsx
+++ b/src/pitwall/ui/src/features/data/OwnCarTraces.tsx
@@ -124,7 +124,6 @@ export function OwnCarTraces({ tick, discontinuity }: OwnCarTracesProps) {
           rivalColour={TRACE_COLOURS.rival}
           yRange={DELTA_Y}
           xMax={xMax}
-          mainCode={arcade.driver_main}
           rivalCode={rivalCode}
           main={[]}
           rival={frame.delta}
@@ -143,7 +142,6 @@ export function OwnCarTraces({ tick, discontinuity }: OwnCarTracesProps) {
           rivalColour={TRACE_COLOURS.rival}
           yRange={SPEED_Y}
           xMax={xMax}
-          mainCode={arcade.driver_main}
           rivalCode={rivalCode}
           main={channel(frame.main, "speed")}
           rival={channel(frame.rival, "speed")}
@@ -156,7 +154,6 @@ export function OwnCarTraces({ tick, discontinuity }: OwnCarTracesProps) {
           rivalColour={TRACE_COLOURS.rival}
           yRange={BRAKE_Y}
           xMax={xMax}
-          mainCode={arcade.driver_main}
           rivalCode={rivalCode}
           main={channel(frame.main, "brake")}
           rival={channel(frame.rival, "brake")}
@@ -169,7 +166,6 @@ export function OwnCarTraces({ tick, discontinuity }: OwnCarTracesProps) {
           rivalColour={TRACE_COLOURS.rival}
           yRange={THROTTLE_Y}
           xMax={xMax}
-          mainCode={arcade.driver_main}
           rivalCode={rivalCode}
           main={channel(frame.main, "throttle")}
           rival={channel(frame.rival, "throttle")}
@@ -201,7 +197,13 @@ function TracesHeader({ tick }: { tick: Tick }) {
       {rivalCode ? (
         <>
           <span className="traces-vs">vs</span>
-          <span className="driver-chip driver-chip-rival">{rivalCode}</span>
+          {/* The BROADCAST tag rides on the rival's chip now that the per-cell
+           * legends are gone. Rival car data is real and public, but it is the
+           * coarse low-rate channel every team sees rather than pit-wall-grade
+           * telemetry, and the Qt window rendered it unlabelled. */}
+          <span className="driver-chip driver-chip-rival" title="broadcast tier">
+            {rivalCode} <span className="trace-tier">BROADCAST</span>
+          </span>
         </>
       ) : null}
     </header>

--- a/src/pitwall/ui/src/features/data/TimingTower.tsx
+++ b/src/pitwall/ui/src/features/data/TimingTower.tsx
@@ -27,6 +27,7 @@
 import type { ArcadeState, Bulk, DriverLaps, LapRow } from "../../lib/bridge";
 import { driverStatus, type DriverStatus } from "../../lib/driverStatus";
 import { formatGapCell, gapCell } from "../../lib/gapCell";
+import { sessionBests, type BestField, type SessionBests } from "../../lib/sessionBests";
 
 interface TimingTowerProps {
   arcade: ArcadeState;
@@ -36,6 +37,10 @@ interface TimingTowerProps {
 export function TimingTower({ arcade, bulk }: TimingTowerProps) {
   const order = arcade.race_order;
   const leader = order[0];
+  // The same reduction the bests panel ranks, from the same module. Two
+  // components each reducing over `bulk.drivers` is how the tower ends up
+  // painting a purple the panel does not list.
+  const bests = sessionBests(bulk);
 
   return (
     <section className="tower card">
@@ -73,6 +78,7 @@ export function TimingTower({ arcade, bulk }: TimingTowerProps) {
               leader={leader}
               arcade={arcade}
               bulk={bulk}
+              bests={bests}
             />
           ))}
         </tbody>
@@ -89,9 +95,10 @@ interface TowerRowProps {
   leader: string;
   arcade: ArcadeState;
   bulk: Bulk | null;
+  bests: SessionBests;
 }
 
-function TowerRow({ code, position, front, leader, arcade, bulk }: TowerRowProps) {
+function TowerRow({ code, position, front, leader, arcade, bulk, bests }: TowerRowProps) {
   const car = arcade.drivers[code];
   const status: DriverStatus = car ? driverStatus(car) : "out";
   const laps: DriverLaps | undefined = bulk?.drivers[code];
@@ -112,9 +119,21 @@ function TowerRow({ code, position, front, leader, arcade, bulk }: TowerRowProps
       </td>
       <td className="col-gap">{formatGapCell(gap)}</td>
       <td className="col-gap">{interval === null ? "—" : formatGapCell(interval)}</td>
-      <SectorCell time={last?.s1 ?? null} speed={last?.v1 ?? null} />
-      <SectorCell time={last?.s2 ?? null} speed={last?.v2 ?? null} />
-      <SectorCell time={last?.s3 ?? null} speed={last?.vfl ?? null} />
+      <SectorCell
+        time={last?.s1 ?? null}
+        speed={last?.v1 ?? null}
+        tone={sectorTone(last?.s1 ?? null, laps?.best.s1 ?? null, bests, "s1")}
+      />
+      <SectorCell
+        time={last?.s2 ?? null}
+        speed={last?.v2 ?? null}
+        tone={sectorTone(last?.s2 ?? null, laps?.best.s2 ?? null, bests, "s2")}
+      />
+      <SectorCell
+        time={last?.s3 ?? null}
+        speed={last?.vfl ?? null}
+        tone={sectorTone(last?.s3 ?? null, laps?.best.s3 ?? null, bests, "s3")}
+      />
       <td className={`col-last ${last?.deleted ? "is-deleted" : ""}`}>{lastCell(status, last)}</td>
       <td className="col-st">{last?.vst === null || last?.vst === undefined ? "—" : last.vst}</td>
       <td className="col-tyre">{tyreCell(last)}</td>
@@ -130,15 +149,52 @@ function TowerRow({ code, position, front, leader, arcade, bulk }: TowerRowProps
  * over twenty rows is 120 px of a window that has none to give, and buys back
  * 62 px of width the column does not need.
  */
-function SectorCell({ time, speed }: { time: number | null; speed: number | null }) {
+function SectorCell({
+  time,
+  speed,
+  tone,
+}: {
+  time: number | null;
+  speed: number | null;
+  tone: SectorTone;
+}) {
   return (
-    <td className="col-sector">
+    <td className={`col-sector is-${tone}`}>
       {time === null ? "—" : time.toFixed(3)}
       {/* A real space, not only the margin: the cell is read by a screen
        * reader and copied by a mouse, and "29.412301" is a different number. */}
       {speed === null ? null : <span className="cell-speed"> {speed}</span>}
     </td>
   );
+}
+
+/** Purple, green, yellow or nothing - the timing screen's four states. */
+type SectorTone = "purple" | "green" | "yellow" | "plain";
+
+/**
+ * The sector colour code every timing screen uses.
+ *
+ * Purple is fastest of the session outright, green is the driver's own best,
+ * yellow is slower than his own best, and plain is a time with nothing to
+ * compare against yet. The comparisons are made on the values the reader
+ * served, which already exclude deleted laps and generated rows, so a struck
+ * time cannot paint the tower purple.
+ *
+ * Both bests are recomputed over the REVEALED subset, so a rewind takes the
+ * colours back with the laps: the purple that only exists at lap 44 must not
+ * survive onto a screen whose clock says lap 10.
+ */
+function sectorTone(
+  value: number | null,
+  personalBest: number | null,
+  bests: SessionBests,
+  field: BestField,
+): SectorTone {
+  if (value === null) return "plain";
+  const sessionBest = bests[field][0];
+  if (sessionBest !== undefined && value <= sessionBest.value) return "purple";
+  if (personalBest === null) return "plain";
+  return value <= personalBest ? "green" : "yellow";
 }
 
 /**

--- a/src/pitwall/ui/src/features/data/TimingTower.tsx
+++ b/src/pitwall/ui/src/features/data/TimingTower.tsx
@@ -1,0 +1,195 @@
+/**
+ * Band 2, left: the timing tower.
+ *
+ * `P | # | DRV | GAP | INT | S1 t+v | S2 t+v | S3 t+v | LAST | ST | TYRE | STOPS`,
+ * which is the SBG/Catapult RaceX client's row read off the pit-wall
+ * photographs in this project's research - including the detail that each
+ * sector cell carries two numbers, a time and a trap speed, and that `ST` is
+ * the speed trap rather than the stint.
+ *
+ * **Rows and order come from the TICK; the numbers come from the BULK.** The
+ * split is not stylistic. Order changes mid-lap on ticks that change no
+ * `laps_completed`, so only the wire can answer it; the seconds are quantised
+ * to the line and the parquet is the official clock, which the arcade's own
+ * `gaps.py` concedes its interpolated crossings sit a median 22 ms away from.
+ *
+ * **Iterate `race_order`, never the bulk's keys.** SAI, DOO and HAD have only
+ * `FastF1Generated` rows on Melbourne 2025, so they reveal nothing at all -
+ * measured, `bulk.drivers.SAI` is present with zero rows for the whole race.
+ * A tower keyed on what the bulk contains renders them as blanks it cannot
+ * place; `race_order` always carries twenty codes and puts them where the
+ * producer's own ranking does.
+ *
+ * The GAP and INT columns are quantised to the line and the HEADER says so,
+ * once, rather than each of the forty cells repeating it.
+ */
+
+import type { ArcadeState, Bulk, DriverLaps, LapRow } from "../../lib/bridge";
+import { driverStatus, type DriverStatus } from "../../lib/driverStatus";
+import { formatGapCell, gapCell } from "../../lib/gapCell";
+
+interface TimingTowerProps {
+  arcade: ArcadeState;
+  bulk: Bulk | null;
+}
+
+export function TimingTower({ arcade, bulk }: TimingTowerProps) {
+  const order = arcade.race_order;
+  const leader = order[0];
+
+  return (
+    <section className="tower card">
+      <table className="tower-table">
+        <thead>
+          <tr>
+            <th className="col-pos">P</th>
+            <th className="col-num">#</th>
+            <th className="col-drv">DRV</th>
+            {/* The (L) that the arcade suffixes onto every label lives here
+             * instead: it is the same claim, made once, on a surface that has
+             * a header to make it on. */}
+            <th className="col-gap">
+              GAP <span className="col-note">(L)</span>
+            </th>
+            <th className="col-gap">
+              INT <span className="col-note">(L)</span>
+            </th>
+            <th className="col-sector">S1</th>
+            <th className="col-sector">S2</th>
+            <th className="col-sector">S3</th>
+            <th className="col-last">LAST</th>
+            <th className="col-st">ST</th>
+            <th className="col-tyre">TYRE</th>
+            <th className="col-stops">STOPS</th>
+          </tr>
+        </thead>
+        <tbody>
+          {order.map((code, index) => (
+            <TowerRow
+              key={code}
+              code={code}
+              position={index + 1}
+              front={index === 0 ? null : order[index - 1]}
+              leader={leader}
+              arcade={arcade}
+              bulk={bulk}
+            />
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}
+
+interface TowerRowProps {
+  code: string;
+  position: number;
+  /** The car directly ahead in the published order, or null for the leader. */
+  front: string | null;
+  leader: string;
+  arcade: ArcadeState;
+  bulk: Bulk | null;
+}
+
+function TowerRow({ code, position, front, leader, arcade, bulk }: TowerRowProps) {
+  const car = arcade.drivers[code];
+  const status: DriverStatus = car ? driverStatus(car) : "out";
+  const laps: DriverLaps | undefined = bulk?.drivers[code];
+  // The last lap this driver has actually completed. It can be a generated
+  // row - a car that never finished one - and then every number on it is
+  // null, which is the honest rendering rather than an absent row.
+  const last: LapRow | null = laps?.laps.length ? laps.laps[laps.laps.length - 1] : null;
+
+  const gap = front === null ? { kind: "leader" as const } : gapCell(leader, code, arcade, bulk);
+  const interval = front === null ? null : gapCell(front, code, arcade, bulk);
+
+  return (
+    <tr className={`tower-row is-${status}`}>
+      <td className="col-pos">{position}</td>
+      <td className="col-num">{laps?.number ?? "—"}</td>
+      <td className="col-drv" style={{ color: driverColour(arcade, code) }}>
+        {code}
+      </td>
+      <td className="col-gap">{formatGapCell(gap)}</td>
+      <td className="col-gap">{interval === null ? "—" : formatGapCell(interval)}</td>
+      <SectorCell time={last?.s1 ?? null} speed={last?.v1 ?? null} />
+      <SectorCell time={last?.s2 ?? null} speed={last?.v2 ?? null} />
+      <SectorCell time={last?.s3 ?? null} speed={last?.vfl ?? null} />
+      <td className={`col-last ${last?.deleted ? "is-deleted" : ""}`}>{lastCell(status, last)}</td>
+      <td className="col-st">{last?.vst === null || last?.vst === undefined ? "—" : last.vst}</td>
+      <td className="col-tyre">{tyreCell(last)}</td>
+      <td className="col-stops">{laps?.stops ?? "—"}</td>
+    </tr>
+  );
+}
+
+/**
+ * A sector's time with its trap speed beside it, dimmer and smaller.
+ *
+ * Inline rather than stacked. Stacking the pair costs six pixels a row, which
+ * over twenty rows is 120 px of a window that has none to give, and buys back
+ * 62 px of width the column does not need.
+ */
+function SectorCell({ time, speed }: { time: number | null; speed: number | null }) {
+  return (
+    <td className="col-sector">
+      {time === null ? "—" : time.toFixed(3)}
+      {/* A real space, not only the margin: the cell is read by a screen
+       * reader and copied by a mouse, and "29.412301" is a different number. */}
+      {speed === null ? null : <span className="cell-speed"> {speed}</span>}
+    </td>
+  );
+}
+
+/**
+ * What the LAST column shows, in the order a timing screen decides it.
+ *
+ * A broadcast screen puts `IN PIT` or `OUT` **in place of the lap time**, and
+ * that is what happens here - except that "OUT" is used for a car that has
+ * stopped, matching the arcade leaderboard on screen beside this one, so an
+ * out-lap says `PIT EXIT` rather than borrowing the same word for a car that
+ * is very much still racing.
+ */
+function lastCell(status: DriverStatus, last: LapRow | null): string {
+  if (status === "out") return "OUT";
+  if (last === null) return "—";
+  if (last.pit_in) return "IN PIT";
+  if (last.pit_out) return "PIT EXIT";
+  return last.lap_time === null ? "—" : formatLapTime(last.lap_time);
+}
+
+/**
+ * The compound's letter and the set's age.
+ *
+ * The letter is the compound's own first character, which is correct for all
+ * five (SOFT, MEDIUM, HARD, INTERMEDIATE, WET) and is therefore not a second
+ * copy of the arcade's letter table. The compound arrives from the BULK,
+ * which is the repaired frame: the live-timing feed drops stint records and
+ * restarts the stint at the recovery lap, so the unrepaired value reads
+ * `TyreLife 1` on a set that has done twenty-four racing laps.
+ */
+function tyreCell(last: LapRow | null): string {
+  if (!last?.compound) return "—";
+  const age = last.tyre_life === null ? "" : ` ${Math.round(last.tyre_life)}`;
+  return `${last.compound[0]}${age}`;
+}
+
+/** `1:25.744` past the minute, `58.220` under it, as a timing screen prints them. */
+function formatLapTime(seconds: number): string {
+  if (seconds < 60) return seconds.toFixed(3);
+  const minutes = Math.floor(seconds / 60);
+  const rest = seconds - minutes * 60;
+  return `${minutes}:${rest.toFixed(3).padStart(6, "0")}`;
+}
+
+/**
+ * The driver's own colour, from the arcade's palette on the wire.
+ *
+ * Never a table here: `driver_colors` rides on every tick precisely so no
+ * consumer keeps a second copy of a palette this repo has already found five
+ * copies of.
+ */
+function driverColour(arcade: ArcadeState, code: string): string {
+  const rgb = arcade.driver_colors[code];
+  return rgb ? `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})` : "var(--qt-fg-1)";
+}

--- a/src/pitwall/ui/src/features/data/TraceChart.tsx
+++ b/src/pitwall/ui/src/features/data/TraceChart.tsx
@@ -28,7 +28,6 @@ export interface TraceChartProps {
   yRange: [number, number];
   /** Locked X maximum: the circuit length, or the fallback until one arrives. */
   xMax: number;
-  mainCode: string;
   rivalCode: string | null;
   main: [number, number][];
   rival: [number, number][];
@@ -52,7 +51,6 @@ export function TraceChart(props: TraceChartProps) {
     rivalColour,
     yRange,
     xMax,
-    mainCode,
     rivalCode,
     main,
     rival,
@@ -127,18 +125,22 @@ export function TraceChart(props: TraceChartProps) {
 
   return (
     <div className="trace-cell">
+      {/* Title and subtitle only.
+       *
+       * Qt puts a `MAIN · VER` / `RIVAL · PIA` legend chip in every cell, and
+       * band 4 kept them while it spanned the window. In the right column a
+       * cell is 277 px wide and the row wraps - "Δ Time (s)" onto three lines -
+       * which costs about 35 px of plot per wrapped line and leaves the 2x2
+       * grid ragged. The identity moves to the card header, where both codes
+       * were already shown and where saying it once for four charts of the
+       * same two cars is the honest amount. The BROADCAST tier tag goes with
+       * it: that label is a deliberate addition over the Qt window, not
+       * decoration, so it had to keep a home rather than be dropped. */}
       <div className="trace-title-row">
-        <span className="trace-title">{title}</span>
-        <span className="trace-subtitle">{subtitle}</span>
-        <span className="trace-spacer" />
-        <span className="trace-legend" style={{ color: mainColour }}>
-          MAIN · {mainCode || "—"}
+        <span className="trace-title" style={{ color: mainColour }}>
+          {title}
         </span>
-        {rivalCode ? (
-          <span className="trace-legend" style={{ color: rivalColour }} title="broadcast tier">
-            RIVAL · {rivalCode} <span className="trace-tier">BROADCAST</span>
-          </span>
-        ) : null}
+        <span className="trace-subtitle">{subtitle}</span>
       </div>
       {placeholder ? (
         <div className="trace-placeholder">{placeholder}</div>

--- a/src/pitwall/ui/src/lib/gapCell.ts
+++ b/src/pitwall/ui/src/lib/gapCell.ts
@@ -1,0 +1,160 @@
+/**
+ * The interval between two cars, as a timing tower renders it.
+ *
+ * A port of `DriverInfoPanel._gap_label` (`src/arcade/overlays.py`), and it
+ * is ONE exported function for the reason `driverStatus.ts` is: the tower's
+ * GAP column and its INT column are the second and third callers of a rule
+ * whose four branches were written once, and two inline copies is this
+ * repo's dominant defect - one gets fixed and its twin does not. The Qt
+ * panel's own docstring records what the missing branches cost: without the
+ * OUT branch it rendered "an interval, up to 22 minutes old, naming a car
+ * that stopped".
+ *
+ * **Two clocks, and this one deliberately picks the other one.** The arcade
+ * measures intervals from crossings it detects by interpolating a step
+ * function; the parquet's `Time` is FastF1's timing table. Measured over all
+ * 7,018 at-line pairs of Melbourne 2025 they differ by a median 17 ms
+ * (p95 105 ms, worst 568 ms), which is enough to change 83 % of the strings
+ * a tower prints at two decimals, and one pair is sign-inverted outright.
+ * `gaps.py` concedes the gap: its crossings sit a median 22 ms from the
+ * parquet's and 9.8 % of them land more than a frame away. So the SECONDS
+ * come from the bulk (the official clock) while the ORDER, the status and
+ * the laps-down all keep coming from the wire, which is the only side that
+ * can answer them mid-lap.
+ *
+ * The accepted cost, so nobody files it as a bug while both windows are on
+ * screen: PITWALL's hundredths differ from the arcade's on about 83 % of
+ * pairs by at most a tenth, and on 0.1 % of labels PITWALL shows a dash
+ * where the arcade shows a number. PITWALL is the one that matches official
+ * timing.
+ */
+
+import type { ArcadeState, Bulk } from "./bridge";
+import { driverStatus } from "./driverStatus";
+
+/**
+ * One frame of the replay, and the tolerance on an inverted interval.
+ *
+ * `interval_at_line` reports a difference within one frame period of zero as
+ * 0.0 rather than as an inversion, because the crossing itself is only
+ * resolved to a frame and a sub-frame negative is noise. Anything more
+ * negative than this means the pair was passed in the wrong order, and the
+ * answer is a dash - **never a clamp to zero**, because zero is a legitimate
+ * interval (two cars level) and clamping turns a detectable inversion into a
+ * plausible reading. Measured in the arcade: under such a clamp an inverted
+ * call returned `0.000` on five of six sampled laps while the truth was 1 to
+ * 25 seconds the other way.
+ */
+const FRAME_SECONDS = 1 / 25;
+
+export type GapCell =
+  /** This car leads; there is nothing in front to measure against. */
+  | { kind: "leader" }
+  /** One of the two cars has stopped. Any interval to it is frozen and stale. */
+  | { kind: "out" }
+  /** More than a full lap of track apart. */
+  | { kind: "laps"; laps: number }
+  /** Seconds, measured at the line ending `lap`. */
+  | { kind: "secs"; seconds: number; lap: number }
+  /** An input is unknown. Never a plausible-looking substitute. */
+  | { kind: "na" };
+
+/**
+ * Whole laps of track between two cars, or null when the answer does not exist.
+ *
+ * Positional, from the wire's `progress`, exactly as `RaceGapCalculator.
+ * laps_down` is - and deliberately NOT a difference of lap numbers, which
+ * differs by one for the whole window between the two cars crossing the
+ * line, which is not being lapped. Null rather than 0 when either progress
+ * is unknown or the pair is inverted, because 0 legitimately means "same
+ * lap".
+ */
+function lapsDown(frontProgress: number | null, backProgress: number | null): number | null {
+  if (frontProgress === null || backProgress === null) return null;
+  const difference = frontProgress - backProgress;
+  if (difference < 0) return null;
+  return Math.trunc(difference);
+}
+
+/**
+ * The interval between the car in front and the car behind it.
+ *
+ * Four outcomes, decided in this order - the order is the contract, not the
+ * arithmetic:
+ *
+ * 1. **OUT** when either car has stopped. `np.interp` clamps past a driver's
+ *    last sample, so a parked car keeps reporting its final state forever
+ *    and every later branch would happily measure against it.
+ * 2. **+N LAP(S)** when the car in front is more than a full lap of track
+ *    ahead, the way a timing screen shows it. Without this a lapped pair
+ *    reads as tens of seconds, as if they were racing.
+ * 3. **seconds at the line** ending the last lap BOTH cars have completed.
+ * 4. **N/A** when any input is unknown.
+ *
+ * The lap is taken from the bulk's own `laps_revealed` rather than from the
+ * tick's `laps_completed`, and that is not a shortcut. The two agree, but
+ * the bulk's crossings only exist for the laps the bulk has revealed, so
+ * asking for a lap the tick knows about and the bulk has not served yet
+ * would blink the whole column to dashes once per lap. Taking both from the
+ * same payload makes the pair self-consistent by construction.
+ */
+export function gapCell(
+  frontCode: string,
+  backCode: string,
+  arcade: ArcadeState,
+  bulk: Bulk | null,
+): GapCell {
+  const front = arcade.drivers[frontCode];
+  const back = arcade.drivers[backCode];
+  if (!front || !back) return { kind: "na" };
+
+  if (driverStatus(front) === "out" || driverStatus(back) === "out") return { kind: "out" };
+
+  const laps = lapsDown(front.progress, back.progress);
+  if (laps === null) return { kind: "na" };
+  if (laps >= 1) return { kind: "laps", laps };
+
+  const frontLaps = bulk?.drivers[frontCode];
+  const backLaps = bulk?.drivers[backCode];
+  if (!frontLaps || !backLaps) return { kind: "na" };
+
+  const lap = Math.min(frontLaps.laps_revealed, backLaps.laps_revealed);
+  // No crossing map holds lap 0, so the opening lap reads N/A rather than
+  // inventing an interval - which is right: no classification exists there.
+  const frontTime = frontLaps.crossings[lap];
+  const backTime = backLaps.crossings[lap];
+  if (frontTime === undefined || backTime === undefined) return { kind: "na" };
+
+  const seconds = backTime - frontTime;
+  if (seconds < -FRAME_SECONDS) return { kind: "na" };
+  return { kind: "secs", seconds: Math.max(0, seconds), lap };
+}
+
+/**
+ * The cell as the tower prints it.
+ *
+ * **The "(L)" suffix the arcade appends is NOT here, and the omission is
+ * deliberate.** In the arcade the label is loose text with no header, so the
+ * suffix is the only place it can say the number is quantised to the line;
+ * in a table there are forty of these cells and a header, and the header
+ * carries it once. The rule the delivery plan sets is that the column says
+ * so on screen, and it does - "an unlabelled number on a fidelity surface
+ * implies a liveness this one does not have" is satisfied by the column
+ * heading, not by repeating three characters forty times.
+ */
+export function formatGapCell(cell: GapCell): string {
+  switch (cell.kind) {
+    case "leader":
+      return "LEADER";
+    case "out":
+      return "OUT";
+    case "laps":
+      return `+${cell.laps} LAP${cell.laps > 1 ? "S" : ""}`;
+    case "secs":
+      return `+${cell.seconds.toFixed(2)}s`;
+    case "na":
+      // The same dash every other unknown cell in the tower uses. The arcade
+      // prints "N/A" because it has no column of dashes to be consistent with.
+      return "—";
+  }
+}

--- a/src/pitwall/ui/src/lib/sessionBests.ts
+++ b/src/pitwall/ui/src/lib/sessionBests.ts
@@ -1,0 +1,78 @@
+/**
+ * The field's best sector and lap times, ranked, over what the clock revealed.
+ *
+ * One module because two panels need the identical answer: the bests panel
+ * ranks it, and the tower colours a sector cell purple when it matches. Two
+ * components each reducing over `bulk.drivers` is the twin this repo keeps
+ * paying for - the day one of them starts excluding deleted laps and the
+ * other does not, the tower paints a purple that the panel does not list.
+ *
+ * **Recomputed, never read off `IsPersonalBest`.** That flag is a running one
+ * and it is safe under masking, but the two sequences are not identical:
+ * measured on Melbourne 2025 they differ on 47 lap-flags across all twenty
+ * drivers, in both directions, concentrated on the wet-start laps. They
+ * converge only at the final frame, and mid-race is the only state a masked
+ * panel ever renders. The exclusions the recompute needs - a deleted time
+ * does not count, a generated row has no time at all - are already applied by
+ * the reader that produced `best`.
+ */
+
+import type { Bulk } from "./bridge";
+
+/** The fields a bests section can rank. `lap_time` is the fourth section. */
+export type BestField = "s1" | "s2" | "s3" | "lap_time";
+
+export interface BestEntry {
+  code: string;
+  value: number;
+  /** The compound the fastest LAP was set on; null for a sector - see below. */
+  compound: string | null;
+}
+
+export type SessionBests = Record<BestField, BestEntry[]>;
+
+const FIELDS: BestField[] = ["s1", "s2", "s3", "lap_time"];
+
+/**
+ * Every driver's best per field, fastest first, drivers with none omitted.
+ *
+ * The compound is only carried on the lap ranking. The reader serves the
+ * compound of a driver's fastest LAP, which is the right answer there and a
+ * wrong one for a sector - his best S1 may well have been set on another set
+ * entirely. Rather than attach a plausible-looking compound to a sector, the
+ * sector rankings carry none, and the panel renders the column empty for them.
+ */
+export function sessionBests(bulk: Bulk | null): SessionBests {
+  const ranked = { s1: [], s2: [], s3: [], lap_time: [] } as SessionBests;
+  if (!bulk?.available) return ranked;
+
+  for (const field of FIELDS) {
+    const entries: BestEntry[] = [];
+    for (const [code, driver] of Object.entries(bulk.drivers)) {
+      const value = driver.best[field];
+      if (value === null) continue;
+      entries.push({
+        code,
+        value,
+        compound: field === "lap_time" ? driver.best.compound : null,
+      });
+    }
+    entries.sort((left, right) => left.value - right.value);
+    ranked[field] = entries;
+  }
+  return ranked;
+}
+
+/**
+ * The ideal lap: the field's best S1, S2 and S3 recombined.
+ *
+ * Null while any of the three is still unknown rather than a partial sum,
+ * which would read as a lap somebody nearly drove. Lap 1 has no S1 for any
+ * driver by construction, so this stays null until the field has completed
+ * two laps - which is correct and not a bug to paper over.
+ */
+export function theoreticalLap(bests: SessionBests): number | null {
+  const sectors = [bests.s1[0], bests.s2[0], bests.s3[0]];
+  if (sectors.some((entry) => entry === undefined)) return null;
+  return sectors.reduce((total, entry) => total + entry.value, 0);
+}

--- a/src/pitwall/ui/src/lib/useBulk.ts
+++ b/src/pitwall/ui/src/lib/useBulk.ts
@@ -1,0 +1,61 @@
+/**
+ * The revealed lap table, polled on its own timer.
+ *
+ * The second data channel (design decision C7): the tick carries the instant,
+ * this carries everything the timing table and the bests panel show. It is
+ * static parquet, known before lap 1, so the panel is a progressive reveal
+ * rather than a stream to accumulate - and the host applies the mask, so what
+ * arrives here is already only what the clock has opened.
+ *
+ * **Compare the revision on inequality, never on "greater than".** A rewind
+ * takes laps BACK and LOWERS the revision's content; treating a lower value
+ * as stale would keep rows the clock has un-revealed, which is the leak
+ * host-side masking exists to prevent, one level up. The host holds the same
+ * rule; this hook simply hands back whatever it is given.
+ *
+ * **Nothing here accumulates.** Each result REPLACES the previous one. A
+ * grow-only cache would survive a seek to the end and then show the final
+ * classification on a screen whose clock says lap 10.
+ *
+ * Half a second, not the tick's 100 ms: the mask changes only when some
+ * driver completes a lap, about once every four and a half seconds, and the
+ * column it feeds is lap-quantised anyway.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { getBulk, whenBridgeReady, type Bulk } from "./bridge";
+
+const POLL_INTERVAL_MS = 500;
+
+export function useBulk(): Bulk | null {
+  const [bulk, setBulk] = useState<Bulk | null>(null);
+  // A ref, not state: the loop must read the newest revision without
+  // re-subscribing, and a stale closure would ask for the same one forever.
+  const revision = useRef(-1);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: number | undefined;
+
+    const poll = async () => {
+      const next = await getBulk(revision.current);
+      if (cancelled) return;
+      if (next) {
+        revision.current = next.rev;
+        setBulk(next);
+      }
+      timer = window.setTimeout(poll, POLL_INTERVAL_MS);
+    };
+
+    whenBridgeReady().then(() => {
+      if (!cancelled) poll();
+    });
+
+    return () => {
+      cancelled = true;
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
+  }, []);
+
+  return bulk;
+}

--- a/src/pitwall/ui/src/styles/data.css
+++ b/src/pitwall/ui/src/styles/data.css
@@ -242,6 +242,145 @@
   color: var(--qt-fg-3);
 }
 
+/* The sector colour code every timing screen uses: purple is fastest of the
+ * session outright, green is the driver's own best, yellow is slower than his
+ * own best. Plain is a time with nothing to compare against yet, and it stays
+ * the body colour rather than borrowing one of the three - a colour that means
+ * something is not free to spend on "no comparison". */
+.col-sector.is-purple {
+  color: #a78bfa;
+  font-weight: 700;
+}
+.col-sector.is-green {
+  color: #10b981;
+}
+/* WARNING, not the broadcast's own yellow. Every colour in these stylesheets
+ * has to trace back to a name in `palette.py`, and #facc15 - the yellow the
+ * arcade's flag banner uses - is not one of them. Amber reads as "slower"
+ * just as well and stays inside the guard. */
+.col-sector.is-yellow {
+  color: #f59e0b;
+}
+
+/* --- Band 2 right: the bests panel ---------------------------------------- */
+
+.bests {
+  padding: 10px;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-self: start;
+}
+
+.bests-header {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 0 2px;
+}
+
+.bests-title {
+  color: var(--qt-fg-1);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 1px;
+}
+
+.bests-subtitle {
+  color: var(--qt-fg-3);
+  font-size: 10px;
+}
+
+/* Four sections side by side. They spend WIDTH, which the left column has,
+ * rather than height, which it does not: stacked they would be four times as
+ * tall for the same twelve rows. */
+.bests-sections {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+}
+
+.bests-section {
+  min-width: 0;
+}
+
+.bests-field-label {
+  color: var(--qt-fg-3);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  padding-bottom: 2px;
+  border-bottom: 1px solid var(--qt-border);
+  margin-bottom: 3px;
+}
+
+.bests-row {
+  display: grid;
+  grid-template-columns: 10px 30px 1fr auto 10px;
+  gap: 4px;
+  align-items: baseline;
+  font-family: var(--qt-mono);
+  font-size: 11px;
+  line-height: 17px;
+  color: var(--qt-fg-2);
+}
+
+.bests-row.is-purple .bests-value {
+  color: #a78bfa;
+  font-weight: 700;
+}
+
+.bests-rank,
+.bests-compound {
+  color: var(--qt-fg-3);
+  font-size: 9px;
+}
+
+.bests-code {
+  color: var(--qt-fg-1);
+  font-weight: 800;
+  letter-spacing: 0.5px;
+}
+
+.bests-value {
+  text-align: right;
+}
+
+.bests-delta {
+  color: var(--qt-fg-3);
+  font-size: 9px;
+}
+
+.bests-empty {
+  color: var(--qt-fg-3);
+  font-family: var(--qt-mono);
+  font-size: 11px;
+  line-height: 17px;
+}
+
+.bests-theoretical {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding-top: 6px;
+  border-top: 1px solid var(--qt-border);
+}
+
+.bests-theoretical-value {
+  color: var(--qt-fg-1);
+  font-family: var(--qt-mono);
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.bests-theoretical-note {
+  color: var(--qt-fg-3);
+  font-family: var(--qt-mono);
+  font-size: 10px;
+}
+
 /* A stopped car stays in the tower at the place its laps earned, dimmed. It
  * is not removed: a timing screen classifies retirements, it does not pretend
  * they were never entered. */

--- a/src/pitwall/ui/src/styles/data.css
+++ b/src/pitwall/ui/src/styles/data.css
@@ -130,6 +130,130 @@
   color: var(--qt-fg-2);
 }
 
+/* --- The two columns ------------------------------------------------------
+ *
+ * The all-cars world on the left and the own-car world on the right, which is
+ * how a real wall splits them across physical surfaces - and, separately, the
+ * only arrangement that fits: four stacked bands need 908 px of the 790 this
+ * window has, with band 3 still at zero.
+ *
+ * 630 px for the left column, and the number is measured on THIS table rather
+ * than inherited: its natural width is 597 px at 11 px mono, so the card needs
+ * 619 before any column is compressed. The design gate's prototype measured
+ * 597.6 and recommended 620, which happens to land one pixel clear - close
+ * enough that a font fallback would eat it. 630 leaves eleven pixels of air.
+ */
+.data-main {
+  display: grid;
+  grid-template-columns: 630px minmax(0, 1fr);
+  gap: 10px;
+  min-height: 0;
+}
+
+/* `auto` for the tower and the remainder for what sits under it. The tower
+ * must NEVER be squeezed: scrollbars are hidden globally (`qt-base.css`), so
+ * a squeezed tower does not gain a scrollbar, it silently stops drawing its
+ * last rows - a timing tower with no P15 to P20 and nothing saying so. */
+.left-column {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 10px;
+  min-height: 0;
+}
+
+/* --- Band 2 left: the timing tower ---------------------------------------- */
+
+.tower {
+  padding: 10px;
+  min-width: 0;
+}
+
+/* 11 px mono and 20 px rows: the floor at which the twelve columns stay
+ * legible at 150 % scaling, measured on the real screen. 12 px fits THIS
+ * machine and costs the bests panel its room on a 1080p laptop at 125 %. */
+.tower-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--qt-mono);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.tower-table th {
+  color: var(--qt-fg-3);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  text-align: right;
+  padding: 0 4px 3px;
+  border-bottom: 1px solid var(--qt-border);
+  white-space: nowrap;
+}
+
+.tower-table td {
+  height: 20px;
+  padding: 0 4px;
+  text-align: right;
+  color: var(--qt-fg-2);
+  white-space: nowrap;
+}
+
+.col-pos,
+.col-num,
+.col-drv,
+.col-tyre {
+  text-align: left;
+}
+
+.col-pos {
+  color: var(--qt-fg-3);
+  width: 20px;
+}
+.col-num {
+  color: var(--qt-fg-3);
+  width: 22px;
+}
+.col-drv {
+  font-weight: 800;
+  letter-spacing: 0.5px;
+  width: 34px;
+}
+.col-last {
+  color: var(--qt-fg-1);
+  font-weight: 700;
+}
+.col-note {
+  font-weight: 400;
+  opacity: 0.7;
+}
+
+/* The trap speed rides beside its sector time, dimmer and smaller, so the
+ * cell reads as one value with an annotation rather than as two columns. */
+.cell-speed {
+  margin-left: 5px;
+  font-size: 0.82em;
+  color: var(--qt-fg-3);
+}
+
+/* A deleted lap time is struck, not hidden: it happened, and it does not
+ * count. The bests recompute already excludes it. */
+.col-last.is-deleted {
+  text-decoration: line-through;
+  color: var(--qt-fg-3);
+}
+
+/* A stopped car stays in the tower at the place its laps earned, dimmed. It
+ * is not removed: a timing screen classifies retirements, it does not pretend
+ * they were never entered. */
+.tower-row.is-out td {
+  color: var(--qt-fg-3);
+  opacity: 0.65;
+}
+
+.tower-row.is-finished .col-last {
+  color: var(--qt-fg-2);
+}
+
 /* Band 4 is the traces plus the ring in its corner. The ring is a fixed
  * column because it is a circle: giving it a fraction of the width makes it
  * shrink as the traces grow, which is backwards - the traces are the thing

--- a/tests/surfaces/test_pitwall_tokens.py
+++ b/tests/surfaces/test_pitwall_tokens.py
@@ -371,15 +371,20 @@ def test_the_data_stylesheets_raw_hexes_are_guarded_too():
         }
     )
 
-    assert raw == ["#10b981", "#3b82f6", "#ef4444", "#f59e0b"], (
+    assert raw == ["#10b981", "#3b82f6", "#a78bfa", "#ef4444", "#f59e0b"], (
         f"a new raw hex entered the DATA stylesheet: {raw}. Either use a --qt-* token or add it "
         "here with the palette name it copies."
     )
-    assert raw[0] == _rgb_to_hex(palette.SUCCESS), "band 1's Connected chip copies SUCCESS"
+    assert raw[0] == _rgb_to_hex(palette.SUCCESS), (
+        "band 1's Connected chip and the tower's personal-best sector copy SUCCESS"
+    )
     assert raw[1] == _rgb_to_hex(palette.INFO), "the main driver chip copies INFO"
-    assert raw[2] == _rgb_to_hex(palette.DANGER), "band 1's Disconnected chip copies DANGER"
-    assert raw[3] == _rgb_to_hex(palette.WARNING), (
-        "the rival driver chip and band 1's PROVISIONAL chip both copy WARNING"
+    assert raw[2] == _rgb_to_hex(palette.ACCENT), (
+        "a session-best sector is purple, and purple here is the arcade's ACCENT"
+    )
+    assert raw[3] == _rgb_to_hex(palette.DANGER), "band 1's Disconnected chip copies DANGER"
+    assert raw[4] == _rgb_to_hex(palette.WARNING), (
+        "the rival chip, band 1's PROVISIONAL chip and a slower-than-own-best sector copy WARNING"
     )
 
 


### PR DESCRIPTION
Closes #927. Stacked on #926 (the tower), so review that one first.

## The panel

`S1 | S2 | S3 | LAP`, each a top three across the FIELD, each row `rank / driver / time / % delta`
with the compound on the lap section, and a THEORETICAL line underneath. The shape is the RaceX
client's `Bests - Time` panel, read off the research photographs.

Three decisions with their reasons:

- **Top three is structural.** A fully ranked section is twenty rows and four of them are 1,668 px
  of a window whose whole body is 790.
- **The delta is a percentage.** The four sections differ by an order of magnitude in absolute
  terms - tenths in a sector against seconds over a lap - and a percentage reads the same in all
  four.
- **The compound rides on the LAP section only.** The reader serves the compound of a driver's
  fastest LAP; his best S1 may have been set on another set entirely, and a plausible-looking
  compound on a sector is worse than none.

## `lib/sessionBests.ts`, and why it is a module

Two panels need the identical answer: the bests panel ranks it, and the tower colours a sector
purple when it matches. Two components each reducing over `bulk.drivers` is how the tower ends up
painting a purple the panel does not list - the twin, one more time.

Recomputed rather than read off `IsPersonalBest`: measured on Melbourne 2025 the two sequences
differ on 47 lap-flags across all twenty drivers, in both directions, and converge only at the
final frame. Mid-race is the only state a masked panel ever renders.

## The sector colour code

Purple for fastest of the session outright, green for the driver's own best, yellow for slower
than his own, and the plain body colour when there is nothing to compare against - a colour that
means something is not free to spend on "no comparison". Both bests come from the revealed subset,
so a rewind takes the colours back with the laps.

A yellow sector uses `WARNING` (#f59e0b) rather than the broadcast's #facc15: every colour in
these stylesheets has to trace back to a name in `palette.py`, and the drift guard says so out
loud when one does not.

## Verification

`smoke-data` 83 checks (was 70). The fixture is arranged so every claim is decidable by hand -
NOR owns S1 and matched it, PIA owns S2 and matched his own S1, VER owns S3 and was slower than
his own - so a panel reading one field for all four sections would show NOR three times, and a
tower deciding purple against the driver's own best would paint three of them.

Watched RED:

- summing one driver's own sectors instead of the field's three gives
  `THEORETICAL 1:27.000` against the expected `1:13.400`;
- the ranking, the per-section owners and the three tones each have their own named check.

A note on how that second mutation went: the first attempt did not COMPILE (two parameters became
unused), so `npm run build` failed, `dist/` kept the previous bundle and the harness ran against
code that no longer existed. A red-check is only evidence once the build that produced it
succeeded - this is the second time this sprint that trap has been live.

`tests/surfaces` 206 passed - `smoke-data` 83 - `smoke-agents` 18 - `tsc` clean - ruff clean.

## Known, and next

The sector columns currently show the LAST COMPLETED lap and hold it until the next one. Víctor is
right that a timing tower blanks them at the line and fills S1, S2, S3 as the car crosses each -
and the data for it exists: `Sector{1,2,3}SessionTime` are in the parquet, on the same clock band
1 already renders. That is its own PR, because where the sector mask lives is an architecture
decision (a clock-driven mask would re-send the whole 342 KB payload ten times a second) and it
should be measured rather than guessed.