### PR TITLE
docs(pitwall): state the crossing-skew convention, and what sprint 5 hands to sprint 6

### DIFF
--- a/documents/research/PITWALL_DELIVERY_PLAN.md
+++ b/documents/research/PITWALL_DELIVERY_PLAN.md
@@ -339,6 +339,25 @@ cells) with Race Trace as a tab of the same panel.
 > The 12 px row is arithmetic on the height gate's own constants and is **NOT measured** - what it
 > measured was 19-20 px for the TOWER's twelve-column row. Measure it first.
 
+**What sprint 5 finished, and the one piece of its own scope it did not.** Bands 1 and 2 are on
+`dev`: the status strip, the twenty-row tower with the sector colour code, the bests panel, and a
+live sector reveal the band list never asked for (#930, because the columns were showing the
+previous lap for the whole of the next one).
+
+**The band-2 spec's SELECTOR is not built** - *"pinning a row overlays its traces in band 4"* -
+and the reason is a decision rather than an omission. The tick carries a telemetry span for **2 of
+20** drivers, and which car is the rival is the arcade's choice. Measured on the real socket: the
+whole tick is 17,278 bytes and the telemetry block 1,161 of them, so all twenty carrying a span is
+**1.6x the tick, 271 KB/s at 10 Hz** - affordable. What is NOT affordable is the alternative: a
+control channel would end PITWALL's read-only-follower posture, which section 3.4 of the realism
+doc parks as a v2 question. Víctor's call (2026-08-14): take the option that breaks nothing, so
+the producer publishes all twenty spans - **and it lands with #199 phase D.3, never before it**,
+because `snapshot_dict` still re-runs a recursive `asdict` behind a blocking `sendall` ten times a
+second and 1.6x makes that worse inside the render loop. Filed as **#936**.
+
+There is no route through disk: **there is no telemetry on disk** (gate A). The 25 Hz frames live
+in one monolithic pickle, which is why #841 put the span on the wire at all.
+
 **Sprint 5's own deferred item, filed rather than improvised:** #931, sub-lap gaps from
 `intervals.parquet`, whose per-driver sample cadence is a measured **4.27 s median**. It is blocked
 on a time anchor (its `date` is UTC; every clock here is SessionTime, so it needs FastF1's

--- a/src/arcade/app.py
+++ b/src/arcade/app.py
@@ -679,10 +679,14 @@ class F1ArcadeView(arcade.View):
         #   crossing map, so it is monotone while playing forward - swept
         #   over 20 drivers x 154,173 frames, no counter-example. It is NOT
         #   exact against the parquet: 76 of 921 crossings (8.3 %) open
-        #   before the parquet's `Time`, worst case 0.463 s, because the
-        #   `lap` field these crossings are detected from is an interpolation
-        #   rather than a line detector. Monotone and per driver, not
-        #   frame-accurate.
+        #   before the parquet's `Time` by more than HALF A FRAME (0.02 s),
+        #   worst case 0.463 s, because the `lap` field these crossings are
+        #   detected from is an interpolation rather than a line detector.
+        #   The half-frame threshold is the convention, and stating it is the
+        #   point: strictly greater than zero the count is 110 (11.9 %) and
+        #   beyond a full 40 ms frame it is 49 (5.3 %). Sub-half-frame is
+        #   rounding noise, but a reader cannot know that from the number.
+        #   Monotone and per driver, not frame-accurate.
         # - `progress` is the ordering coordinate, laps plus fraction of the
         #   current lap; a consumer derives laps-down positionally from it.
         #   None when the telemetry never places the car (#886).


### PR DESCRIPTION
Two things the correctness gate asked for on its way out, neither of them code that runs.

## The unstated convention

The #857 comment in `app.py` says *"76 of 921 crossings (8.3 %) open before the parquet's Time"*
and never says which threshold produced that count. It is **more than half a frame (0.02 s)**.
Strictly greater than zero the count is **110 (11.9 %)**, and beyond a full 40 ms frame it is
**49 (5.3 %)**. The half-frame convention is defensible — sub-half-frame is rounding noise — but a
reader cannot know that from the number, and `gaps.py`'s own header warns about exactly this
shape: *"the convention this sentence used to leave unstated"*.

## What sprint 5 hands over

The delivery plan now records the one piece of sprint 5's OWN scope that was not built, so the next
session does not rediscover it as a gap.

The band-2 spec says the timing table *"doubles as THE SELECTOR: pinning a row overlays its traces
in band 4"*. It is not built, and the reason is a decision:

- the tick carries a telemetry span for **2 of 20** drivers, and which car is the rival is the
  arcade's choice;
- measured on the real socket, the whole tick is 17,278 bytes and the telemetry block 1,161 of
  them, so all twenty carrying one is **1.6x the tick, 271 KB/s at 10 Hz** — affordable;
- a control channel is not, because it would end PITWALL's read-only-follower posture, parked as a
  v2 question in the realism doc's section 3.4.

Víctor's call: the option that breaks nothing, so the producer publishes all twenty spans — **and
it lands with #199 phase D.3, never before it**, because `snapshot_dict` still re-runs a recursive
`asdict` behind a blocking `sendall` ten times a second and 1.6x makes that worse inside the
render loop. Filed as #936.

No route through disk: **there is no telemetry on disk** (gate A) — the 25 Hz frames live in one
monolithic pickle, which is why #841 put the span on the wire at all.

`tests/surfaces` green on the two suites these files touch; ruff clean.