### PR TITLE
feat(pitwall): the radio / RCM feed under the ring

### DIFF
--- a/src/pitwall/host.py
+++ b/src/pitwall/host.py
@@ -23,6 +23,8 @@ import logging
 
 from src.f1_strat_manager.data_cache import get_data_root
 from src.pitwall.agents_view import AgentsViewBuilder
+from src.pitwall.radio_feed import RadioCorpus
+from src.pitwall.radio_feed import unavailable as radio_unavailable
 from src.pitwall.session_data import SessionLaps, unavailable
 from src.pitwall.stream_client import ArcadeStreamClient
 
@@ -64,6 +66,10 @@ class PitwallHost:
         self._bulk_signature: tuple | None = None
         self._session: SessionLaps | None = None
         self._session_key: tuple[int, str] | None = None
+        # The radio/RCM feed of the SAME race, loaded under the SAME key in
+        # `_session_for`. It has no revision of its own: it rides in the bulk
+        # payload because it is a function of the bulk's signature exactly.
+        self._radio: RadioCorpus | None = None
         # The LIVE channel's state, masked by the clock rather than by
         # completed laps. `_live_view` is the last block SERVED, so the
         # revision moves exactly when the screen would change and not ten
@@ -284,6 +290,12 @@ class PitwallHost:
         Cached on (year, location) so pointing the arcade at another race
         replaces the laps instead of serving the previous one's - the
         stale-state class #904 already paid for once on the AGENTS history.
+
+        **The radio corpus loads HERE, under the same key, not beside it.** Two
+        caches on the same race with two invalidation points is how one of them
+        comes to serve the previous race - which is the twin this repo pays for
+        most often, and which F7 caught between these very two channels one
+        sprint ago.
         """
         year, location = arcade.get("year"), arcade.get("location")
         if not isinstance(year, int) or not isinstance(location, str):
@@ -291,6 +303,7 @@ class PitwallHost:
         if self._session_key != (year, location):
             self._session_key = (year, location)
             self._session = SessionLaps.load(get_data_root(), year, location)
+            self._radio = RadioCorpus.load(get_data_root(), year, location)
         return self._session
 
     def _masked_view(self, arcade: dict, reveal: dict[str, int]) -> dict:
@@ -304,11 +317,24 @@ class PitwallHost:
         year, location = arcade.get("year"), arcade.get("location")
         session = self._session_for(arcade)
         if session is None:
-            return unavailable(
+            view = unavailable(
                 year if isinstance(year, int) else None,
                 location if isinstance(location, str) else None,
             )
-        return session.masked_view(reveal, float(arcade.get("global_t_min") or 0.0))
+        else:
+            view = session.masked_view(reveal, float(arcade.get("global_t_min") or 0.0))
+        # The radio feed rides IN this payload rather than on a channel of its
+        # own, because it is a pure function of exactly what already signs this
+        # one: (year, location, reveal map). A second channel would need a
+        # second signature, and a signature that does not determine its payload
+        # is the defect #934 cost a sprint. Measured cost of carrying it: the
+        # bulk is 66,991 / 152,657 / 337,289 bytes at reveal L10 / L24 / L57 on
+        # the real Melbourne payload, and the largest feed in the whole corpus
+        # (Monaco, 210 events) is about 31 KB - 9 %.
+        view["radio"] = (
+            radio_unavailable() if self._radio is None else self._radio.masked_view(reveal)
+        )
+        return view
 
     def release_window(self) -> int:
         """Record that one window has closed; stop the client at the last one.

