### PR TITLE
feat(pitwall): fill the tower's sectors as the car crosses them

### DIFF
--- a/src/pitwall/host.py
+++ b/src/pitwall/host.py
@@ -62,6 +62,11 @@ class PitwallHost:
         self._bulk_reveal: dict[str, int] = {}
         self._session: SessionLaps | None = None
         self._session_key: tuple[int, str] | None = None
+        # The LIVE channel's state, masked by the clock rather than by
+        # completed laps. Its signature is which sectors are open, so the
+        # revision moves when the screen changes and not ten times a second.
+        self._live_rev = 0
+        self._live_signature: dict[str, tuple[bool, ...]] = {}
 
     def start(self) -> None:
         self._client.start()
@@ -174,10 +179,7 @@ class PitwallHost:
         if payload is None:
             return None
         arcade = payload.get("arcade") or {}
-        reveal = {
-            code: int(state.get("laps_completed") or 0)
-            for code, state in (arcade.get("drivers") or {}).items()
-        }
+        reveal = self._reveal_map(arcade)
         if reveal != self._bulk_reveal:
             self._bulk_reveal = reveal
             self._bulk_rev += 1
@@ -188,6 +190,74 @@ class PitwallHost:
         view["rev"] = self._bulk_rev
         return view
 
+    def get_live_lap(self, since_rev: int = -1) -> dict | None:
+        """The lap each driver is ON, with only the sectors he has crossed.
+
+        The tower's sector columns show the lap in progress, blank at the line
+        and filling as each sector goes by. That needs a mask driven by the
+        CLOCK rather than by completed laps, and the two cannot share one
+        payload: a sector opens somewhere in the field every 2.22 s, and
+        re-sending the whole revealed race at that cadence is about 154 KB/s
+        against the tick's own 58. This block is 2 KB for twenty drivers.
+
+        The host still applies the mask, which is the window's load-bearing
+        invariant. What changes is which clock it reads.
+
+        The revision compares on inequality for the same reason `get_bulk`'s
+        does: a rewind CLOSES sectors, and `rev > since_rev` would withhold
+        exactly that - leaving a sector on screen that the car has not yet
+        reached this time round.
+        """
+        payload = self._client.latest
+        if payload is None:
+            return None
+        arcade = payload.get("arcade") or {}
+        session = self._session_for(arcade)
+        if session is None:
+            return None
+
+        reveal = self._reveal_map(arcade)
+        clock = float(arcade.get("t") or 0.0)
+        global_t_min = float(arcade.get("global_t_min") or 0.0)
+        drivers = session.live_lap(reveal, clock, global_t_min)
+
+        # The signature is what the SCREEN shows, so the revision advances
+        # when a sector opens or closes and stays put through the hundreds of
+        # ticks in between. Keying it on the clock instead would bump ten
+        # times a second and re-send an identical payload.
+        signature = {
+            code: tuple(v is not None for v in row.values()) for code, row in drivers.items()
+        }
+        if signature != self._live_signature:
+            self._live_signature = signature
+            self._live_rev += 1
+        if self._live_rev == since_rev:
+            return None
+        return {"rev": self._live_rev, "drivers": drivers}
+
+    @staticmethod
+    def _reveal_map(arcade: dict) -> dict[str, int]:
+        """Laps completed per driver, which is what both readers mask on."""
+        return {
+            code: int(state.get("laps_completed") or 0)
+            for code, state in (arcade.get("drivers") or {}).items()
+        }
+
+    def _session_for(self, arcade: dict) -> SessionLaps | None:
+        """The loaded race for this tick, or None when it is not on disk.
+
+        Cached on (year, location) so pointing the arcade at another race
+        replaces the laps instead of serving the previous one's - the
+        stale-state class #904 already paid for once on the AGENTS history.
+        """
+        year, location = arcade.get("year"), arcade.get("location")
+        if not isinstance(year, int) or not isinstance(location, str):
+            return None
+        if self._session_key != (year, location):
+            self._session_key = (year, location)
+            self._session = SessionLaps.load(get_data_root(), year, location)
+        return self._session
+
     def _masked_view(self, arcade: dict, reveal: dict[str, int]) -> dict:
         """Load the race once, then slice it; or say it is not on disk.
 
@@ -197,15 +267,13 @@ class PitwallHost:
         #904 already paid for once on the AGENTS history.
         """
         year, location = arcade.get("year"), arcade.get("location")
