### PR TITLE
docs(pitwall): record what sprint 5 measured, and what it deliberately left open

### DIFF
--- a/docs/pages/pitwall.md
+++ b/docs/pages/pitwall.md
@@ -54,14 +54,36 @@ so rather than opening blank.
 
 ### PITWALL · DATA
 
-Four bands, delivered one per sprint. Band 4 is the one that exists today: the
-own car's lap as **four locked-axis traces against distance** — Δ Time, Speed,
-Brake, Throttle — ported field by field from the Qt telemetry panel, plus a
-shared vertical cursor marking where the car is on the lap, and a schematic
-**track ring** placing the whole field by lap fraction.
+A status strip across the top, then two columns: the **all-cars world** on the
+left and the **own-car world** on the right. That is the zoning a real pit wall
+uses — the two live on physically different surfaces there — and it is also the
+only arrangement that fits, because four stacked bands need 908 px of a window
+that has 790.
 
-Two details that are not cosmetic:
+**Left: the timing tower**, twenty rows of
+`P · # · DRV · GAP · INT · S1 · S2 · S3 · LAST · ST · TYRE · STOPS`, with the
+sector colour code every timing screen uses — purple for fastest of the session,
+green for a driver's own best, amber for slower than his own. Under it, the
+**bests**: S1, S2, S3 and Lap ranked across the field with their percentage off
+the leader, and the theoretical lap those three sectors recombine into.
 
+**Right: the own car's lap** as four locked-axis traces against distance — Δ
+Time, Speed, Brake, Throttle — ported field by field from the Qt telemetry
+panel, plus a shared vertical cursor marking where the car is on the lap, and a
+schematic **track ring** placing the whole field by lap fraction.
+
+Four details that are not cosmetic:
+
+- **The sector columns are the lap in progress.** They blank at the line and
+  fill as the car crosses each sector, because `laps.parquet` records the
+  instant of every crossing. A sector faster than the session's best paints
+  purple immediately and joins the bests ranking only when the lap completes,
+  which is what a broadcast does.
+- **The GAP and INT columns are quantised to the line**, and the header says so
+  with an `(L)`. They are the difference of two crossings, taken from the
+  official timing table rather than from the replay's own interpolation — which
+  means they can differ from the arcade's leaderboard beside them by a few
+  hundredths, and PITWALL is the one that matches official timing.
 - The rival's traces carry a **BROADCAST** tag. Rival car data is real and
   public, but it is the coarse low-rate channel every team sees, not
   pit-wall-grade telemetry. The Qt window rendered it unlabelled.
@@ -70,6 +92,12 @@ Two details that are not cosmetic:
   median 1.3° and up to 24° (on a pit lap) from its true circuit position. It
   answers *where is everyone* — the pyglet window next to it answers *where
   exactly*.
+
+One consequence of taking the order from the replay and the seconds from the
+timing table: they disagree by one place at about 0.7 % of line crossings, both
+times within a tenth of a second of each other. When they do, the interval cell
+shows a dash rather than a negative number. It is two measurements of the same
+moment, not an error in either.
 
 ### PITWALL · AGENTS
 

--- a/documents/research/PITWALL_DELIVERY_PLAN.md
+++ b/documents/research/PITWALL_DELIVERY_PLAN.md
@@ -267,6 +267,12 @@ Two rules that must be written into the code, not assumed:
   lap, where no classification exists yet" - and the wire publishes it anyway. **Band 1 must
   render the tower as provisional until `laps_completed >= 1` for every driver**, exactly as a
   broadcast timing tower does.
+  ⚠️ **"Every driver" had to become "every driver still IN the race", and the real race is what
+  said so.** Read literally the rule never switches off on Melbourne 2025: SAI, DOO and HAD
+  crashed on lap 1, so their `laps_completed` stays 0 for the whole afternoon. Measured against
+  the live wire at lap 23 - three of twenty drivers under one lap, and all three OUT. A chip that
+  is permanently lit marks nothing. The test is over the cars that can still contribute a
+  classification, which a stopped one never will (#922).
 - **A rewind UN-reveals.** `laps_completed` falls when the clock goes back, so a lap that was
   open must close again; a reveal cache keyed only on "seen once" leaks the whole future after
   one seek to the end.
@@ -288,8 +294,56 @@ Two rules that must be written into the code, not assumed:
   removed it). The lap-quantised intent survives both.
   A precise-looking wrong number on a fidelity surface is the P3 A2 defect class.
 
