### PR TITLE
fix(pitwall): make the tower's sector cells roll, and stop the live revision missing a rewind

### DIFF
--- a/src/pitwall/host.py
+++ b/src/pitwall/host.py
@@ -54,12 +54,14 @@ class PitwallHost:
         # answer depend on whether the AGENTS window had polled: with only the
         # DATA window open, a producer that died read "Connecting..." forever.
         self._ever_connected = False
-        # The BULK channel's state. `_bulk_reveal` is the last map served, so
-        # the revision can advance on a rewind as readily as on a completed
-        # lap; `_session_key` is what makes pointing the arcade at another
-        # race replace the loaded laps instead of serving the previous one's.
+        # The BULK channel's state. `_bulk_signature` is (year, location,
+        # reveal map) - everything the payload is a function of - so the
+        # revision advances on a rewind as readily as on a completed lap, and
+        # cannot miss a race switch. `_session_key` is what makes pointing the
+        # arcade at another race replace the loaded laps rather than serve the
+        # previous one's.
         self._bulk_rev = 0
-        self._bulk_reveal: dict[str, int] = {}
+        self._bulk_signature: tuple | None = None
         self._session: SessionLaps | None = None
         self._session_key: tuple[int, str] | None = None
         # The LIVE channel's state, masked by the clock rather than by
@@ -182,8 +184,16 @@ class PitwallHost:
             return None
         arcade = payload.get("arcade") or {}
         reveal = self._reveal_map(arcade)
-        if reveal != self._bulk_reveal:
-            self._bulk_reveal = reveal
+        # The RACE is part of the signature, not only the reveal map. The map
+        # alone does not determine this payload: a race switch whose first
+        # observed tick carried the previous race's per-driver counters would
+        # serve the old table as current. Unreachable in practice - a new
+        # replay's first tick is an all-zero map - but it is the structural
+        # rule #934 just cost, one channel over: a signature that does not
+        # determine the payload is not a signature.
+        signature = (arcade.get("year"), arcade.get("location"), reveal)
+        if signature != self._bulk_signature:
+            self._bulk_signature = signature
             self._bulk_rev += 1
         if self._bulk_rev == since_rev:
             return None
@@ -216,7 +226,15 @@ class PitwallHost:
         arcade = payload.get("arcade") or {}
         session = self._session_for(arcade)
         if session is None:
-            return None
+            # The twin `get_bulk` has always had this branch and this one did
+            # not. Plain None means "keep what you have", so pointing the
+            # arcade at a race with no parquet left the PREVIOUS race's sector
+            # times, flags and colours on the new race's rows indefinitely,
+            # beside a table that had correctly gone to `available=False`.
+            # An empty block once is the honest render: the cells fall to
+            # dashes and stay there. `since_rev` goes through so it is served
+            # ONCE and not re-sent on every poll of a race that has no laps.
+            return self._serve_live({}, since_rev)
 
         reveal = self._reveal_map(arcade)
         clock = float(arcade.get("t") or 0.0)
@@ -241,6 +259,10 @@ class PitwallHost:
         # Comparing the dict itself still leaves the revision still through
         # the hundreds of ticks between two crossings, which is the whole
         # point of having one.
+        return self._serve_live(drivers, since_rev)
+
+    def _serve_live(self, drivers: dict, since_rev: int = -1) -> dict | None:
+        """Advance the revision when the block changed, then answer the caller."""
         if drivers != self._live_view:
             self._live_view = drivers
             self._live_rev += 1

--- a/src/pitwall/host.py
+++ b/src/pitwall/host.py
@@ -63,10 +63,12 @@ class PitwallHost:
         self._session: SessionLaps | None = None
         self._session_key: tuple[int, str] | None = None
         # The LIVE channel's state, masked by the clock rather than by
-        # completed laps. Its signature is which sectors are open, so the
-        # revision moves when the screen changes and not ten times a second.
+        # completed laps. `_live_view` is the last block SERVED, so the
+        # revision moves exactly when the screen would change and not ten
+        # times a second - and it cannot miss a change, which a hash of the
+        # block's shape could and did (#934).
         self._live_rev = 0
-        self._live_signature: dict[str, tuple[bool, ...]] = {}
+        self._live_view: dict[str, dict] = {}
 
     def start(self) -> None:
         self._client.start()
@@ -221,15 +223,26 @@ class PitwallHost:
         global_t_min = float(arcade.get("global_t_min") or 0.0)
         drivers = session.live_lap(reveal, clock, global_t_min)
 
-        # The signature is what the SCREEN shows, so the revision advances
-        # when a sector opens or closes and stays put through the hundreds of
-        # ticks in between. Keying it on the clock instead would bump ten
-        # times a second and re-send an identical payload.
-        signature = {
-            code: tuple(v is not None for v in row.values()) for code, row in drivers.items()
-        }
-        if signature != self._live_signature:
-            self._live_signature = signature
+        # **The signature IS the payload, not a hash of its shape.** It used
+        # to be `tuple(v is not None for v in row.values())` - which cells are
+        # filled - and that is lossy in exactly the direction that leaks: a
+        # (driver, lap) pair determines the values, but the lap entered the
+        # signature only as a constant True. Measured on the real race, 3,667
+        # sampled pairs at least ten seconds apart share a presence pattern
+        # with completely different numbers, the worst of them a 28-minute
+        # rewind across the wet start - and across it `get_live_lap` answered
+        # None, so the client kept a dry-lap sector time on a screen whose
+        # clock said lap 2 (#934).
+        #
+        # `get_bulk` was immune because its signature is the reveal MAP, which
+        # is its full input state. A signature that does not determine the
+        # payload is not a signature.
+        #
+        # Comparing the dict itself still leaves the revision still through
+        # the hundreds of ticks between two crossings, which is the whole
+        # point of having one.
+        if drivers != self._live_view:
+            self._live_view = drivers
             self._live_rev += 1
         if self._live_rev == since_rev:
             return None