-        if not isinstance(year, int) or not isinstance(location, str):
-            return unavailable(year if isinstance(year, int) else None, None)
-
-        if self._session_key != (year, location):
-            self._session_key = (year, location)
-            self._session = SessionLaps.load(get_data_root(), year, location)
-        if self._session is None:
-            return unavailable(year, location)
-        return self._session.masked_view(reveal, float(arcade.get("global_t_min") or 0.0))
+        session = self._session_for(arcade)
+        if session is None:
+            return unavailable(
+                year if isinstance(year, int) else None,
+                location if isinstance(location, str) else None,
+            )
+        return session.masked_view(reveal, float(arcade.get("global_t_min") or 0.0))
 
     def release_window(self) -> int:
         """Record that one window has closed; stop the client at the last one.

--- a/src/pitwall/session_data.py
+++ b/src/pitwall/session_data.py
@@ -52,6 +52,20 @@ logger = logging.getLogger(__name__)
 # the finish line and ST is the longest straight.
 _SPEED_COLUMNS = {"SpeedI1": "v1", "SpeedI2": "v2", "SpeedFL": "vfl", "SpeedST": "vst"}
 _SECTOR_COLUMNS = {"Sector1Time": "s1", "Sector2Time": "s2", "Sector3Time": "s3"}
+# When each sector was CROSSED, on FastF1's SessionTime. This is what lets a
+# sector be revealed at the instant it happened rather than a whole lap later,
+# which is the difference between a timing tower and a table of the previous
+# lap. Same clock as the tick's `t + global_t_min`.
+_SECTOR_AT_COLUMNS = {
+    "Sector1SessionTime": "s1_at",
+    "Sector2SessionTime": "s2_at",
+    "Sector3SessionTime": "s3_at",
+}
+
+# The sector, its time, its trap speed, and the moment it opened. The speed is
+# measured AT the trap, so it becomes known with its sector and not before.
+_LIVE_SECTORS = (("s1", "v1", "s1_at"), ("s2", "v2", "s2_at"), ("s3", "vfl", "s3_at"))
+_SECTOR_AT_KEYS = frozenset(_SECTOR_AT_COLUMNS.values())
 
 # Fields the bests panel ranks. `s1` is in here even though lap 1 never has
 # one: the min simply ignores the Nones, which is why they must be None and
@@ -128,6 +142,7 @@ def _lap_row(record: dict[str, Any]) -> dict[str, Any]:
         "pb": record.get("IsPersonalBest") is True,
     }
     row.update({key: _seconds(record.get(column)) for column, key in _SECTOR_COLUMNS.items()})
+    row.update({key: _seconds(record.get(column)) for column, key in _SECTOR_AT_COLUMNS.items()})
     row.update({key: _none_if_nan(record.get(column)) for column, key in _SPEED_COLUMNS.items()})
     if row["position"] is not None:
         row["position"] = int(row["position"])
@@ -275,6 +290,71 @@ class SessionLaps:
         }
         return result
 
+    def live_lap(
+        self, laps_completed: dict[str, int], clock_s: float, global_t_min: float = 0.0
+    ) -> dict[str, Any]:
+        """The lap each driver is ON, with only the sectors he has already crossed.
+
+        The tower's three sector columns show the lap IN PROGRESS, blank at
+        the line and filling as the car crosses each sector - which is what a
+        timing tower does and what showing the last COMPLETED lap for a whole
+        lap afterwards does not.
+
+        **This does not weaken the reveal rule; it applies it at a finer
+        coordinate.** `masked_view`'s `L <= laps_completed` is the rule for
+        lap ROWS, which only exist once the lap is over. A sector has its own
+        timestamp, so its own moment: reveal it iff the replay clock has
+        passed `SectorNSessionTime`. Nothing here is visible before it
+        happened, and a rewind closes the sectors again because the clock
+        goes back with it.
+
+        It is a separate reader rather than part of `masked_view` because the
+        two are masked by different things at different rates. A sector opens
+        somewhere in the field every 2.22 s (measured: 2,744 crossings over
+        6,103 s of Melbourne 2025), and re-sending the whole revealed race at
+        that cadence is ~154 KB/s against the tick's own ~58. This block is
+        2 KB for twenty drivers.
+        """
+        session_clock = clock_s + global_t_min
+        drivers: dict[str, Any] = {}
+        for code, rows in self._by_driver.items():
+            in_progress = self._row_for_lap(rows, laps_completed.get(code, 0) + 1)
+            if in_progress is None:
+                continue
+            drivers[code] = self._revealed_sectors(in_progress, session_clock)
+        return drivers
+
+    @staticmethod
+    def _row_for_lap(rows: list[dict[str, Any]], lap: int) -> dict[str, Any] | None:
+        """The driver's row for one lap, or None when he has no such lap.
+
+        None covers three real cases and they all mean the same thing to the
+        caller: a car that retired has no further row, a finisher has no lap
+        past the flag, and a car whose only rows are `FastF1Generated` has
+        nothing with times in it.
+        """
+        for row in rows:
+            if row["lap"] == lap:
+                return None if row["generated"] else row
+        return None
+
+    @staticmethod
+    def _revealed_sectors(row: dict[str, Any], session_clock: float) -> dict[str, Any]:
+        """One in-progress lap, with the sectors the clock has not reached left out.
+
+        `None` for a sector that has not happened yet, exactly as for one that
+        has no data - the renderer draws a dash either way, and inventing a
+        distinction the tower cannot use would only be a third state for every
+        consumer to carry.
+        """
+        live: dict[str, Any] = {"lap": row["lap"]}
+        for sector, speed, crossed_at in _LIVE_SECTORS:
+            moment = row[crossed_at]
+            open_now = moment is not None and moment <= session_clock
+            live[sector] = row[sector] if open_now else None
+            live[speed] = row[speed] if open_now else None
+        return live
+
     @staticmethod
     def _driver_view(
         revealed: list[dict[str, Any]], revealed_to: int, global_t_min: float
@@ -291,7 +371,17 @@ class SessionLaps:
         holds real rows only - a generated row's `Time` stamp sorts before
         the entire field and would invert the interval it takes part in.
         """