--- a/src/pitwall/radio_feed.py
+++ b/src/pitwall/radio_feed.py
@@ -1,0 +1,269 @@
+"""The RADIO channel: a race's team radio and race control, revealed lap by lap.
+
+The DATA window's fourth panel is a chronological feed of what was said during
+the race - the RaceX client's `Race Control Messages` list, merged with the
+driver radio its own tab carries separately.
+
+**It is read from disk and not from the wire, and that is a correction to the
+sprint brief rather than a preference.** `strategy.per_agent.radio` really does
+carry `radio_events` and `rcm_events` with the original transcripts, but
+`StrategyState.snapshot_dict` strips `per_agent` from every entry of
+`history_tail`, so the wire holds the CURRENT lap and nothing else. Building a
+chronological feed from that means accumulating client-side, and this window
+has a rule against exactly that (`useBulk.ts`: "a grow-only cache would survive
+a seek to the end"). Accumulation would also start empty on a mid-race attach,
+hole at 8x where laps are skipped, and vanish entirely when the producer runs
+without `--strategy`, which the DATA window does not otherwise need.
+
+The corpus is static parquet known before lap 1, so it is a progressive reveal
+masked by the clock - the same argument that shaped `session_data.py`, and the
+same shape, so the two cannot drift apart.
+
+Three properties this module exists to guarantee:
+
+1. **The reveal is a THIRD coordinate and it is coarse on purpose.** A driver
+   radio from lap L shows once that driver has completed lap L; a race-control
+   message from lap L shows once the LEADER has. Never early, at most one lap
+   late. It cannot be finer: both parquets stamp events in UTC while every
+   clock in this window is SessionTime, and bridging them needs FastF1's
+   `t0_date` - the blocker #931 and #842 are already filed against. The panel
+   states the rule on screen rather than inventing an anchor.
+2. **Nothing here decides the TIER.** Which driver is ours lives on the tick
+   (`arcade.driver_main`), which is not part of the bulk's signature, so a
+   payload that baked the tier in would not be determined by the signature that
+   serves it - the defect #934 cost a sprint. The renderer holds the tick and
+   labels there.
+3. **The reader is the corpus reader the CLI already uses.** Constructing
+   `RadioPipelineRunner` with `eager_transcribe=False` loads no model - Whisper
+   comes in lazily through `_get_whisper` - and it owns the parquet paths, the
+   transcript cache and its backslash/forward-slash key convention, whose other
+   half is the WRITER. Re-implementing any of that here would be a second copy.
+
+--- WHERE TO CHANGE IF THE CORPUS MOVES ---
+`RadioPipelineRunner` owns every path: the parquets under
+`data/processed/race_radios/{year}/{slug}/` and the transcript cache under
+`data/processed/radio_nlp/{year}/{slug}/`. The slug is a third GP keyspace and
+`src/f1_strat_manager/gp_slugs.py` is its single source of truth.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from src.nlp.radio_runner import RadioPipelineRunner
+from src.pitwall.session_data import race_dir
+
+logger = logging.getLogger(__name__)
+
+
+def _codes_by_number(laps_frame: pd.DataFrame) -> dict[int, str]:
+    """`{car number: driver code}` from the RAW lap table.
+
+    Keyed on the number as an INT on both sides. The parquet holds it as a
+    string because "07" is a real car number and `int()` would print it "7" -
+    but the radio corpus holds the same number as an integer, so normalising
+    both through `int` is what makes the two meet at all, and the code is what
+    gets displayed anyway.
+    """
+    if "DriverNumber" not in laps_frame or "Driver" not in laps_frame:
+        return {}
+    pairs = laps_frame[["DriverNumber", "Driver"]].dropna().drop_duplicates()
+    codes: dict[int, str] = {}
+    for row in pairs.itertuples():
+        try:
+            codes[int(row.DriverNumber)] = str(row.Driver)
+        except (TypeError, ValueError):
+            continue
+    return codes
+
+
+def _transcript_text(runner: RadioPipelineRunner, audio_path: Any) -> str:
+    """The cached transcript for one radio row, or an empty string.
+
+    Empty is the runner's own contract for "no usable text"
+    (`_transcribe_one` writes an empty entry rather than dropping the row), and
+    it is the COMMON case here: 23 of the 24 races on the Hub have no
+    transcribed audio and there is not one MP3 on disk. The event still
+    renders - that a radio happened, from whom and on which lap is information.
+    """
+    if audio_path is None or pd.isna(audio_path):
+        return ""
+    # Private only by name. It is the shared convention between this reader and
+    # the cache's WRITER - the parquet stores the path with native separators
+    # and the JSON keys it with forward slashes - so calling it is the whole
+    # point and copying it would be the twin.
+    key = RadioPipelineRunner._normalize_audio_path(str(audio_path))
+    entry = runner.transcripts.get(key) or {}
+    return str(entry.get("text") or "")
+
+
+def _rcm_text(row: Any) -> str:
+    """A race-control row's message, falling back to its bare flag."""
+    message = str(getattr(row, "message", "") or "").strip()
+    if message:
+        return message
+    return str(getattr(row, "flag", "") or "").strip()
+
+
+class RadioCorpus:
+    """One race's radio and RCM events, ordered once and sliced on every read.
+
+    Immutable after construction. Each event is held beside the driver code
+    whose lap counter gates it - `None` meaning the leader's - so the reveal is
+    DATA rather than a branch that has to stay in step with `kind`. Sprint 5's
+    most expensive defect was a guard that looked like the reveal rule and
+    checked something adjacent to it.
+    """
+
+    def __init__(self, gated: list[tuple[str | None, dict[str, Any]]]) -> None:
+        self._gated = gated
+
+    @classmethod
+    def load(cls, data_root: Path, year: int, location: str) -> RadioCorpus | None:
+        """Read the race's corpus, or None when there is none on disk.
+
+        Resolved through the race FOLDER's name rather than the wire's raw
+        `location`, because the two disagree and only one of them resolves.
+        FastF1's 2025 Location is "Miami Gardens" while the folder is
+        `Miami_Gardens` and `gp_slugs.FOLDER_ALIASES` is keyed on the
+        underscore form - so `race_dir` does the disk-level resolution once and
+        this reads the answer off it.
+
+        Returns None rather than raising for every miss, including the
+        `ValueError` `resolve_gp_slug` throws at an unknown GP: on a curated
+        install a missing corpus is the COMMON case, so it is absent data and
+        not a failed operation. The same reasoning as `SessionLaps.load`.
+        """
+        directory = race_dir(data_root, year, location)
+        if directory is None:
+            return None
+        laps_frame = pd.read_parquet(directory / "laps.parquet")
+        try:
+            runner = RadioPipelineRunner(
+                year=year,
+                gp_name=directory.name,
+                # Deliberately EMPTY, and typed so the runner's own mapper
+                # answers `{}` quietly instead of logging a failure. It builds
+                # `{number: code}` by slicing on `GP_Name`, a column only the
+                # FEATURED parquet carries, so handing it the raw table would
+                # log "Could not build driver code map" on every race switch
+                # about a map this reader does not use: PITWALL takes its codes
+                # from `_codes_by_number` below, off the same frame the tower's
+                # rows come from, which is what makes the two agree.
+                laps_df=pd.DataFrame(columns=["GP_Name", "DriverNumber", "Driver"]),
+                data_root=data_root,
+                eager_transcribe=False,
+            )
+        except ValueError:
+            # An unknown GP name. The runner raises so a CLI typo cannot
+            # produce a silent zero-radio simulation; here the same input is a
+            # season we have no corpus for, which is data we do not have.
+            logger.info("No radio corpus slug for %s %s", year, location)
+            return None
+        if runner.total_radios() == 0 and runner.total_rcms() == 0:
+            logger.info("Radio corpus empty for %s %s", year, location)
+            return None
+        return cls(cls._ordered_events(runner, _codes_by_number(laps_frame)))
+
+    @staticmethod
+    def _ordered_events(
+        runner: RadioPipelineRunner,
+        codes_by_number: dict[int, str],
+    ) -> list[tuple[str | None, dict[str, Any]]]:
+        """Every event of the race, in order, each beside its reveal driver.
+
+        **The codes come from the RAW lap table, not from the runner's own
+        map, and the difference was a silent total loss.** The runner builds
+        `{number: code}` off the FEATURED parquet, which carries a `GP_Name`
+        column to slice on; the raw `laps.parquet` this window reads has no
+        such column, so its mapper caught its own exception, logged a warning
+        and returned `{}` - and every radio came out as the synthetic `D12`,
+        which no reveal map and no tower row can ever match. Executed on
+        Melbourne: **0 of 14 driver radios were ever revealed** while all 90
+        race-control rows were, so the panel would have looked like a working
+        RCM feed on a race with no team radio at all. Reading the codes off the
+        same frame the tower's come from also guarantees the two agree.
+
+        **The order is by LAP, then by the parquet's UTC stamp within it.** The
+        stamp is unusable as an ABSOLUTE anchor against this window's
+        SessionTime clock, which is what blocks a finer reveal - but it orders
+        two events of the same lap perfectly well, and that is all it is asked
+        to do here. (No row is missing one: 0 of 2,126 across the 24 races on
+        disk. A future null would sort first within its lap, never crash.)
+        """
+        ordered: list[tuple[tuple[int, Any], str | None, dict[str, Any]]] = []
+        for row in runner.radios_df.itertuples():
+            code = codes_by_number.get(int(row.driver_number))
+            if code is None:
+                # A car number with no lap rows - a reserve entry, or corpus
+                # drift. It cannot be placed on this clock: gating it on the
+                # leader would show it EARLIER than the driver it belongs to
+                # ever reaches, which is the one direction the reveal must
+                # never fail in. Dropped and said out loud.
+                logger.info(
+                    "Radio from car %s on lap %s has no driver in the lap table - skipped",
+                    row.driver_number,
+                    row.lap_number,
+                )
+                continue
+            payload = {
+                "kind": "radio",
+                "lap": int(row.lap_number),
+                "driver": code,
+                "text": _transcript_text(runner, row.audio_path),
+                "category": None,
+                "flag": None,
+            }
+            ordered.append(((int(row.lap_number), row.date), code, payload))
+        for row in runner.rcm_df.itertuples():
+            payload = {
+                "kind": "rcm",
+                "lap": int(row.lap_number),
+                # The message already names its car, so a code here would print
+                # it twice. Measured across all 24 races on disk: of the 492
+                # rows carrying a `driver_number`, 492 spell that number inside
+                # the text ("WAVED BLUE FLAG FOR CAR 87 (BEA) ..."), code
+                # included. The key stays so both kinds of event have one shape
+                # and the renderer needs no optional-key branch.
+                "driver": None,
+                "text": _rcm_text(row),
+                "category": str(getattr(row, "category", "") or "") or None,
+                "flag": str(getattr(row, "flag", "") or "") or None,
+            }
+            # None, never the car the message names: race control issues it on
+            # the RACE's lap, and a row names a car only because the flag or
+            # the penalty is about it.
+            ordered.append(((int(row.lap_number), row.date), None, payload))
+        ordered.sort(key=lambda item: item[0])
+        return [(gate, payload) for _key, gate, payload in ordered]
+
+    def masked_view(self, laps_completed: dict[str, int]) -> dict[str, Any]:
+        """The feed as of the clock: every event whose lap is over.
+
+        A rewind LOWERS `laps_completed` and therefore shortens this list,
+        because it is recomputed rather than accumulated. That is the whole
+        reason the feed is read from disk instead of gathered off the wire.
+        """
+        leader_lap = max(laps_completed.values(), default=0)
+        events = [
+            event
+            for driver, event in self._gated
+            if event["lap"] <= (leader_lap if driver is None else laps_completed.get(driver, 0))
+        ]
+        result = {"available": True, "events": events}
+        return result
+
+
+def unavailable() -> dict[str, Any]:
+    """The payload for a race with no corpus, so the panel can say so.
+
+    An explicit state rather than an empty one, for the reason `session_data`
+    already spells out: a feed rendering nothing silently is the same pixel as
+    a feed whose reveal is broken.
+    """
+    result = {"available": False, "events": []}
+    return result

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -1024,6 +1024,144 @@ check(
 
 await towerCtx.close();
 
+// --- The radio / RCM feed, in the column under the ring ----------------------
+
+/**
+ * Six events chosen so every branch of the panel is decidable by eye.
+ *
+ * Oldest first, exactly as the host serves them: the panel reverses, and a
+ * fixture already in display order would let a renderer that forgot to reverse
+ * pass. LAW's radio is longer than two lines at 260 px, so it also exercises
+ * the clamp; HAM's has no transcript, which is what 23 of the 24 published
+ * races look like.
+ */
+const RADIO_EVENTS = [
+  { kind: "rcm", lap: 2, driver: null, text: "DOUBLE YELLOW IN TRACK SECTOR 20", category: "Flag", flag: "DOUBLE YELLOW" },
+  { kind: "radio", lap: 6, driver: "NOR", text: "Weather update, no significant rain expected.", category: null, flag: null },
+  { kind: "radio", lap: 14, driver: "HAM", text: "", category: null, flag: null },
+  { kind: "rcm", lap: 20, driver: null, text: "FIA STEWARDS: INCIDENT INVOLVING CAR 22 (TSU) NO FURTHER ACTION - SAFETY CAR INFRINGEMENT", category: "Other", flag: null },
+  { kind: "radio", lap: 21, driver: "NOR", text: "Lando, a bit of an update on the safety car window.", category: null, flag: null },
+  { kind: "radio", lap: 23, driver: "VER", text: "If there is heavy rain we might need to fit inters, bear in mind.", category: null, flag: null },
+];
+
+async function radioPage(radio) {
+  const context = await browser.newContext({ viewport: { width: 1485, height: 833 } });
+  const rPage = await context.newPage();
+  rPage.on("pageerror", (error) => failures.push(`pageerror(radio): ${error.message}`));
+  await rPage.addInitScript(
+    ([payload, bulk, live]) => {
+      window.pywebview = {
+        api: {
+          get_tick: async (sinceSeq) => (sinceSeq === payload.seq ? null : payload),
+          get_bulk: async (sinceRev) => (sinceRev === bulk.rev ? null : bulk),
+          get_live_lap: async (sinceRev) => (sinceRev === live.rev ? null : live),
+          get_connection: async () => "Connected",
+        },
+      };
+    },
+    [
+      tick(1, { drivers: towerField(), order: TOWER_ORDER }),
+      { ...towerBulk(), radio },
+      towerLive(),
+    ],
+  );
+  await rPage.goto(url, { waitUntil: "domcontentloaded" });
+  await rPage.waitForSelector(".radio-feed", { timeout: 5000 });
+  await rPage.waitForTimeout(500);
+  return [context, rPage];
+}
+
+const [radioCtx, feedPage] = await radioPage({ available: true, events: RADIO_EVENTS });
+
+// Tolerant for the same reason `cell` is: a defect that DROPS rows makes every
+// later selector miss, and a throwing helper kills the harness with a stack
+// instead of naming the failures - so the one check that explains the cause is
+// never printed. Measured: a mutation that filtered out transcript-less rows
+// took the whole run down with a TimeoutError before this was tolerant.
+const rowText = async (n) => {
+  try {
+    const text = await feedPage
+      .locator(`.radio-row:nth-child(${n})`)
+      .innerText({ timeout: 1000 });
+    return text.replace(/\s+/g, " ").trim();
+  } catch {
+    return "<no such row>";
+  }
+};
+
+// Six events, six rows. The panel drops nothing of its own accord: the only
+// thing allowed to remove an event is the reveal, upstream of here. Measured
+// on a mutated copy that filtered out transcript-less radios - the count in the
+// header still read 6, because it counts the PAYLOAD, so without this check the
+// six-into-five silently passed.
+check(
+  (await feedPage.locator(".radio-row").count()) === RADIO_EVENTS.length,
+  "every revealed event gets a row when they all fit",
+);
+
+// Newest FIRST. A pit wall reads the top line; a feed rendered in arrival order
+// puts lap 2 there and the freshest message off the bottom of a 416 px card.
+check((await rowText(1)).startsWith("L23 VER"), "the newest event is the top row");
+check((await rowText(6)).startsWith("L2 RCM"), "and the oldest is the last one");
+
+// The tier claim, on screen rather than in a PDF. NOR is `driver_main`.
+const tiers = await feedPage.evaluate(() =>
+  [...document.querySelectorAll(".radio-row")].map((row) => ({
+    who: row.querySelector(".radio-who")?.textContent ?? "",
+    broadcast: row.querySelector(".radio-tier") !== null,
+  })),
+);
+check(
+  tiers.filter((row) => row.who === "VER" || row.who === "HAM").every((row) => row.broadcast),
+  "a rival's radio is tagged BROADCAST, exactly as band 4 tags a pinned rival's trace",
+);
+check(
+  tiers.filter((row) => row.who === "NOR").every((row) => !row.broadcast),
+  "our own car's radio is not - it is team tier and carries no tag",
+);
+check(
+  tiers.filter((row) => row.who === "RCM").every((row) => !row.broadcast),
+  "and race control is neither: it is public by definition, not a rival's channel",
+);
+
+// A radio whose audio was never transcribed still occupies a row. Dropping it
+// would present a race as quieter than it was, and that is the COMMON case:
+// 23 of the 24 published races have no transcript at all.
+check((await rowText(4)).includes("no transcript"), "a radio with no words still shows itself");
+
+// The count is what stops an overflow being silent. Scrollbars are hidden
+// globally, so a panel that shows nine of forty-two and says nothing looks
+// exactly like a panel showing all there is.
+check(
+  (await feedPage.locator(".radio-count").innerText()).trim() === String(RADIO_EVENTS.length),
+  "the header counts every revealed event, not the ones that happen to fit",
+);
+
+// EFFECT, not mechanism: the card must not spill past the column it lives in.
+const fits = await feedPage.evaluate(() => {
+  const card = document.querySelector(".radio-feed");
+  const column = document.querySelector(".side-column");
+  return {
+    overflow: card.getBoundingClientRect().bottom - column.getBoundingClientRect().bottom,
+    ringVisible: document.querySelector(".ring").getBoundingClientRect().height > 0,
+  };
+});
+check(fits.overflow <= 1, `the feed stays inside its column (spills ${fits.overflow.toFixed(1)}px)`);
+check(fits.ringVisible, "and the ring above it is still there");
+
+await radioCtx.close();
+
+// A race with no corpus SAYS so. An empty list and a missing corpus are the
+// same pixel otherwise, which is the twin F7 caught one sprint ago between
+// get_bulk and get_live_lap.
+const [emptyCtx, emptyPage] = await radioPage({ available: false, events: [] });
+check((await emptyPage.locator(".radio-row").count()) === 0, "no rows for a race with no corpus");
+check(
+  (await emptyPage.locator(".radio-subtitle").innerText()).includes("no corpus"),
+  "and the panel says so instead of going quietly blank",
+);
+await emptyCtx.close();
+
 await browser.close();
 server.close();
 

--- a/src/pitwall/ui/src/features/data/DataWindow.tsx
+++ b/src/pitwall/ui/src/features/data/DataWindow.tsx
@@ -23,6 +23,7 @@
 
 import { BestsPanel } from "./BestsPanel";
 import { OwnCarTraces } from "./OwnCarTraces";
+import { RadioFeed } from "./RadioFeed";
 import { StatusStrip } from "./StatusStrip";
 import { TimingTower } from "./TimingTower";
 import { TrackRing } from "./TrackRing";
@@ -57,7 +58,10 @@ export function DataWindow() {
             </div>
             <div className="band4">
               <OwnCarTraces tick={tick} discontinuity={discontinuity} />
-              <TrackRing arcade={tick.arcade} />
+              <div className="side-column">
+                <TrackRing arcade={tick.arcade} />
+                <RadioFeed bulk={bulk} driverMain={tick.arcade.driver_main} />
+              </div>
             </div>
           </div>
         ) : (

--- a/src/pitwall/ui/src/features/data/RadioFeed.tsx
+++ b/src/pitwall/ui/src/features/data/RadioFeed.tsx
@@ -1,0 +1,104 @@
+/**
+ * The radio / RCM feed: what was said, in the order it was said.
+ *
+ * The RaceX client's `Race Control Messages` panel with the driver radio
+ * merged into it, in the column under the ring.
+ *
+ * **It shows the WHOLE FIELD, and rivals carry a `BROADCAST` tag.** Víctor's
+ * call, and his reason is the one that settles the tier question: a real team
+ * receives the public broadcast radio feed, so rendering it is fidelity rather
+ * than a privilege we grant ourselves. The tag is the same treatment band 4
+ * gives a pinned rival's trace - which is what makes the tier discipline
+ * visible on screen instead of asserted in a PDF.
+ *
+ * **The tier is decided HERE and not by the host.** Which car is ours lives on
+ * the tick (`arcade.driver_main`), and the feed rides in the bulk payload,
+ * whose signature is (year, location, reveal map). A host that baked the tier
+ * in would be serving a payload its own signature does not determine, which is
+ * exactly what #934 cost a sprint.
+ *
+ * Newest first, because a pit wall reads the newest line at the top. What
+ * falls off the bottom is the OLDEST, and the header's count says how many
+ * there are in total so the cut is never silent.
+ */
+
+import type { Bulk, RadioEvent } from "../../lib/bridge";
+
+/**
+ * Who said it: a driver's code, or `RCM` for race control.
+ *
+ * Race control's own rows carry no code on purpose - the message already
+ * names the car it is about, code included, on all 492 such rows across the
+ * 24 races published, so a badge would print it twice.
+ */
+function whoLabel(event: RadioEvent): string {
+  if (event.kind === "rcm") return "RCM";
+  return event.driver ?? "--";
+}
+
+/** Every radio that is not our own car's is public-feed material. */
+function isBroadcast(event: RadioEvent, driverMain: string | null): boolean {
+  return event.kind === "radio" && event.driver !== driverMain;
+}
+
+/**
+ * A radio row with no transcript still renders, with the words missing.
+ *
+ * That is the corpus reader's own contract, and it is the COMMON case: 23 of
+ * the 24 races published have no transcribed audio and there is not one MP3 on
+ * disk. That a radio happened, from whom, and on which lap is information; a
+ * dropped row would present a race as quieter than it was.
+ */
+function bodyText(event: RadioEvent): string {
+  if (event.text) return event.text;
+  return event.kind === "radio" ? "(no transcript)" : "";
+}
+
+export function RadioFeed({ bulk, driverMain }: { bulk: Bulk | null; driverMain: string | null }) {
+  const feed = bulk?.radio;
+  const events = feed?.events ?? [];
+  // Newest first. The array arrives oldest-first because that is the order the
+  // race happened in and the order the host reveals it in; reversing here
+  // rather than there keeps the payload in the shape a future full-history
+  // panel would want.
+  const newestFirst = [...events].reverse();
+
+  return (
+    <section className="card radio-feed">
+      <header className="radio-header">
+        <span className="radio-title">RADIO · RCM</span>
+        {feed?.available ? (
+          <span className="radio-count">{events.length}</span>
+        ) : (
+          <span className="radio-subtitle">no corpus</span>
+        )}
+      </header>
+      {feed?.available && newestFirst.length === 0 ? (
+        <p className="radio-empty">Nothing said yet.</p>
+      ) : null}
+      <ol className="radio-list">
+        {newestFirst.map((event, index) => (
+          <li
+            className={`radio-row is-${event.kind}`}
+            // The corpus has no stable id, and two race-control rows of the
+            // same lap really can carry the same text (four identical BLUE
+            // FLAG lines for the same car on Melbourne's lap 46). The index
+            // into a list that is rebuilt whole on every reveal is the honest
+            // key; a text-based one would collapse those four into one.
+            key={`${event.lap}-${event.kind}-${index}`}
+            title={event.text || undefined}
+          >
+            <span className="radio-lap">L{event.lap}</span>
+            <span className="radio-who">{whoLabel(event)}</span>
+            <span className="radio-text">
+              {isBroadcast(event, driverMain) ? (
+                <span className="radio-tier">BROADCAST </span>
+              ) : null}
+              {bodyText(event)}
+            </span>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/src/pitwall/ui/src/lib/bridge.ts
+++ b/src/pitwall/ui/src/lib/bridge.ts
@@ -145,6 +145,26 @@ export interface DriverLaps {
   theoretical: number | null;
 }
 
+/**
+ * One thing that was said during the race - a team radio or a race-control message.
+ *
+ * `driver` is the speaker's code on a radio and always `null` on an RCM, whose
+ * message already names the car it concerns.
+ *
+ * **The TIER is not on this object.** Which car is ours lives on the tick, and
+ * this rides in the bulk, so the renderer pairs the two: a radio from anyone
+ * but `arcade.driver_main` is broadcast-tier and says so on screen.
+ */
+export interface RadioEvent {
+  kind: "radio" | "rcm";
+  lap: number;
+  driver: string | null;
+  /** The transcript, or "" when the audio was never transcribed - which is the common case. */
+  text: string;
+  category: string | null;
+  flag: string | null;
+}
+
 export interface Bulk {
   /** Advances whenever the reveal changes IN EITHER DIRECTION. A rewind bumps it too. */
   rev: number;
@@ -152,6 +172,13 @@ export interface Bulk {
   available: boolean;
   race: { year: number | null; location: string | null; total_laps: number };
   drivers: Record<string, DriverLaps>;
+  /**
+   * The radio/RCM feed of the same race, oldest first, masked by the same
+   * reveal. It rides in this payload rather than on a channel of its own
+   * because it is a function of exactly what signs this one, and a second
+   * signature that does not determine its payload is what #934 cost.
+   */
+  radio: { available: boolean; events: RadioEvent[] };
 }
 
 /**

--- a/src/pitwall/ui/src/styles/data.css
+++ b/src/pitwall/ui/src/styles/data.css
@@ -682,3 +682,126 @@
   font-size: 9px;
   letter-spacing: 0.5px;
 }
+
+/* --- The radio / RCM feed, in the column under the ring ------------------ */
+
+/* The ring self-sizes (`align-self: start`) and leaves the rest of its 260 px
+ * column empty - about 416 px on this machine. This is what goes there, so
+ * the column becomes ring-then-feed rather than ring-then-nothing. */
+.side-column {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 10px;
+  min-height: 0;
+}
+
+.radio-feed {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px;
+  min-height: 0;
+  /* Scrollbars are hidden globally (`qt-base.css`), so an overflow here has no
+   * affordance at all. The list is newest-first for that reason: what falls
+   * off the bottom is the OLDEST, which is what a ticker is expected to lose,
+   * and the header's count says how many there are so the cut is never
+   * silent. */
+  overflow: hidden;
+}
+
+/* Same rank and rhythm as `.ring-header`, so the two cards in this column
+ * read as one surface. */
+.radio-header {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 0 2px;
+}
+
+.radio-title {
+  color: var(--qt-fg-1);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 1px;
+}
+
+.radio-subtitle {
+  color: var(--qt-fg-3);
+  font-size: 10px;
+}
+
+.radio-count {
+  color: var(--qt-fg-3);
+  font-family: var(--qt-mono);
+  font-size: 10px;
+  margin-left: auto;
+}
+
+.radio-empty {
+  color: var(--qt-fg-3);
+  font-size: 10px;
+  margin: 0;
+  padding: 0 2px;
+}
+
+.radio-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.radio-row {
+  display: grid;
+  grid-template-columns: 22px auto 1fr;
+  align-items: baseline;
+  column-gap: 5px;
+  padding: 3px 2px;
+  border-top: 1px solid var(--qt-border);
+  font-size: 10px;
+  line-height: 13px;
+}
+
+.radio-row:first-child {
+  border-top: none;
+}
+
+.radio-lap {
+  color: var(--qt-fg-3);
+  font-family: var(--qt-mono);
+}
+
+.radio-who {
+  color: var(--qt-fg-1);
+  font-family: var(--qt-mono);
+  font-weight: 700;
+}
+
+/* Race control is the field's own voice rather than a driver's, so it reads
+ * one step back from a code. */
+.radio-row.is-rcm .radio-who {
+  color: var(--qt-fg-3);
+  font-weight: 400;
+}
+
+/* The public feed, tagged exactly as band 4 tags a pinned rival's trace: the
+ * same WARNING the rival chip uses, so one colour means one tier across the
+ * whole window. */
+.radio-tier {
+  color: #f59e0b;
+  font-family: var(--qt-mono);
+  font-size: 8px;
+  letter-spacing: 0.5px;
+}
+
+.radio-text {
+  color: var(--qt-fg-2);
+  /* Two lines, then the `title` attribute carries the rest - the same
+   * treatment the AGENTS radio card gives a transcript, so a long race
+   * control message cannot push nine events off the panel on its own. */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+}

--- a/tests/surfaces/test_pitwall_radio_feed.py
+++ b/tests/surfaces/test_pitwall_radio_feed.py
@@ -1,0 +1,202 @@
+"""The RADIO channel: `src/pitwall/radio_feed.py`, served inside the bulk payload.
+
+Every assertion is about an EFFECT the panel would show, not about a constant
+someone chose. The one that matters most is the first: it pins that the feed
+carries DRIVER RADIO with real three-letter codes. Before it existed the reader
+took its `{number: code}` map from `RadioPipelineRunner`, whose mapper slices on
+a `GP_Name` column only the FEATURED parquet has - so against the raw table it
+swallowed its own exception, returned `{}`, and every radio came out as the
+synthetic `D12`. Nothing raised, nothing logged at ERROR, the RCM half worked
+perfectly, and 0 of Melbourne's 14 driver radios were ever revealed. A test that
+only counted events would have been green through all of it.
+
+Runs against the REAL Melbourne 2025 corpus when it is on disk and skips when it
+is not, exactly as the bulk's own suite does: a curated install holds one race of
+seventy, and the radio corpus is a separate artefact that can be absent on its own.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.f1_strat_manager.data_cache import get_data_root
+from src.pitwall.host import PitwallHost
+from src.pitwall.radio_feed import RadioCorpus, unavailable
+from src.pitwall.session_data import SessionLaps
+
+MELBOURNE = (2025, "Melbourne")
+
+
+def _corpus_or_skip() -> RadioCorpus:
+    corpus = RadioCorpus.load(get_data_root(), *MELBOURNE)
+    if corpus is None:
+        pytest.skip("the 2025/Melbourne radio corpus is not in this install")
+    return corpus
+
+
+def _codes_or_skip() -> list[str]:
+    session = SessionLaps.load(get_data_root(), *MELBOURNE)
+    if session is None:
+        pytest.skip("2025/Melbourne is not in this install's curated data set")
+    return list(session.masked_view({}, 0.0)["drivers"])
+
+
+def _events(corpus: RadioCorpus, reveal: dict[str, int]) -> list[dict]:
+    return corpus.masked_view(reveal)["events"]
+
+
+def _of_kind(events: list[dict], kind: str) -> list[dict]:
+    return [event for event in events if event["kind"] == kind]
+
+
+class _FakeClient:
+    """The socket stands still so the host's own logic is what is measured."""
+
+    def __init__(self, payload=None):
+        self.latest = payload
+        self.connected = True
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+
+def _tick(reveal: dict[str, int], year: int = 2025, location: str = "Melbourne") -> dict:
+    drivers = {code: {"laps_completed": laps} for code, laps in reveal.items()}
+    return {
+        "seq": 1,
+        "arcade": {"year": year, "location": location, "global_t_min": 0.0, "drivers": drivers},
+    }
+
+
+def test_the_feed_carries_driver_radio_under_real_driver_codes():
+    """The whole race's radio, attributed to drivers the tower also shows.
+
+    The assertion is deliberately on the CODES and not on the count. A count
+    survives the `D12` degradation described in the module docstring; a code
+    does not, because `D12` is not a driver on any grid and never matches a row
+    in the timing tower beside it.
+    """
+    corpus = _corpus_or_skip()
+    codes = _codes_or_skip()
+    everything = _events(corpus, {code: 999 for code in codes})
+
+    radios = _of_kind(everything, "radio")
+    assert radios, "the race's driver radio never reaches the feed"
+    speakers = {event["driver"] for event in radios}
+    assert speakers <= set(codes), f"radio attributed to non-drivers: {speakers - set(codes)}"
+    assert all(len(code) == 3 for code in speakers), f"synthetic codes in the feed: {speakers}"
+
+
+def test_a_radio_waits_for_its_own_driver_and_an_rcm_waits_for_the_leader():
+    """The two reveal coordinates, on a RAGGED field - which is the normal one.
+
+    At 96 % of instants the running field spans two or three different laps, so
+    a feed cut at one shared lap leaks for the cars behind and lags the leaders
+    at the same time. Here one driver is deep into the race and everyone else is
+    at lap 5: his radio must be on screen and theirs must not, while race
+    control - which is not any one car's - follows the leader.
+    """
+    corpus = _corpus_or_skip()
+    codes = _codes_or_skip()
+    ahead = "NOR"
+    ragged = dict.fromkeys(codes, 5)
+    ragged[ahead] = 24
+
+    events = _events(corpus, ragged)
+    for radio in _of_kind(events, "radio"):
+        limit = 24 if radio["driver"] == ahead else 5
+        assert radio["lap"] <= limit, (
+            f"{radio['driver']}'s lap-{radio['lap']} radio is on screen "
+            f"while he has completed {limit}"
+        )
+    assert any(
+        radio["driver"] == ahead and radio["lap"] > 5 for radio in _of_kind(events, "radio")
+    ), "the driver who is 19 laps ahead gained nothing, so the reveal is not per driver"
+    for rcm in _of_kind(events, "rcm"):
+        assert rcm["lap"] <= 24, "race control ran ahead of the leader"
+
+
+def test_nothing_is_served_before_its_lap_is_over():
+    """Sweep every lap of the race: no event ever appears early.
+
+    The direction that matters. The coordinate is coarse - an event shows when
+    its lap is COMPLETE, so it is up to a lap late - and late is the honest
+    failure here, because the parquet stamps events in UTC and this window's
+    clock is SessionTime.
+    """
+    corpus = _corpus_or_skip()
+    codes = _codes_or_skip()
+    for lap in range(0, 58):
+        for event in _events(corpus, dict.fromkeys(codes, lap)):
+            assert event["lap"] <= lap, (
+                f"a {event['kind']} from lap {event['lap']} is on screen at lap {lap}"
+            )
+
+
+def test_a_rewind_takes_events_back_off_the_feed():
+    """The reason it is read from disk rather than gathered off the wire.
+
+    An accumulating feed grows only, so a seek backwards would leave messages
+    on screen from a part of the race the clock has un-run.
+    """
+    corpus = _corpus_or_skip()
+    codes = _codes_or_skip()
+    late = _events(corpus, dict.fromkeys(codes, 40))
+    rewound = _events(corpus, dict.fromkeys(codes, 5))
+
+    assert len(rewound) < len(late), "the feed did not shrink across a rewind"
+    assert all(event["lap"] <= 5 for event in rewound)
+
+
+def test_race_control_messages_do_not_print_their_car_twice():
+    """An RCM names its car inside the text, so the row carries no separate code.
+
+    Measured across all 24 races on disk: of the 492 rows carrying a
+    `driver_number`, 492 spell that number - and its code - inside the message.
+    """
+    corpus = _corpus_or_skip()
+    codes = _codes_or_skip()
+    rcms = _of_kind(_events(corpus, {code: 999 for code in codes}), "rcm")
+
+    assert rcms, "the race's control messages never reach the feed"
+    assert all(rcm["driver"] is None for rcm in rcms)
+    assert all(rcm["text"] for rcm in rcms), "a race control row reached the panel with no words"
+
+
+def test_a_race_with_no_corpus_says_so_instead_of_going_quiet():
+    """Absent data is a state, not a blank.
+
+    The twin F7 caught one sprint ago, on this same shape: `get_bulk` had an
+    explicit unavailable payload and `get_live_lap` did not, so pointing the
+    arcade at a race with no parquet left the PREVIOUS race's numbers on screen.
+    A feed that answered with an empty list would repeat it one channel over.
+    """
+    assert unavailable() == {"available": False, "events": []}
+    assert RadioCorpus.load(get_data_root(), 2025, "Shanghai") is None
+
+
+def test_the_feed_rides_in_the_bulk_and_a_race_switch_empties_it():
+    """Served through `get_bulk`, and gone when the race it belongs to is.
+
+    It has no revision of its own on purpose: it is a function of exactly what
+    signs the bulk - (year, location, reveal map) - and a second signature that
+    does not determine its payload is what #934 cost a sprint.
+    """
+    codes = _codes_or_skip()
+    _corpus_or_skip()
+    client = _FakeClient(_tick(dict.fromkeys(codes, 24)))
+    host = PitwallHost(client, window_count=1)
+
+    served = host.get_bulk(-1)
+    assert served["radio"]["available"] is True
+    assert served["radio"]["events"], "the bulk went out without the feed"
+
+    client.latest = _tick(dict.fromkeys(codes, 24), location="Shanghai")
+    switched = host.get_bulk(served["rev"])
+    assert switched["available"] is False, "the table did not follow the race switch"
+    assert switched["radio"] == {"available": False, "events": []}, (
+        "the previous race's radio stayed on screen beside a table that had gone empty"
+    )


### PR DESCRIPTION
Closes #938. Sprint 6, first PR.

## What

The ~260 x 416 px the ring leaves empty in its own column becomes the chronological team-radio and
race-control feed - the RaceX client's `Race Control Messages` panel with the driver radio merged in.

**The whole field, with a `BROADCAST` tag on every radio that is not our car's.** Víctor's call, and his
reason is the one that settles the tier question: *a real team receives the public broadcast radio
feed*, so rendering it is fidelity rather than a privilege we grant ourselves. It reads exactly as
band 4 reads a pinned rival's trace, in the same WARNING amber, so one colour means one tier across
the window. The AGENTS radio card is untouched - it is a per-lap verdict, this is the record.

## The correction to the sprint brief: the wire carries ONE lap, not the race

`strategy.per_agent.radio` does carry the transcripts, but `StrategyState.snapshot_dict`
(`src/arcade/strategy.py:179-182`) strips `per_agent` from every entry of `history_tail`. It exists
on `latest` and nowhere else. A feed built from that has to accumulate client-side, and that:
keeps events across a rewind the clock has taken back (`useBulk.ts:16` is the scar), starts
permanently empty on a mid-race attach, holes at 8x where laps are skipped, and dies when the
producer runs without `--strategy`, which DATA does not otherwise need.

So it is read off disk and masked by the clock - the shape `session_data.py` already argued for,
and the same one, so the two cannot drift. Still zero producer changes.

## It rides IN the bulk payload

The feed is a pure function of `(year, location, reveal map)`, which is `get_bulk`'s signature
exactly since #935 hardened it. Folding it in means there is no second revision to get wrong -
and *a signature that does not determine its payload is not a signature* is what #934 cost a sprint.

Measured on the real Melbourne payload: the bulk is **66,991 / 152,657 / 337,289 bytes** at reveal
L10 / L24 / L57, and the largest feed in the entire corpus (Monaco, 210 events) is **~31 KB**. +9 %
on the channel that already carries it.

## The reveal is a third coordinate, coarse on purpose

A driver radio from lap *L* shows once **that driver** has completed lap *L*; a race-control message
once **the leader** has. Never early, at most one lap late. It cannot be finer: both parquets stamp
in UTC while every clock here is SessionTime, which needs FastF1's `t0_date` - the blocker #931 and
#842 are already filed against. No anchor was invented.

## A defect caught before it shipped

`RadioPipelineRunner` builds its `{number: code}` map by slicing on `GP_Name`, a column only the
**featured** parquet carries. Against the raw `laps.parquet` this window reads, the mapper caught its
own exception, logged a warning and returned `{}` - so every radio came out as the synthetic `D12`,
which no reveal map can match. Executed: **0 of Melbourne's 14 driver radios were ever revealed**
while all 90 race-control rows were. A panel that looks like a working RCM feed on a race with no
team radio. The codes now come from the same raw frame the tower's own rows do, so the two agree by
construction.

## What was executed

| | |
|---|---|
| `tests/surfaces` | **224 passed** (7 new, in `test_pitwall_radio_feed.py`) |
| `smoke-data.mjs` | **102 checks OK** (12 new) |
| ruff 0.15.22 (the CI pin) | check + format clean |
| the real window | opened, captured DPI-aware, and **looked at** |

**Both guard sets were verified RED first.** Python: an empty code map plus the `D{n}` fallback -
two guards failed, including the one asserting real three-letter codes. UI: three mutations
(no reverse, tag everyone, drop transcript-less rows) - four named failures, each caught by its own
check, and the run also proved the row helper had to be tolerant or a dropped row kills the harness
with a stack instead of naming the cause. Both builds were confirmed to SUCCEED before the red runs
were believed; one earlier mutation attempt did not compile and was correctly rejected as evidence.

On the real window at lap 33: newest first from L32 down, `BROADCAST` amber on HAM and VER, `NOR`
untagged, race control dim and codeless, two-line clamp, and the header reading **47** so the cut is
never silent.

## Corpus reality, measured over all 24 races

`radios: max 74 (Las Vegas), median 22.5` - `rcm: max 180 (Monaco), median 65.5`. **23 of the 24
have zero transcribed radios and there is not one MP3 on disk**; only `australia` has a transcript
cache. A row with no words still renders: that a radio happened, from whom and on which lap is
information, and the runner's own contract already says so.

Of the 492 RCM rows across all races that name a car, **492** spell that number and its code inside
the message text, so the row carries no separate driver badge - it would print it twice.

## Out of scope

Band 3 (the race-pace grid) is the sprint's other half and lands separately. The feed is one merged
chronological list rather than the two tabs the real client uses; the panel is 260 px wide and a tab
strip costs 24 of its 260.