--- a/src/pitwall/session_data.py
+++ b/src/pitwall/session_data.py
@@ -322,7 +322,7 @@ class SessionLaps:
 
         **The first version of this served only the lap in progress, and it
         made the S3 column permanently empty.** S3's crossing IS the end of
-        the lap: measured over all 920 real rows of Melbourne 2025,
+        the lap: measured over the 920 real rows of Melbourne 2025 carrying both stamps,
         `Sector3SessionTime` lands a median 55 ms AFTER the lap's own crossing
         `Time` and after it on 94.1 % of laps. So S1 was visible for 60.3 s of
         its lap, S2 for 40.8 s, and S3 for -0.055 s. One of three columns
@@ -376,15 +376,35 @@ class SessionLaps:
         is what the renderer dims. It is not a third state for a missing
         value: a null sector is simply null and its flag is False.
 
-        The previous lap is only consulted for a sector this lap has not
-        reached yet. Nothing is served before its own crossing, in either lap.
+        **Both branches are gated on the clock, and the second one had to be
+        told so.** It first checked only that the previous lap HAD a stamp,
+        which made the sentence below false on the wire the window serves: the
+        arcade's crossing map increments before that lap's own
+        `Sector3SessionTime` on 837 of 921 laps (median 39 ms, max 0.463 s),
+        so the just-ended S3 went out before its own official moment. It leaked
+        nothing the bulk was not already revealing at the same tick, but a
+        guard that looks like the reveal rule and checks something else is
+        this repo's most expensive shape.
+
+        So: nothing is served before its own crossing, in either lap. The cost
+        is a cell that dashes for a median 39 ms after a line crossing, about
+        one replay frame.
+
+        A sector whose value exists but whose stamp does not - one driver-lap
+        on Melbourne 2025 - dashes rather than being carried, because there is
+        no moment to compare the clock against and the rule above is the one
+        that matters.
         """
         live: dict[str, Any] = {"lap": row["lap"]}
         for sector, speed, crossed_at in _LIVE_SECTORS:
             moment = row[crossed_at]
             if moment is not None and moment <= session_clock:
                 live[sector], live[speed], fresh = row[sector], row[speed], True
-            elif previous is not None and previous[crossed_at] is not None:
+            elif (
+                previous is not None
+                and previous[crossed_at] is not None
+                and previous[crossed_at] <= session_clock
+            ):
                 live[sector], live[speed], fresh = previous[sector], previous[speed], False
             else:
                 live[sector], live[speed], fresh = None, None, False

--- a/src/pitwall/session_data.py
+++ b/src/pitwall/session_data.py
@@ -313,35 +313,42 @@ class SessionLaps:
     def live_lap(
         self, laps_completed: dict[str, int], clock_s: float, global_t_min: float = 0.0
     ) -> dict[str, Any]:
-        """The lap each driver is ON, with only the sectors he has already crossed.
+        """Each sector's most recent value, and whether it belongs to this lap.
 
-        The tower's three sector columns show the lap IN PROGRESS, blank at
-        the line and filling as the car crosses each sector - which is what a
-        timing tower does and what showing the last COMPLETED lap for a whole
-        lap afterwards does not.
+        A timing screen's sector cells do not go blank at the line - they
+        **roll**. Each one shows the freshest number it has: this lap's if the
+        car has crossed that sector, otherwise the lap before's, with the
+        difference shown by dimming rather than by hiding.
 
-        **This does not weaken the reveal rule; it applies it at a finer
-        coordinate.** `masked_view`'s `L <= laps_completed` is the rule for
-        lap ROWS, which only exist once the lap is over. A sector has its own
-        timestamp, so its own moment: reveal it iff the replay clock has
-        passed `SectorNSessionTime`. Nothing here is visible before it
-        happened, and a rewind closes the sectors again because the clock
-        goes back with it.
+        **The first version of this served only the lap in progress, and it
+        made the S3 column permanently empty.** S3's crossing IS the end of
+        the lap: measured over all 920 real rows of Melbourne 2025,
+        `Sector3SessionTime` lands a median 55 ms AFTER the lap's own crossing
+        `Time` and after it on 94.1 % of laps. So S1 was visible for 60.3 s of
+        its lap, S2 for 40.8 s, and S3 for -0.055 s. One of three columns
+        showed nothing for the entire race.
+
+        **The reveal rule still holds at the finer coordinate.** A sector is
+        served only once the clock has passed its own crossing - this lap's or
+        the previous one's - so nothing is visible before it happened, and a
+        rewind takes it back because the clock goes back with it.
 
         It is a separate reader rather than part of `masked_view` because the
         two are masked by different things at different rates. A sector opens
         somewhere in the field every 2.22 s (measured: 2,744 crossings over
-        6,103 s of Melbourne 2025), and re-sending the whole revealed race at
-        that cadence is ~154 KB/s against the tick's own ~58. This block is
-        2 KB for twenty drivers.
+        6,103 s), and re-sending the whole revealed race at that cadence is
+        ~154 KB/s against the tick's own ~58. This block is 2 KB for twenty
+        drivers.
         """
         session_clock = clock_s + global_t_min
         drivers: dict[str, Any] = {}
         for code, rows in self._by_driver.items():
-            in_progress = self._row_for_lap(rows, laps_completed.get(code, 0) + 1)
+            lap = laps_completed.get(code, 0) + 1
+            in_progress = self._row_for_lap(rows, lap)
             if in_progress is None:
                 continue