-        laps = [{**row, "t": SessionLaps._on_wire_clock(row, global_t_min)} for row in revealed]
+        # The sector crossing instants stay OFF this payload. They exist for
+        # `live_lap`, which reveals the lap in progress, and putting three
+        # more floats on each of 927 rows would grow the whole-race worst case
+        # for a field the tower never reads here.
+        laps = [
+            {
+                **{key: value for key, value in row.items() if key not in _SECTOR_AT_KEYS},
+                "t": SessionLaps._on_wire_clock(row, global_t_min),
+            }
+            for row in revealed
+        ]
         crossings = {
             row["lap"]: row["t"] for row in laps if not row["generated"] and row["t"] is not None
         }

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -180,6 +180,7 @@ await page.addInitScript((payload) => {
         return window.__ticks[window.__cursor];
       },
       get_bulk: async () => null,
+      get_live_lap: async () => null,
       get_connection: async () => "Connected",
     },
   };
@@ -469,6 +470,7 @@ await soloPage.addInitScript((payload) => {
     api: {
       get_tick: async (sinceSeq) => (sinceSeq === payload.seq ? null : payload),
       get_bulk: async () => null,
+      get_live_lap: async () => null,
       get_connection: async () => "Connected",
     },
   };
@@ -626,6 +628,7 @@ await stillPage.addInitScript((payload) => {
       // and the check below would pass against the defect it exists for.
       get_tick: async () => ({ ...structuredClone(payload), seq: ++seq }),
       get_bulk: async () => null,
+      get_live_lap: async () => null,
       get_connection: async () => "Connected",
     },
   };
@@ -660,6 +663,8 @@ async function provisionalChips(field) {
       api: {
         get_tick: async (sinceSeq) => (sinceSeq === payload.seq ? null : payload),
         get_bulk: async () => null,
+        get_live_lap: async () => null,
+      get_live_lap: async () => null,
         get_connection: async () => "Connected",
       },
     };
@@ -808,20 +813,46 @@ function towerBulk() {
   return { rev: 1, available: true, race: { year: 2025, location: "Melbourne", total_laps: 57 }, drivers };
 }
 
+/**
+ * The lap in progress: S1 crossed, S2 and S3 not yet.
+ *
+ * The bulk's completed row carries an S2 and an S3 for every driver, so a
+ * tower still reading the last COMPLETED lap would print them - which is the
+ * defect this channel exists to fix, and the reason the checks below look for
+ * dashes in columns the bulk could happily fill.
+ */
+function towerLive() {
+  const drivers = {};
+  TOWER_ORDER.filter((code) => !RETIRED_CODES.includes(code)).forEach((code, index) => {
+    const crafted = TOWER_BESTS[code];
+    drivers[code] = {
+      lap: code === "LAW" ? 23 : 24,
+      s1: crafted ? crafted.lastS1 : 31 + index * 0.1,
+      s2: null,
+      s3: null,
+      v1: 301,
+      v2: null,
+      vfl: null,
+    };
+  });
+  return { rev: 1, drivers };
+}
+
 const towerCtx = await browser.newContext({ viewport: { width: 1485, height: 833 } });
 const towerPage = await towerCtx.newPage();
 towerPage.on("pageerror", (error) => failures.push(`pageerror(tower): ${error.message}`));
 await towerPage.addInitScript(
-  ([payload, bulk]) => {
+  ([payload, bulk, live]) => {
     window.pywebview = {
       api: {
         get_tick: async (sinceSeq) => (sinceSeq === payload.seq ? null : payload),
         get_bulk: async (sinceRev) => (sinceRev === bulk.rev ? null : bulk),
+        get_live_lap: async (sinceRev) => (sinceRev === live.rev ? null : live),
         get_connection: async () => "Connected",
       },
     };
   },
-  [tick(1, { drivers: towerField(), order: TOWER_ORDER }), towerBulk()],
+  [tick(1, { drivers: towerField(), order: TOWER_ORDER }), towerBulk(), towerLive()],
 );
 await towerPage.goto(url, { waitUntil: "domcontentloaded" });
 await towerPage.waitForSelector(".tower-row", { timeout: 5000 });
@@ -919,6 +950,22 @@ check((await tone(1)).includes("is-purple"), "the session's fastest sector is pu
 check((await tone(2)).includes("is-green"), "a driver's own best is green");
 check((await tone(3)).includes("is-yellow"), "slower than his own best is yellow");
 check((await tone(18)).includes("is-plain"), "a sector nobody has set is not coloured at all");
+
+// --- The sectors are the lap IN PROGRESS, not the last completed one ---------
+//
+// The bulk's completed row carries an S2 and an S3 for every driver here, so a
+// tower reading it would print them. The live channel has only S1 open, which
+// is what a car that has crossed one sector of the current lap actually knows.
+check((await cell(1, 7)) === "—", "S2 is blank until the car crosses it");
+check((await cell(1, 8)) === "—", "and so is S3");
+check(
+  (await cell(1, 9)) === "1:25.744",
+  "while LAST still shows the lap the car completed, which is what that column means",
+);
+check(
+  (await cell(18, 6)) === "—",
+  "a retired car has no lap in progress, so its sectors are dashes and not its final ones",
+);
 
 // --- Band 2 right: the bests panel -------------------------------------------
 

--- a/src/pitwall/ui/src/features/data/DataWindow.tsx
+++ b/src/pitwall/ui/src/features/data/DataWindow.tsx
@@ -28,6 +28,7 @@ import { TimingTower } from "./TimingTower";
 import { TrackRing } from "./TrackRing";
 import { useBulk } from "../../lib/useBulk";
 import { useConnection } from "../../lib/useConnection";
+import { useLiveLap } from "../../lib/useLiveLap";
 import { useStatusText } from "../../lib/useStatusText";
 import { useTick } from "../../lib/useTick";
 
@@ -37,6 +38,7 @@ export function DataWindow() {
   const { tick, discontinuity, live } = useTick();
   const connection = useConnection();
   const bulk = useBulk();
+  const liveLap = useLiveLap();
   // Qt re-arms `showMessage(f"lap {lap} · live", 1500)` on every broadcast,
   // so the line stays up while streaming and clears 1.5 s after the producer
   // stops. `useStatusText` is keyed on the sequence for that reason.
@@ -50,7 +52,7 @@ export function DataWindow() {
         {live && tick ? (
           <div className="data-main">
             <div className="left-column">
-              <TimingTower arcade={tick.arcade} bulk={bulk} />
+              <TimingTower arcade={tick.arcade} bulk={bulk} live={liveLap} />
               <BestsPanel bulk={bulk} />
             </div>
             <div className="band4">

--- a/src/pitwall/ui/src/features/data/TimingTower.tsx
+++ b/src/pitwall/ui/src/features/data/TimingTower.tsx
@@ -24,7 +24,7 @@
  * once, rather than each of the forty cells repeating it.
  */
 
-import type { ArcadeState, Bulk, DriverLaps, LapRow } from "../../lib/bridge";
+import type { ArcadeState, Bulk, DriverLaps, LapRow, LiveLap } from "../../lib/bridge";
 import { driverStatus, type DriverStatus } from "../../lib/driverStatus";
 import { formatGapCell, gapCell } from "../../lib/gapCell";
 import { sessionBests, type BestField, type SessionBests } from "../../lib/sessionBests";
@@ -32,9 +32,10 @@ import { sessionBests, type BestField, type SessionBests } from "../../lib/sessi
 interface TimingTowerProps {
   arcade: ArcadeState;
   bulk: Bulk | null;
+  live: LiveLap | null;
 }
 
-export function TimingTower({ arcade, bulk }: TimingTowerProps) {
+export function TimingTower({ arcade, bulk, live }: TimingTowerProps) {
   const order = arcade.race_order;
   const leader = order[0];
   // The same reduction the bests panel ranks, from the same module. Two
@@ -78,6 +79,7 @@ export function TimingTower({ arcade, bulk }: TimingTowerProps) {
               leader={leader}
               arcade={arcade}
               bulk={bulk}
+              live={live}
               bests={bests}
             />
           ))}
@@ -95,10 +97,11 @@ interface TowerRowProps {
   leader: string;
   arcade: ArcadeState;
   bulk: Bulk | null;
+  live: LiveLap | null;
   bests: SessionBests;
 }
 
-function TowerRow({ code, position, front, leader, arcade, bulk, bests }: TowerRowProps) {
+function TowerRow({ code, position, front, leader, arcade, bulk, live, bests }: TowerRowProps) {
   const car = arcade.drivers[code];
   const status: DriverStatus = car ? driverStatus(car) : "out";
   const laps: DriverLaps | undefined = bulk?.drivers[code];
@@ -106,6 +109,10 @@ function TowerRow({ code, position, front, leader, arcade, bulk, bests }: TowerR
   // row - a car that never finished one - and then every number on it is
   // null, which is the honest rendering rather than an absent row.
   const last: LapRow | null = laps?.laps.length ? laps.laps[laps.laps.length - 1] : null;
+  // Absent for a car that has retired or taken the flag: it has no lap in
+  // progress, so its sector columns are dashes rather than the last lap it
+  // happened to drive.
+  const sectors = live?.drivers[code];
 
   const gap = front === null ? { kind: "leader" as const } : gapCell(leader, code, arcade, bulk);
   const interval = front === null ? null : gapCell(front, code, arcade, bulk);
@@ -119,20 +126,23 @@ function TowerRow({ code, position, front, leader, arcade, bulk, bests }: TowerR
       </td>
       <td className="col-gap">{formatGapCell(gap)}</td>
       <td className="col-gap">{interval === null ? "—" : formatGapCell(interval)}</td>
+      {/* The sectors are the lap IN PROGRESS - blank at the line, filling as
+       * the car crosses each. Every other column on this row is about the
+       * last COMPLETED lap, which is what LAST, ST, TYRE and STOPS mean. */}
       <SectorCell
-        time={last?.s1 ?? null}
-        speed={last?.v1 ?? null}
-        tone={sectorTone(last?.s1 ?? null, laps?.best.s1 ?? null, bests, "s1")}
+        time={sectors?.s1 ?? null}
+        speed={sectors?.v1 ?? null}
+        tone={sectorTone(sectors?.s1 ?? null, laps?.best.s1 ?? null, bests, "s1")}
       />
       <SectorCell
-        time={last?.s2 ?? null}
-        speed={last?.v2 ?? null}
-        tone={sectorTone(last?.s2 ?? null, laps?.best.s2 ?? null, bests, "s2")}
+        time={sectors?.s2 ?? null}
+        speed={sectors?.v2 ?? null}
+        tone={sectorTone(sectors?.s2 ?? null, laps?.best.s2 ?? null, bests, "s2")}
       />
       <SectorCell
-        time={last?.s3 ?? null}
-        speed={last?.vfl ?? null}
-        tone={sectorTone(last?.s3 ?? null, laps?.best.s3 ?? null, bests, "s3")}
+        time={sectors?.s3 ?? null}
+        speed={sectors?.vfl ?? null}
+        tone={sectorTone(sectors?.s3 ?? null, laps?.best.s3 ?? null, bests, "s3")}
       />
       <td className={`col-last ${last?.deleted ? "is-deleted" : ""}`}>{lastCell(status, last)}</td>
       <td className="col-st">{last?.vst === null || last?.vst === undefined ? "—" : last.vst}</td>

--- a/src/pitwall/ui/src/lib/bridge.ts
+++ b/src/pitwall/ui/src/lib/bridge.ts
@@ -154,6 +154,31 @@ export interface Bulk {
   drivers: Record<string, DriverLaps>;
 }
 
+/**
+ * The lap a driver is ON, with only the sectors he has already crossed.
+ *
+ * Every field is null until the replay clock passes that sector's own
+ * crossing time, so the tower's columns blank at the line and fill as the car
+ * goes round - the way a timing tower does, rather than holding the previous
+ * lap for the whole of the next one.
+ */
+export interface LiveSectors {
+  lap: number;
+  s1: number | null;
+  s2: number | null;
+  s3: number | null;
+  v1: number | null;
+  v2: number | null;
+  vfl: number | null;
+}
+
+export interface LiveLap {
+  /** Advances when a sector OPENS or CLOSES. A rewind closes them, and bumps it. */
+  rev: number;
+  /** Drivers with a lap in progress. A retired or finished car is absent, not empty. */
+  drivers: Record<string, LiveSectors>;
+}
+
 interface PitwallApi {
   get_tick: (sinceSeq: number) => Promise<Tick | null>;
 }
@@ -250,6 +275,20 @@ export async function getBulk(sinceRev: number): Promise<Bulk | null> {
   if (api?.get_bulk) return api.get_bulk(sinceRev);
   if (IN_A_WINDOW) return null;
   return fetchJson<Bulk>("/api/bulk", sinceRev);
+}
+
+/**
+ * The lap in progress, or null when this caller's revision is current.
+ *
+ * Same inequality rule as `getBulk`, and here it is what makes a rewind
+ * CLOSE a sector again: `>` would keep a cell filled with a time the car has
+ * not re-driven yet.
+ */
+export async function getLiveLap(sinceRev: number): Promise<LiveLap | null> {
+  const api = window.pywebview?.api as { get_live_lap?: (r: number) => Promise<LiveLap | null> };
+  if (api?.get_live_lap) return api.get_live_lap(sinceRev);
+  if (IN_A_WINDOW) return null;
+  return fetchJson<LiveLap>("/api/live", sinceRev);
 }
 
 /**

--- a/src/pitwall/ui/src/lib/useLiveLap.ts
+++ b/src/pitwall/ui/src/lib/useLiveLap.ts
@@ -1,0 +1,54 @@
+/**
+ * The lap in progress, polled fast enough that a sector appears when it happens.
+ *
+ * The third channel, and it exists because the other two are masked by
+ * different things. `useBulk` is masked by completed laps and changes about
+ * once every four and a half seconds; this is masked by the CLOCK, and a
+ * sector opens somewhere in the field every 2.22 seconds. Widening the bulk
+ * to carry it would re-send up to 342 KB at that cadence; this payload is
+ * 2 KB for the whole field.
+ *
+ * Two hundred milliseconds, so a sector lands within a fifth of a second of
+ * the car crossing it. The host answers null on every poll in between, which
+ * is almost all of them.
+ *
+ * Nothing accumulates, and here that is not an optimisation: a rewind CLOSES
+ * sectors, and a cache that only ever filled cells would leave a time on
+ * screen for track the car has yet to re-drive.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { getLiveLap, whenBridgeReady, type LiveLap } from "./bridge";
+
+const POLL_INTERVAL_MS = 200;
+
+export function useLiveLap(): LiveLap | null {
+  const [live, setLive] = useState<LiveLap | null>(null);
+  const revision = useRef(-1);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: number | undefined;
+
+    const poll = async () => {
+      const next = await getLiveLap(revision.current);
+      if (cancelled) return;
+      if (next) {
+        revision.current = next.rev;
+        setLive(next);
+      }
+      timer = window.setTimeout(poll, POLL_INTERVAL_MS);
+    };
+
+    whenBridgeReady().then(() => {
+      if (!cancelled) poll();
+    });
+
+    return () => {
+      cancelled = true;
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
+  }, []);
+
+  return live;
+}

--- a/src/pitwall/webserver.py
+++ b/src/pitwall/webserver.py
@@ -66,6 +66,8 @@ class TickSource(Protocol):
 
     def get_bulk(self, since_rev: int = -1) -> dict[str, Any] | None: ...
 
+    def get_live_lap(self, since_rev: int = -1) -> dict[str, Any] | None: ...
+
     def get_connection(self) -> str: ...
 
 
@@ -74,6 +76,7 @@ _READERS = {
     "/api/tick": "get_tick",
     "/api/agents": "get_agents_view",
     "/api/bulk": "get_bulk",
+    "/api/live": "get_live_lap",
 }
 
 # Readers with no revision at all. The connection label is a property of the

--- a/tests/surfaces/test_pitwall_session_data.py
+++ b/tests/surfaces/test_pitwall_session_data.py
@@ -418,3 +418,78 @@ def test_no_tick_means_no_bulk():
     host = PitwallHost(_FakeClient(None), window_count=1)
 
     assert host.get_bulk(-1) is None
+
+
+# --- The lap in progress: sectors revealed at the moment they were crossed ----
+
+
+def test_a_sector_is_closed_until_the_clock_reaches_its_crossing():
+    """The reveal rule at a finer coordinate, on the real race.
+
+    `masked_view`'s `L <= laps_completed` is the rule for lap ROWS, which only
+    exist once the lap is over. A sector carries its own `SectorNSessionTime`,
+    so it has its own moment - and revealing it then is not look-ahead, it is
+    the present.
+
+    NOR's lap 23 at Melbourne crossed S1 at SessionTime 6689.966. One second
+    before that the cell must be empty; a tenth of a second after it must hold
+    31.865 and the 266 km/h measured at that trap.
+    """
+    session = _session_or_skip()
+    global_t_min = 4260.355
+    row = next(r for r in session._by_driver["NOR"] if r["lap"] == 23)
+
+    before = session.live_lap({"NOR": 22}, row["s1_at"] - 1 - global_t_min, global_t_min)["NOR"]
+    after = session.live_lap({"NOR": 22}, row["s1_at"] + 0.1 - global_t_min, global_t_min)["NOR"]
+
+    assert before["lap"] == 23 and after["lap"] == 23, "both probes are on the lap in progress"
+    assert before["s1"] is None and before["v1"] is None, "nothing before the car got there"
+    assert after["s1"] == row["s1"], "and the real sector time the instant it did"
+    assert after["v1"] == row["v1"], "with the speed measured at that trap"
+    assert after["s2"] is None, "the sectors after it stay shut"
+
+
+def test_a_rewind_shuts_the_sectors_again():
+    """The clock going back must CLOSE a cell, not leave it filled.
+
+    A cache that only ever fills would leave a time on screen for track the
+    car has yet to re-drive - the same leak as a lap-row reveal that never
+    un-reveals, one coordinate down.
+    """
+    session = _session_or_skip()
+    global_t_min = 4260.355
+    row = next(r for r in session._by_driver["NOR"] if r["lap"] == 23)
+
+    late = session.live_lap({"NOR": 22}, row["s3_at"] + 1 - global_t_min, global_t_min)["NOR"]
+    rewound = session.live_lap({"NOR": 22}, row["s1_at"] - 1 - global_t_min, global_t_min)["NOR"]
+
+    assert [late["s1"], late["s2"], late["s3"]] == [row["s1"], row["s2"], row["s3"]]
+    assert [rewound["s1"], rewound["s2"], rewound["s3"]] == [None, None, None]
+
+
+def test_a_car_with_no_lap_in_progress_is_absent_rather_than_empty():
+    """Retired, finished, or never completed one - all three mean the same here.
+
+    SAI's only rows on this race are `FastF1Generated`, which carry no times
+    at all, so serving one as "the lap in progress" would put a row of nulls
+    on screen that looks like a car waiting to cross a sector it never will.
+    """
+    session = _session_or_skip()
+    live = session.live_lap({"SAI": 0, "NOR": 22}, 3000.0, 4260.355)
+
+    assert "SAI" not in live, "a generated-only driver has no lap in progress"
+    assert "NOR" in live, "and the fixture is not simply empty"
+
+
+def test_the_sector_crossing_instants_stay_off_the_bulk_payload():
+    """They exist for `live_lap`; the tower never reads them from a lap row.
+
+    Three more floats on each of 927 rows is a field nobody consumes riding on
+    the channel that already carries the whole race.
+    """
+    session = _session_or_skip()
+    view = session.masked_view(_all_revealed(session), 0.0)
+    row = view["drivers"]["NOR"]["laps"][0]
+
+    for key in ("s1_at", "s2_at", "s3_at"):
+        assert key not in row, f"{key} leaked onto the bulk payload"


### PR DESCRIPTION
Closes #929. Reported by Víctor on seeing the tower live.

The sector columns showed the last COMPLETED lap and held it through the whole of the next one:
at the line nothing changed, and then all three changed at once. A timing tower blanks them at the
line and fills S1, then S2, then S3.

## The data was already on disk

`laps.parquet` carries `Sector{1,2,3}SessionTime` - the instant each sector was crossed, on the
same clock band 1 already renders:

```
NOR, lap 23
  Sector1Time  0:00:31.865     Sector1SessionTime  1:51:29.966
  Sector2Time  0:00:18.917     Sector2SessionTime  1:51:48.883
  Sector3Time  0:00:39.140     Sector3SessionTime  1:52:28.023
```

**This does not weaken the reveal rule; it applies it at a finer coordinate.** `masked_view`'s
`L <= laps_completed` is the rule for lap ROWS, which only exist once the lap is over. A sector
has its own timestamp, so its own moment - and nothing here is visible before it happened.

## Where the mask lives, measured rather than assumed

| option | cost |
|---|---|
| clock-driven mask over the whole bulk | a sector opens every **2.22 s** across the field (2,744 crossings over 6,103 s) → up to 342 KB re-sent at that cadence, **~154 KB/s** against the tick's own ~58 |
| a separate reader, still host-masked | **2,007 bytes** for twenty drivers |

So a third channel. **The host still applies the mask** - the window's load-bearing invariant is
untouched; what changes is which clock it reads. The revision is keyed on WHICH sectors are open,
so it advances when the screen changes and not ten times a second.

## Verification

**The real path, executed** - producer → socket → host → HTTP, sampled every 8 s while the replay
ran:

```
rev=  6  lap= 23  NOR lap 23  open=none          s1=None    v1=None
rev= 11  lap= 23  NOR lap 23  open=['s1']        s1=31.865  v1=266.0
rev= 21  lap= 23  NOR lap 23  open=['s1','s2']   s1=31.865  v1=266.0
```

**And on the real window**, at lap 24: NOR and PIA have crossed S1 (31.717, 31.595) with S2 and S3
still dashed; VER, RUS, LEC, TSU, ALB, HAM and GAS have not reached S1 at all; the cars further
round already show S1 and S2. That staggered picture is the thing a real tower shows and a
last-completed-lap table cannot.

PIA's live S1 renders **purple** at 31.595 while the bests panel still lists 31.622 - a live
sector beats the session best on screen immediately and joins the ranking only when the lap
completes, which is what a broadcast does.

**Guards, watched RED.** Dropping the clock comparison (`open_now = moment is not None`) fails
both `test_a_sector_is_closed_until_the_clock_reaches_its_crossing` and
`test_a_rewind_shuts_the_sectors_again`. Four more Python guards cover the absent-driver case and
the crossing instants staying off the bulk payload; `smoke-data` gains four effect checks, of
which the sharpest is that S2 and S3 render dashes **while the bulk's completed row could happily
fill them**.

`tests/surfaces` 210 passed · `smoke-data` 87 · `smoke-agents` 18 · `tsc` clean · ruff clean.

## One consequence worth naming

`get_bulk` and `get_live_lap` now share one reveal map and one session loader. They were about
to be two copies of "which race is this and how many laps has each driver done", which is the
defect this repo names most often.