-**Sprint 6, band 3.** The Run Timeline heat grid (drivers as columns, laps as rows, purple / green /
-yellow / red, `IN PIT` and `OUT` cells) with Race Trace as a tab of the same panel.
+> ✅ **SPRINT 5 SHIPPED 2026-08-13** (#922, #924, #926, #928, #930), and three things about it are
+> worth carrying rather than rediscovering.
+>
+> **The four bands are two COLUMNS, not four rows.** The window's real client area is 1485 x 833
+> logical (measured DPI-aware on the open window, not the 1500 x 950 `WindowSpec` asks for), which
+> leaves 790 px for bands. Band 1 (29) + a full 20-row tower (439) + band 4's floor (420) + gaps is
+> **908**, over by 118 with band 3 still at zero, on the largest screen in the fleet. So: band 1
+> full width on top, then a 630 px left column (tower over bests) and a right column holding band
+> 4. That is also the zoning a real wall uses - the all-cars world and the own-car world sit on
+> physically different surfaces. Budget: `~/.claude/plans/pitwall-sprint5/band-height-budget.md`.
+>
+> **The SECTOR columns are the lap IN PROGRESS, and that is a second reveal coordinate.**
+> `laps.parquet` carries `Sector{1,2,3}SessionTime`, so a sector is revealed at the instant it was
+> crossed and the columns blank at the line and fill as the car goes round. It does not weaken the
+> rule above: `L <= laps_completed` is the rule for lap ROWS, which only exist once the lap is
+> over. It is a separate reader because a sector opens somewhere in the field every **2.22 s**, and
+> a clock-driven mask over the whole bulk would re-send up to 342 KB at that cadence (#930).
+>
+> **The wire's order and the parquet's clock disagree at about 0.7 % of crossings, by one place.**
+> Seen live on the tower: P11 read `+45.83s` above P12's `+42.79s`, and P12's INT rendered a dash
+> because the sign guard refused a negative interval. The tower renders the WIRE order because
+> only the wire can order mid-lap; the seconds come from the parquet because it is the official
+> clock. Both are right, they are just different measurements. **Do not file it as a bug.**
+
+**Sprint 6, band 3.** The Run Timeline heat grid (purple / green / yellow / red, `IN PIT` and `OUT`
+cells) with Race Trace as a tab of the same panel.
+
+> ⚠️ **ITS ORIENTATION IS DELIBERATELY UNDECIDED, and sprint 6 measures before it draws.**
+> The RaceX client puts one COLUMN per driver and one ROW per lap, and the research notes it
+> "occupies more screen area than anything else in the photographs". The band-height gate
+> recommended TRANSPOSING it - drivers as rows, laps as columns - but that recommendation was
+> derived against the STACKED band model and may not survive the column one: the right column is
+> 751 px tall, and the real orientation needs `24 (tabs) + 18 (header) + 57 x 12 = 726`.
+>
+> The trade, so sprint 6 starts from it rather than from a preference:
+>
+> | | real orientation (drivers as columns) | transposed (the gate's proposal) |
+> |---|---|---|
+> | height | 57 lap-rows x 12 px = 684 + chrome | 20 driver-rows x 20 px = 440 |
+> | width per cell | 835 / 20 = **41.7 px** - a lap time FITS at 9 px | 835 / 57 = **14.6 px** - colour only, no number |
+> | cost | the ring is hidden while this tab is open | the cell loses the number the real client writes in it |
+>
+> The 12 px row is arithmetic on the height gate's own constants and is **NOT measured** - what it
+> measured was 19-20 px for the TOWER's twelve-column row. Measure it first.
+
+**Sprint 5's own deferred item, filed rather than improvised:** #931, sub-lap gaps from
+`intervals.parquet`, whose per-driver sample cadence is a measured **4.27 s median**. It is blocked
+on a time anchor (its `date` is UTC; every clock here is SessionTime, so it needs FastF1's
+`t0_date` - the same shape as #842) and on the decision that it would put a THIRD clock on one
+column, covering 19 drivers of 20.
 
 **Sprint 4, band 4 — SHIPPED 2026-08-10** (#897, #898). Own-car traces stacked on one x axis with
 a shared vertical cursor, pinned rival overlaid and labelled broadcast tier, and the ring.


### PR DESCRIPTION
Three corrections to the delivery plan and a rewrite of the DATA window's public page.

## The delivery plan

**The provisional rule was wrong as written.** It said *until `laps_completed >= 1` for every
driver*, and read literally it never switches off on the race this window is developed against:
SAI, DOO and HAD crashed on lap 1 and stay at zero all afternoon. Measured on the live wire at lap
23 - three of twenty under one lap, all three OUT. It is the cars still **in** the race.

**The four bands are two COLUMNS**, with the arithmetic that forced it recorded: the window's real
client area is 1485 x 833, which leaves 790 px, and band 1 + a full tower + band 4's floor is 908.

**Band 3's orientation is DELIBERATELY undecided**, and the trade is written out rather than
resolved. The height gate recommended transposing it, but that recommendation was derived against
the STACKED band model; in the column model the real orientation may well fit, and transposing
costs the cell the lap time the real client writes inside it. The 12 px row that decides it is
arithmetic on the gate's own constants and **not a measurement** - what it measured was 19-20 px
for the tower's twelve-column row. Sprint 6 measures before it draws.

**And the ±1 disagreement is documented so nobody files it as a bug.** The wire's order and the
parquet's clock differ by one place at about 0.7 % of crossings; seen live on the tower, P11 read
`+45.83s` above P12's `+42.79s` and P12's interval rendered a dash because the sign guard
refused a negative number. Two measurements of one moment.

Plus a pointer to #931 (sub-lap gaps), filed with its measured cadence and its two blockers rather
than improvised into this sprint.

## The docs page

It described a window with one band in it. It now describes the one that exists: the two-column
zoning and why it matches a real wall, the tower's row, the bests, and the two things a reader
would otherwise mis-read - that the sector columns are the lap **in progress**, and that the gap
columns are quantised to the line and say so.

`tests/surfaces/test_docs_site_links.py` 4 passed.