-            drivers[code] = self._revealed_sectors(in_progress, session_clock)
+            previous = self._row_for_lap(rows, lap - 1)
+            drivers[code] = self._rolling_sectors(in_progress, previous, session_clock)
         return drivers
 
     @staticmethod
@@ -359,20 +366,29 @@ class SessionLaps:
         return None
 
     @staticmethod
-    def _revealed_sectors(row: dict[str, Any], session_clock: float) -> dict[str, Any]:
-        """One in-progress lap, with the sectors the clock has not reached left out.
+    def _rolling_sectors(
+        row: dict[str, Any], previous: dict[str, Any] | None, session_clock: float
+    ) -> dict[str, Any]:
+        """Each sector's freshest crossed value, flagged with whose lap it is.
 
-        `None` for a sector that has not happened yet, exactly as for one that
-        has no data - the renderer draws a dash either way, and inventing a
-        distinction the tower cannot use would only be a third state for every
-        consumer to carry.
+        `<sector>_fresh` is True when the value belongs to the lap in
+        progress and False when it is carried over from the lap before, which
+        is what the renderer dims. It is not a third state for a missing
+        value: a null sector is simply null and its flag is False.
+
+        The previous lap is only consulted for a sector this lap has not
+        reached yet. Nothing is served before its own crossing, in either lap.
         """
         live: dict[str, Any] = {"lap": row["lap"]}
         for sector, speed, crossed_at in _LIVE_SECTORS:
             moment = row[crossed_at]
-            open_now = moment is not None and moment <= session_clock
-            live[sector] = row[sector] if open_now else None
-            live[speed] = row[speed] if open_now else None
+            if moment is not None and moment <= session_clock:
+                live[sector], live[speed], fresh = row[sector], row[speed], True
+            elif previous is not None and previous[crossed_at] is not None:
+                live[sector], live[speed], fresh = previous[sector], previous[speed], False
+            else:
+                live[sector], live[speed], fresh = None, None, False
+            live[f"{sector}_fresh"] = fresh and live[sector] is not None
         return live
 
     @staticmethod

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -814,12 +814,14 @@ function towerBulk() {
 }
 
 /**
- * The lap in progress: S1 crossed, S2 and S3 not yet.
+ * The lap in progress: S1 crossed on THIS lap, S2 and S3 carried over.
  *
- * The bulk's completed row carries an S2 and an S3 for every driver, so a
- * tower still reading the last COMPLETED lap would print them - which is the
- * defect this channel exists to fix, and the reason the checks below look for
- * dashes in columns the bulk could happily fill.
+ * The cells roll rather than blank, so the fixture carries a value in all
+ * three and the flags say which lap each belongs to. **The first version of
+ * this fixture set `s2` and `s3` to null and the checks asserted dashes** -
+ * which is how the S3 column came to be permanently empty on the real race
+ * and no guard noticed: the test and the code agreed with each other and
+ * neither agreed with the parquet (#933).
  */
 function towerLive() {
   const drivers = {};
@@ -828,11 +830,14 @@ function towerLive() {
     drivers[code] = {
       lap: code === "LAW" ? 23 : 24,
       s1: crafted ? crafted.lastS1 : 31 + index * 0.1,
-      s2: null,
-      s3: null,
+      s2: 19.5,
+      s3: 26.75,
       v1: 301,
-      v2: null,
-      vfl: null,
+      v2: 288,
+      vfl: 279,
+      s1_fresh: true,
+      s2_fresh: false,
+      s3_fresh: false,
     };
   });
   return { rev: 1, drivers };
@@ -956,8 +961,18 @@ check((await tone(18)).includes("is-plain"), "a sector nobody has set is not col
 // The bulk's completed row carries an S2 and an S3 for every driver here, so a
 // tower reading it would print them. The live channel has only S1 open, which
 // is what a car that has crossed one sector of the current lap actually knows.
-check((await cell(1, 7)) === "—", "S2 is blank until the car crosses it");
-check((await cell(1, 8)) === "—", "and so is S3");
+// S2 and S3 carry the PREVIOUS lap's values, dimmed. They are not blank, and
+// that is the whole of #933: a cell that blanked until this lap's crossing
+// left S3 empty for the entire race, because a third sector's crossing IS the
+// end of its lap.
+check((await cell(1, 7)).startsWith("19.500"), "S2 shows the previous lap's value, not a dash");
+check((await cell(1, 8)).startsWith("26.750"), "and so does S3, which otherwise NEVER fills");
+const staleness = async (column) =>
+  (await towerPage.locator(`.tower-row:nth-child(1) td:nth-child(${column})`).getAttribute("class"))
+    .includes("is-stale");
+check((await staleness(6)) === false, "this lap's own sector is not dimmed");
+check((await staleness(7)) === true, "a carried-over sector says so by being dimmed");
+check((await staleness(8)) === true, "and S3 is carried over essentially always");
 check(
   (await cell(1, 9)) === "1:25.744",
   "while LAST still shows the lap the car completed, which is what that column means",

--- a/src/pitwall/ui/src/features/data/TimingTower.tsx
+++ b/src/pitwall/ui/src/features/data/TimingTower.tsx
@@ -126,22 +126,27 @@ function TowerRow({ code, position, front, leader, arcade, bulk, live, bests }: 
       </td>
       <td className="col-gap">{formatGapCell(gap)}</td>
       <td className="col-gap">{interval === null ? "—" : formatGapCell(interval)}</td>
-      {/* The sectors are the lap IN PROGRESS - blank at the line, filling as
-       * the car crosses each. Every other column on this row is about the
-       * last COMPLETED lap, which is what LAST, ST, TYRE and STOPS mean. */}
+      {/* The sector cells ROLL, they do not blank. Each shows the freshest
+       * value it has - this lap's once the car has crossed that sector, the
+       * previous lap's until then - and `stale` dims the carried-over ones.
+       * Every other column on this row is about the last COMPLETED lap, which
+       * is what LAST, ST, TYRE and STOPS mean. */}
       <SectorCell
         time={sectors?.s1 ?? null}
         speed={sectors?.v1 ?? null}
+        stale={!sectors?.s1_fresh}
         tone={sectorTone(sectors?.s1 ?? null, laps?.best.s1 ?? null, bests, "s1")}
       />
       <SectorCell
         time={sectors?.s2 ?? null}
         speed={sectors?.v2 ?? null}
+        stale={!sectors?.s2_fresh}
         tone={sectorTone(sectors?.s2 ?? null, laps?.best.s2 ?? null, bests, "s2")}
       />
       <SectorCell
         time={sectors?.s3 ?? null}
         speed={sectors?.vfl ?? null}
+        stale={!sectors?.s3_fresh}
         tone={sectorTone(sectors?.s3 ?? null, laps?.best.s3 ?? null, bests, "s3")}
       />
       <td className={`col-last ${last?.deleted ? "is-deleted" : ""}`}>{lastCell(status, last)}</td>
@@ -163,13 +168,16 @@ function SectorCell({
   time,
   speed,
   tone,
+  stale,
 }: {
   time: number | null;
   speed: number | null;
   tone: SectorTone;
+  /** Carried over from the previous lap rather than set on this one. */
+  stale: boolean;
 }) {
   return (
-    <td className={`col-sector is-${tone}`}>
+    <td className={`col-sector is-${tone}${stale ? " is-stale" : ""}`}>
       {time === null ? "—" : time.toFixed(3)}
       {/* A real space, not only the margin: the cell is read by a screen
        * reader and copied by a mouse, and "29.412301" is a different number. */}

--- a/src/pitwall/ui/src/lib/bridge.ts
+++ b/src/pitwall/ui/src/lib/bridge.ts
@@ -170,6 +170,20 @@ export interface LiveSectors {
   v1: number | null;
   v2: number | null;
   vfl: number | null;
+  /**
+   * Whether each value belongs to the lap IN PROGRESS or was carried over
+   * from the one before, which the tower dims.
+   *
+   * **`s3_fresh` is false essentially always, and that is the data, not a
+   * bug.** A third sector's crossing IS the end of its lap - measured over
+   * the whole race, `Sector3SessionTime` lands a median 55 ms AFTER the lap's
+   * own line crossing - so the S3 a strategist sees mid-lap is always the
+   * previous lap's. Serving only the current lap made the column permanently
+   * empty (#933).
+   */
+  s1_fresh: boolean;
+  s2_fresh: boolean;
+  s3_fresh: boolean;
 }
 
 export interface LiveLap {

--- a/src/pitwall/ui/src/styles/data.css
+++ b/src/pitwall/ui/src/styles/data.css
@@ -262,6 +262,14 @@
   color: #f59e0b;
 }
 
+/* A sector carried over from the previous lap. Dimmed, never hidden: it is a
+ * real time the car really set, and it is the freshest thing that cell can
+ * honestly hold - the third sector's crossing IS the end of its lap, so the S3
+ * on screen mid-lap is always the previous one's. */
+.col-sector.is-stale {
+  opacity: 0.5;
+}
+
 /* --- Band 2 right: the bests panel ---------------------------------------- */
 
 .bests {

--- a/tests/surfaces/test_pitwall_session_data.py
+++ b/tests/surfaces/test_pitwall_session_data.py
@@ -449,6 +449,10 @@ def test_a_sector_of_this_lap_is_not_served_before_its_crossing():
     assert before["s1"] == earlier["s1"] and before["s1_fresh"] is False, (
         "what it shows is the previous lap's, and it says so"
     )
+    assert before["v1"] == earlier["v1"], (
+        "and the trap speed comes from the SAME row as the time it sits beside"
+    )
+    assert before["v1"] != row["v1"], "never this lap's speed under the previous lap's time"
     assert after["s1"] == row["s1"] and after["s1_fresh"] is True
     assert after["v1"] == row["v1"], "with the speed measured at that trap"
     assert after["s2"] != row["s2"], "the sectors after it are still the previous lap's"
@@ -727,3 +731,113 @@ def test_a_rewind_onto_the_same_open_sector_pattern_is_still_served():
         "answered None - the window would keep the FUTURE lap's sector times on screen"
     )
     assert rewound["drivers"] != forward["drivers"], "and it must serve the earlier numbers"
+
+
+def test_no_sector_is_served_before_its_own_crossing_even_on_an_early_wire():
+    """The invariant measured on the clock the WINDOW serves, not the tests' one.
+
+    The carried-over branch first checked only that the previous lap HAD a
+    stamp, with no clock gate - and the docstring claimed nothing is served
+    before its own crossing. On the parquet-derived clock the tests use, that
+    was true. On the wire it was not: the arcade's crossing map increments
+    before that lap's own `Sector3SessionTime` on 837 of 921 laps (median
+    39 ms, max 0.463 s), so the just-ended S3 went out before its official
+    moment (#933 gate finding F6).
+
+    The wire's lead is reproduced here by advancing `laps_completed` EARLY -
+    by more than the measured worst case - which is exactly the shape of the
+    real skew and needs no 382 MB pickle to exercise. A guard that looks like
+    the reveal rule and checks something else is this repo's most expensive
+    shape, so this one checks the rule itself: every value on screen has a
+    stamp the clock has already passed.
+    """
+    session = _session_or_skip()
+    global_t_min = 4260.355
+    wire_lead = 0.6  # comfortably beyond the measured 0.463 s worst case
+
+    stamps = {
+        code: {row["lap"]: row for row in rows if not row["generated"]}
+        for code, rows in session._by_driver.items()
+    }
+    crossings = {
+        code: {lap: row["time_s"] for lap, row in laps.items() if row["time_s"] is not None}
+        for code, laps in stamps.items()
+    }
+    moments = sorted({t for laps in crossings.values() for t in laps.values()})
+
+    checked = 0
+    for probe in range(0, len(moments), 7):
+        session_clock = moments[probe]
+        # The wire is EARLY: a lap counts as completed before the parquet says so.
+        early_reveal = {
+            code: sum(1 for t in laps.values() if t <= session_clock + wire_lead)
+            for code, laps in crossings.items()
+        }
+        live = session.live_lap(early_reveal, session_clock - global_t_min, global_t_min)
+        for code, row in live.items():
+            lap_rows = stamps[code]
+            for sector, _speed, crossed_at in (
+                ("s1", "v1", "s1_at"),
+                ("s2", "v2", "s2_at"),
+                ("s3", "vfl", "s3_at"),
+            ):
+                if row[sector] is None:
+                    continue
+                source = row["lap"] if row[f"{sector}_fresh"] else row["lap"] - 1
+                moment = lap_rows.get(source, {}).get(crossed_at)
+                assert moment is not None and moment <= session_clock, (
+                    f"{code} shows {sector}={row[sector]} from lap {source} at clock "
+                    f"{session_clock:.3f}, but that sector was crossed at {moment}"
+                )
+                checked += 1
+
+    assert checked > 2000, f"only {checked} served sectors examined; this proves nothing"
+
+
+def test_pointing_the_arcade_at_a_race_with_no_laps_clears_the_sectors():
+    """The twin: `get_bulk` had this branch and `get_live_lap` did not.
+
+    A missing parquet makes the table say `available=False`, which is
+    deliberate - "a tower rendering zero rows silently is the same pixel as a
+    tower whose reveal is broken". Its sibling answered plain `None`, and
+    `None` means "keep what you have" to the client, so switching races left
+    the PREVIOUS race's sector times, dimming flags and colours on the new
+    race's rows indefinitely, beside a table that had correctly gone blank.
+
+    Reachable exactly the way `_session_for`'s own docstring says race
+    switches are - the stale-state class #904 already paid for once.
+    """
+
+    def tick_for(location: str, laps_completed: int) -> dict:
+        return {
+            "seq": 1,
+            "arcade": {
+                "year": 2025,
+                "location": location,
+                "t": 3000.0,
+                "global_t_min": 0.0,
+                "drivers": {"NOR": {"laps_completed": laps_completed}},
+            },
+        }
+
+    client = _FakeClient(tick_for("Melbourne", 20))
+    host = PitwallHost(client, window_count=1)
+
+    melbourne = host.get_live_lap(-1)
+    if melbourne is None or not melbourne["drivers"]:
+        pytest.skip("2025/Melbourne is not in this install's curated data set")
+    assert melbourne["drivers"]["NOR"]["lap"] == 21
+
+    client.latest = tick_for("Shanghai", 20)
+    switched = host.get_live_lap(melbourne["rev"])
+
+    assert switched is not None, (
+        "a race with no laps must be SAID, not answered with 'keep what you have' - "
+        "the tower would hold the previous race's sectors on the new race's rows"
+    )
+    assert switched["drivers"] == {}, "and what it says is: nothing to show"
+    assert switched["rev"] != melbourne["rev"], "with a revision the client will accept"
+
+    assert host.get_live_lap(switched["rev"]) is None, (
+        "served once, not re-sent on every poll of a race that has no laps"
+    )

--- a/tests/surfaces/test_pitwall_session_data.py
+++ b/tests/surfaces/test_pitwall_session_data.py
@@ -423,7 +423,7 @@ def test_no_tick_means_no_bulk():
 # --- The lap in progress: sectors revealed at the moment they were crossed ----
 
 
-def test_a_sector_is_closed_until_the_clock_reaches_its_crossing():
+def test_a_sector_of_this_lap_is_not_served_before_its_crossing():
     """The reveal rule at a finer coordinate, on the real race.
 
     `masked_view`'s `L <= laps_completed` is the rule for lap ROWS, which only
@@ -431,40 +431,55 @@ def test_a_sector_is_closed_until_the_clock_reaches_its_crossing():
     so it has its own moment - and revealing it then is not look-ahead, it is
     the present.
 
-    NOR's lap 23 at Melbourne crossed S1 at SessionTime 6689.966. One second
-    before that the cell must be empty; a tenth of a second after it must hold
-    31.865 and the 266 km/h measured at that trap.
+    NOR's lap 23 at Melbourne crossed S1 at SessionTime 6689.966. Before that
+    the cell must NOT hold lap 23's S1; the freshest thing it can honestly
+    show is lap 22's, flagged as not-this-lap. A tenth of a second later it
+    holds 31.865 and the 266 km/h measured at that trap, flagged as fresh.
     """
     session = _session_or_skip()
     global_t_min = 4260.355
     row = next(r for r in session._by_driver["NOR"] if r["lap"] == 23)
+    earlier = next(r for r in session._by_driver["NOR"] if r["lap"] == 22)
 
     before = session.live_lap({"NOR": 22}, row["s1_at"] - 1 - global_t_min, global_t_min)["NOR"]
     after = session.live_lap({"NOR": 22}, row["s1_at"] + 0.1 - global_t_min, global_t_min)["NOR"]
 
     assert before["lap"] == 23 and after["lap"] == 23, "both probes are on the lap in progress"
-    assert before["s1"] is None and before["v1"] is None, "nothing before the car got there"
-    assert after["s1"] == row["s1"], "and the real sector time the instant it did"
+    assert before["s1"] != row["s1"], "lap 23's S1 cannot be on screen before it was set"
+    assert before["s1"] == earlier["s1"] and before["s1_fresh"] is False, (
+        "what it shows is the previous lap's, and it says so"
+    )
+    assert after["s1"] == row["s1"] and after["s1_fresh"] is True
     assert after["v1"] == row["v1"], "with the speed measured at that trap"
-    assert after["s2"] is None, "the sectors after it stay shut"
+    assert after["s2"] != row["s2"], "the sectors after it are still the previous lap's"
 
 
-def test_a_rewind_shuts_the_sectors_again():
-    """The clock going back must CLOSE a cell, not leave it filled.
+def test_a_rewind_takes_this_laps_sectors_back():
+    """The clock going back must UNDO a cell, not leave this lap's time in it.
 
-    A cache that only ever fills would leave a time on screen for track the
+    A cache that only ever filled would leave a number on screen for track the
     car has yet to re-drive - the same leak as a lap-row reveal that never
-    un-reveals, one coordinate down.
+    un-reveals, one coordinate down. What the cell falls back to is the
+    PREVIOUS lap's value, which the car really did set before this clock, and
+    the flag says it is not from the lap in progress.
     """
     session = _session_or_skip()
     global_t_min = 4260.355
     row = next(r for r in session._by_driver["NOR"] if r["lap"] == 23)
+    earlier = next(r for r in session._by_driver["NOR"] if r["lap"] == 22)
 
     late = session.live_lap({"NOR": 22}, row["s3_at"] + 1 - global_t_min, global_t_min)["NOR"]
     rewound = session.live_lap({"NOR": 22}, row["s1_at"] - 1 - global_t_min, global_t_min)["NOR"]
 
     assert [late["s1"], late["s2"], late["s3"]] == [row["s1"], row["s2"], row["s3"]]
-    assert [rewound["s1"], rewound["s2"], rewound["s3"]] == [None, None, None]
+    assert all(late[f"{s}_fresh"] for s in ("s1", "s2", "s3")), "all three were set on this lap"
+
+    assert [rewound["s1"], rewound["s2"], rewound["s3"]] == [
+        earlier["s1"],
+        earlier["s2"],
+        earlier["s3"],
+    ], "every cell falls back to a lap the car had really finished by then"
+    assert not any(rewound[f"{s}_fresh"] for s in ("s1", "s2", "s3"))
 
 
 def test_a_car_with_no_lap_in_progress_is_absent_rather_than_empty():
@@ -549,3 +564,166 @@ def test_a_best_lap_time_is_still_the_smallest():
             checked += 1
 
     assert checked >= 60, f"only {checked} time bests compared; the fixture proves nothing"
+
+
+def test_every_sector_column_actually_shows_numbers_over_the_race():
+    """The check that would have caught the S3 column being permanently empty.
+
+    The first version of `live_lap` served only the lap in progress, which is
+    right for S1 and S2 and impossible for S3: S3's crossing IS the end of the
+    lap. Measured over all 920 real rows, `Sector3SessionTime` lands a median
+    55 ms AFTER the lap's own crossing `Time`, and after it on 94.1 % of laps -
+    so S1 was visible for 60.3 s of its lap, S2 for 40.8 s and S3 for
+    -0.055 s. One of three columns was a dash for the entire race.
+
+    The guards that missed it were fixture-shaped: the smoke harness hand-set
+    `s3: null` and asserted a dash, so the test and the code agreed with each
+    other and neither agreed with the race. This one samples the REAL clock
+    across the REAL race and asks what a strategist would actually see.
+    """
+    session = _session_or_skip()
+    global_t_min = 4260.355
+    crossings = {
+        code: {row["lap"]: row["time_s"] for row in rows if row["time_s"] is not None}
+        for code, rows in session._by_driver.items()
+    }
+    starts = [t for laps in crossings.values() for t in laps.values()]
+    first, last = min(starts), max(starts)
+
+    filled = {"s1": 0, "s2": 0, "s3": 0}
+    samples = 0
+    for step in range(60):
+        session_clock = first + (last - first) * step / 59
+        laps_completed = {
+            code: sum(1 for t in laps.values() if t <= session_clock)
+            for code, laps in crossings.items()
+        }
+        live = session.live_lap(laps_completed, session_clock - global_t_min, global_t_min)
+        for row in live.values():
+            samples += 1
+            for sector in filled:
+                if row[sector] is not None:
+                    filled[sector] += 1
+
+    assert samples > 500, f"only {samples} driver-instants sampled; this proves nothing"
+    for sector, count in filled.items():
+        share = count / samples
+        assert share > 0.75, (
+            f"{sector} is filled on only {share:.1%} of {samples} driver-instants across the "
+            f"race - a column a strategist never sees a number in"
+        )
+
+
+def test_a_carried_over_sector_says_it_is_not_from_this_lap():
+    """Rolling the value is honest; passing it off as the current lap is not.
+
+    Right after the line the freshest S3 a car has is the one that ENDED the
+    lap it just finished, so the cell shows it - and `s3_fresh` is False, which
+    is what the renderer dims. A cell that lied about which lap it belonged to
+    would be a stale number wearing a live one's clothes, on a fidelity
+    surface.
+    """
+    session = _session_or_skip()
+    global_t_min = 4260.355
+    lap23 = next(r for r in session._by_driver["NOR"] if r["lap"] == 23)
+    lap24 = next(r for r in session._by_driver["NOR"] if r["lap"] == 24)
+
+    # Just after lap 23 ended: lap 24 is in progress and has reached nothing.
+    just_after = session.live_lap({"NOR": 23}, lap23["time_s"] + 1 - global_t_min, global_t_min)
+    row = just_after["NOR"]
+
+    assert row["lap"] == 24, "the lap in progress is the new one"
+    assert row["s3"] == lap23["s3"], "and its S3 cell carries the sector that just ended lap 23"
+    assert row["s3_fresh"] is False, "flagged as belonging to the previous lap"
+
+    # Once lap 24's own S1 is crossed, THAT one is fresh and S3 still is not.
+    later = session.live_lap({"NOR": 23}, lap24["s1_at"] + 0.1 - global_t_min, global_t_min)["NOR"]
+    assert later["s1"] == lap24["s1"] and later["s1_fresh"] is True
+    assert later["s3"] == lap23["s3"] and later["s3_fresh"] is False
+
+
+def test_a_rewind_onto_the_same_open_sector_pattern_is_still_served():
+    """The collision the old revision signature could not see (#934).
+
+    `get_live_lap` used to key its revision on WHICH cells were filled. A
+    (driver, lap) pair determines the values, but the lap entered that
+    signature only as a constant True - so a rewind landing the whole field on
+    the same open-sector pattern, with every number different, bumped nothing,
+    answered None, and the client kept the FUTURE lap's sector times on a
+    screen whose clock had gone back. The gate that found it measured 3,667
+    such pairs at least ten seconds apart, the worst a 28-minute rewind across
+    the wet start.
+
+    This drives the REAL `get_live_lap` across a collision found by SEARCHING
+    the real race, so it asserts the effect - what the second call returns -
+    rather than re-implementing the comparison and checking its own arithmetic.
+    """
+    session = _session_or_skip()
+    global_t_min = 4260.355
+    crossings = {
+        code: {row["lap"]: row["time_s"] for row in rows if row["time_s"] is not None}
+        for code, rows in session._by_driver.items()
+    }
+    moments = sorted({t for laps in crossings.values() for t in laps.values()})
+
+    def reveal_at(session_clock: float) -> dict[str, int]:
+        return {
+            code: sum(1 for t in laps.values() if t <= session_clock)
+            for code, laps in crossings.items()
+        }
+
+    def pattern(session_clock: float) -> tuple:
+        view = session.live_lap(
+            reveal_at(session_clock), session_clock - global_t_min, global_t_min
+        )
+        return tuple(
+            (code, tuple(value is not None for value in row.values()))
+            for code, row in sorted(view.items())
+        )
+
+    late = moments[len(moments) * 3 // 4]
+    late_pattern = pattern(late)
+    early = next(
+        (
+            t
+            for t in moments
+            if late - t > 60
+            and pattern(t) == late_pattern
+            and session.live_lap(reveal_at(t), t - global_t_min, global_t_min)
+            != session.live_lap(reveal_at(late), late - global_t_min, global_t_min)
+        ),
+        None,
+    )
+    assert early is not None, (
+        "no same-pattern pair found on this race, so this guard would assert nothing"
+    )
+
+    client = _FakeClient()
+    host = PitwallHost(client, window_count=1)
+
+    def serve(session_clock: float, since_rev: int):
+        client.latest = {
+            "seq": 1,
+            "arcade": {
+                "year": 2025,
+                "location": "Melbourne",
+                "t": session_clock - global_t_min,
+                "global_t_min": global_t_min,
+                "drivers": {
+                    code: {"laps_completed": laps}
+                    for code, laps in reveal_at(session_clock).items()
+                },
+            },
+        }
+        return host.get_live_lap(since_rev)
+
+    forward = serve(late, -1)
+    assert forward is not None, "the first read must serve something"
+
+    rewound = serve(early, forward["rev"])
+
+    assert rewound is not None, (
+        f"the clock went back {late - early:.0f} s onto the same open-sector pattern and the host "
+        "answered None - the window would keep the FUTURE lap's sector times on screen"
+    )
+    assert rewound["drivers"] != forward["drivers"], "and it must serve the earlier numbers"


### PR DESCRIPTION
Closes #933. Closes #934.

Two defects in the live-sector channel #930 shipped, then three more the correctness gate found
**in the fixes for them**. One I found by looking at the window; the rest I had no idea about.

## #933 — the S3 column was structurally always a dash

A third sector's crossing **is** the end of its lap. Measured over the 920 real rows of
Melbourne 2025 carrying both stamps:

```
s3_at - the lap's own crossing Time:  median +0.055 s   p5 +0.000   p95 +0.089
fraction where S3 opens AFTER the line:  94.1 %

how long each sector stayed visible inside its own lap:
  S1   60.3 s
  S2   40.8 s
  S3   -0.055 s      <-- it never opened before the lap it belongs to had ended
```

So by the time S3's session time passed, `laps_completed` had incremented and `live_lap` had moved
to the next lap. One of three sector columns showed nothing, for every driver, for the whole race.

**The cells now ROLL, which is what a timing screen does.** Each shows this lap's value once the
car has crossed that sector and the previous lap's until then, with `s1_fresh`/`s2_fresh`/
`s3_fresh` saying which and the tower dimming the carried-over ones.

Measured after the fix at the window's own coordinates (the arcade's reveal map, 0.2 s cadence,
495,825 driver-instants): **S1 96.7 %, S2 98.8 %, S3 97.6 %** filled. `s3_fresh` is true for a
summed **2.7 s of a 6,167 s race**, so the S3 column is dimmed essentially always — which is the
data, not a bug: the S3 a strategist sees mid-lap is always the previous lap's.

> An earlier version of this PR body quoted 98.2 / 100 / 99.1 % from a 60-probe sweep. The gate
> re-measured on the served distribution and the "100 %" was a sampling artefact. The direction
> holds and the guard's 75 % threshold sits below both, but the number was wrong and this is the
> third time this sprint a figure measured on a convenient distribution needed correcting.

### My own guard asserted the defect

The smoke fixture hand-set `s3: null` and the check read *"and so is S3"*. The test and the code
agreed with each other and neither agreed with the parquet. The replacement samples the REAL clock
across the REAL race and asserts each column is filled on more than 75 % of driver-instants.
Against the old code: *"s1 is filled on only 62.6 % of 952 driver-instants across the race - a
column a strategist never sees a number in"*.

## #934 — the live revision could miss a rewind, so the reveal leaked

`get_live_lap`'s signature was `tuple(v is not None for v in row.values())` — which cells are
filled, not what is in them. A `(driver, lap)` pair determines the values, but the lap entered the
signature only as a constant `True`. So a rewind landing the whole field on the same open-sector
pattern bumped nothing, answered `None`, and the client kept the FUTURE lap's sector times.

**3,667 sampled pairs at least ten seconds apart share a presence pattern with completely
different numbers**, the worst a 28-minute rewind across the wet start.

```
at t=6166.5   rev=1   NOR live: lap 17, s1=31.990, v1=264
rewind to t=4445.0 → get_live_lap(rev=1) returns None        <-- stale kept
truth at t=4445.0:    NOR live: lap 2,  s1=58.907, v1=68
get_bulk across the same rewind: RE-SERVED (rev 1 → 2)       <-- the bulk was correct
```

The signature is now the served block itself. **A signature that does not determine the payload is
not a signature.** The gate then measured that this did not cost the channel its reason for
existing: over 51,391 polls at ~10 Hz it re-sends **0.44 times a second, about 1.1 KB/s** — one
per 2.27 s, matching the 2.22 s sector cadence, against the ~154 KB/s the channel exists to avoid.

## Then the gate audited those two fixes, and found three more

**The carried-over branch had no clock gate** — only *"the previous lap has a stamp"*. On the
parquet clock the tests use that is indistinguishable from the real rule; on the wire it is not.
The arcade's crossing map increments before that lap's own `Sector3SessionTime` on **837 of 921
laps** (median 39 ms, worst 0.463 s), so the just-ended S3 went out before its official moment —
under a docstring saying *"nothing is served before its own crossing, in either lap"*.

Nothing leaked that the bulk was not revealing at the same tick, but a guard that **looks like**
the reveal rule and checks something else is the shape that cost this project a whole sprint once.
Gated now, and the sentence is true. Cost: a cell that dashes for about one replay frame after a
line crossing.

**`get_live_lap` had no unavailable state while `get_bulk` has had one all along** — the twin,
again. Pointing the arcade at a race with no parquet made the table say `available=False` while
the live channel answered `None`, which means *keep what you have*, so the tower held the
**previous race's** sector times, flags and colours on the new race's rows indefinitely. It now
serves an empty block once.

**`get_bulk`'s own signature was the reveal map alone**, so the race was not part of what it is a
function of. Unreachable in practice; fixed because it is the same structural rule, one channel
over.

## Guards, every one watched RED

| guard | red against |
|---|---|
| the fill-rate guard | *"s1 is filled on only 62.6 % of 952 driver-instants"* |
| `test_a_rewind_onto_the_same_open_sector_pattern_is_still_served` — **searches** the real race for its collision pair rather than constructing one | *"the clock went back 869 s onto the same open-sector pattern and the host answered None"* |
| `test_no_sector_is_served_before_its_own_crossing_even_on_an_early_wire` — reproduces the wire's lead by advancing `laps_completed` beyond the measured worst case | *"NOR shows s3=54.007 from lap 1 at clock 4377.726, but that sector was crossed at 4377.784"* |
| `test_pointing_the_arcade_at_a_race_with_no_laps_clears_the_sectors` | *"a race with no laps must be SAID"* |

The two guards that asserted the pre-fix contract were rewritten rather than deleted and keep
their original property; the before-state assertion on the trap speed, dropped while rewriting
one of them, is back.

`tests/surfaces` 217 passed · `smoke-data` 90 checks · `smoke-agents` 18 · `tsc` clean · ruff
clean.

## What the gate verified and could not break

Part 2 of its brief ran the REAL producer through TCP → the real host → loopback → the real bundle
in chromium, scripted lap 1 → near the end → rewind to lap 11 → producer death: **38 checks, 0
failures.** Twenty rows in producer order with SAI/DOO/HAD out; nothing survived the 56→11 rewind
in `useBulk`, `useLiveLap`, `sessionBests`, the tower or the bests panel; the bests, percentages
and theoretical equal the recompute; purple/green agree with the panel with the fresh-live sector
as the only divergence, which is intended. The status strip's clock, PROVISIONAL both ways,
track-status chip and three connection states were all observed. The arcade's banner extraction is
single-sourced with no TypeScript twin.

Not exercisable: the red-flag corner — Melbourne 2025's status digits are {1, 2, 4}, so no red
flag exists in this race. The pywebview window itself was not opened in the gate's run; its pixel
evidence is chromium against the real loopback host. I opened the real window myself for #933,
which is how the S3 column was found.

Full report: `~/.claude/plans/pitwall-sprint5/correctness-gate.md`.
