### PR TITLE
feat(pitwall): band 3, the race-pace grid

### DIFF
--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -1162,6 +1162,172 @@ check(
 );
 await emptyCtx.close();
 
+// --- Band 3: the race-pace grid -------------------------------------------
+
+/**
+ * Twenty drivers over fifty-seven laps, with the three lap-1 crashers carrying
+ * ONLY generated rows - which is what Melbourne really looks like, and what a
+ * grid keyed on the bulk's own keys silently renders as seventeen columns.
+ *
+ * `TOWER_ORDER` is ranked by POSITION; the numbers below are deliberately not
+ * in that order, so a grid that renders its columns in wire order and one that
+ * sorts them stably by car number cannot both pass.
+ */
+const PACE_LAPS = 57;
+const PACE_FASTEST = { code: TOWER_ORDER[3], lap: 30, time: 84.111 };
+
+function paceBulk() {
+  const drivers = {};
+  TOWER_ORDER.forEach((code, index) => {
+    const number = String((index * 7 + 1) % 88);
+    if (RETIRED_CODES.includes(code)) {
+      // Generated-only: rendered, counted in nothing.
+      drivers[code] = {
+        number, laps_revealed: 0, stops: 0, crossings: {},
+        laps: [{ lap: 1, t: null, lap_time: null, s1: null, s2: null, s3: null,
+          v1: null, v2: null, vfl: null, vst: null, position: null, compound: null,
+          tyre_life: null, stint: null, track_status: "1", pit_in: false, pit_out: false,
+          deleted: false, generated: true, pb: false }],
+        best: { lap: null, lap_time: null, s1: null, s2: null, s3: null,
+          v1: null, v2: null, vfl: null, vst: null, compound: null },
+        theoretical: null,
+      };
+      return;
+    }
+    const laps = [];
+    let best = null;
+    for (let lap = 1; lap <= PACE_LAPS; lap += 1) {
+      const pitIn = lap === 20 && index % 5 === 0;
+      const pitOut = lap === 21 && index % 5 === 0;
+      const isFastest = code === PACE_FASTEST.code && lap === PACE_FASTEST.lap;
+      // Laps 2-6 are the safety car, and they are in this fixture because the
+      // REAL race has them: measured on Melbourne 2025, 82.4 % of laps sit
+      // past +10 % of the session best, so a heat scale anchored on that best
+      // paints four fifths of the grid one colour. A tidy fixture cannot tell
+      // the two scales apart - this one can.
+      const neutralised = lap >= 2 && lap <= 6;
+      const green = 85 + (index % 9) * 0.4 + ((lap * 3) % 11) * 0.2;
+      const time = isFastest ? PACE_FASTEST.time : neutralised ? green * 2.4 : green;
+      if (!pitIn && !pitOut && (best === null || time < best)) best = time;
+      laps.push({ lap, t: lap * 90, lap_time: pitIn || pitOut ? time + 22 : time,
+        s1: 29, s2: 30, s3: 26, v1: 301, v2: 289, vfl: 280, vst: 321,
+        position: index + 1, compound: "MEDIUM", tyre_life: lap, stint: 1,
+        track_status: "1", pit_in: pitIn, pit_out: pitOut, deleted: false,
+        generated: false, pb: false });
+    }
+    drivers[code] = { number, laps_revealed: PACE_LAPS, stops: 1, crossings: {}, laps,
+      best: { lap: PACE_FASTEST.lap, lap_time: best, s1: 29, s2: 30, s3: 26,
+        v1: 301, v2: 289, vfl: 280, vst: 321, compound: "MEDIUM" },
+      theoretical: 85 };
+  });
+  return { rev: 1, available: true, race: { year: 2025, location: "Melbourne", total_laps: PACE_LAPS },
+    drivers, radio: { available: true, events: [] } };
+}
+
+const paceCtx = await browser.newContext({ viewport: { width: 1485, height: 833 } });
+const pacePage = await paceCtx.newPage();
+pacePage.on("pageerror", (error) => failures.push(`pageerror(pace): ${error.message}`));
+await pacePage.addInitScript(
+  ([payload, bulk, live]) => {
+    window.pywebview = { api: {
+      get_tick: async (s) => (s === payload.seq ? null : payload),
+      get_bulk: async (r) => (r === bulk.rev ? null : bulk),
+      get_live_lap: async (r) => (r === live.rev ? null : live),
+      get_connection: async () => "Connected",
+    } };
+  },
+  [tick(1, { drivers: towerField(), order: TOWER_ORDER }), paceBulk(), towerLive()],
+);
+await pacePage.goto(url, { waitUntil: "domcontentloaded" });
+await pacePage.waitForSelector(".tab-strip", { timeout: 5000 });
+
+// The ring and the traces own the column until the reader asks for the grid.
+check((await pacePage.locator(".ring").count()) === 1, "the TRACES tab opens with the ring on it");
+check((await pacePage.locator(".pace-table").count()) === 0, "and the grid is not mounted yet");
+
+await pacePage.getByRole("tab", { name: "RACE PACE" }).click();
+await pacePage.waitForSelector(".pace-table", { timeout: 5000 });
+await pacePage.waitForTimeout(400);
+
+// Measured, not assumed: with the 260 px ring column still mounted the grid
+// gets 555 px, its columns fall to 25.25 px against 25 px of text and 1,101 of
+// 1,140 cells clip. There is no arrangement that keeps both.
+check((await pacePage.locator(".ring").count()) === 0, "the ring hides on the RACE PACE tab");
+check((await pacePage.locator(".radio-feed").count()) === 0, "and the radio feed hides with it");
+
+const paceHead = await pacePage.evaluate(() =>
+  [...document.querySelectorAll(".pace-table thead th")].slice(1).map((h) => h.textContent),
+);
+check(paceHead.length === 20, `twenty columns, including the three with only generated rows (${paceHead.length})`);
+check(
+  new Set(paceHead).size === 20 && paceHead.every((code) => TOWER_ORDER.includes(code)),
+  "every driver the wire names gets a column, exactly once",
+);
+// Stable across the race: `race_order` re-sorts every time two cars swap, and
+// a history grid whose columns move is a history nobody can read back.
+check(
+  JSON.stringify(paceHead) !== JSON.stringify(TOWER_ORDER),
+  "the columns are NOT in position order, which changes under the reader",
+);
+
+const paceCells = await pacePage.evaluate(() => {
+  const cells = [...document.querySelectorAll(".pace-table td")];
+  const tone = (name) => cells.filter((c) => c.className === `is-${name}`).length;
+  return {
+    total: cells.length,
+    clipped: cells.filter((c) => c.scrollWidth > c.clientWidth).length,
+    best: tone("best"), t1: tone("t1"), t2: tone("t2"), t3: tone("t3"),
+    pit: tone("pit"), out: tone("out"), none: tone("none"),
+    pitText: cells.find((c) => c.className === "is-pit")?.textContent,
+    outText: cells.find((c) => c.className === "is-out")?.textContent,
+    rows: document.querySelectorAll(".pace-table tbody tr").length,
+  };
+});
+
+// EFFECT, not mechanism. `overflow-x` on the container reports zero for every
+// variant that clips - only the cell's own scrollWidth sees the digits cut,
+// which is how a 0.27 px "fit" measured as a pass right up to the screenshot.
+check(paceCells.clipped === 0, `no lap time is cut (${paceCells.clipped}/${paceCells.total} clipped)`);
+check(paceCells.rows === PACE_LAPS, `one row per lap of the race (${paceCells.rows})`);
+check(paceCells.pitText === "IN PIT" && paceCells.outText === "OUT",
+  "the in-lap and the out-lap replace the time, as a timing screen shows them");
+check(paceCells.best === 1, `exactly one purple cell - the session's fastest lap (${paceCells.best})`);
+
+// The reason the colour ranks each lap against ITSELF. Anchored on the session
+// best with fixed percentage bands, 82.4 % of the real Melbourne payload lands
+// in one colour, because the race was wet and ran safety cars.
+const spread = [paceCells.t1, paceCells.t2, paceCells.t3];
+check(
+  spread.every((count) => count > 0) && Math.max(...spread) < paceCells.total * 0.75,
+  `the heat scale uses all three tones rather than painting one (${spread.join(" / ")})`,
+);
+
+// The check that actually separates the two scales, and the ONLY one that
+// does - the tidy laps look the same under both. Under a neutralisation the
+// whole field is bunched, so any fixed percentage band collapses it into one
+// or two tones and stops discriminating at exactly the moment a strategist is
+// reading the grid. Measured on a mutated copy that banded at 1.5 % / 4 %:
+// 40 / 45 / 0, the slowest tone empty across all five laps. Ranking inside the
+// lap splits the field whatever the spread.
+const scLaps = await pacePage.evaluate(() => {
+  const rows = [...document.querySelectorAll(".pace-table tbody tr")].slice(1, 6);
+  const tones = {};
+  for (const row of rows) {
+    for (const cell of row.querySelectorAll("td")) {
+      if (cell.textContent === "") continue;
+      tones[cell.className] = (tones[cell.className] ?? 0) + 1;
+    }
+  }
+  return tones;
+});
+const scSpread = ["is-t1", "is-t2", "is-t3"].map((k) => scLaps[k] ?? 0);
+check(
+  scSpread.every((count) => count > 0),
+  `under the safety car the grid still ranks the field instead of painting it one colour (${scSpread.join(" / ")})`,
+);
+
+await paceCtx.close();
+
 await browser.close();
 server.close();
 

--- a/src/pitwall/ui/src/features/data/DataWindow.tsx
+++ b/src/pitwall/ui/src/features/data/DataWindow.tsx
@@ -21,8 +21,11 @@
  * band-height-budget.md`; the drawn layout is in the project's memory.
  */
 
+import { useState } from "react";
+
 import { BestsPanel } from "./BestsPanel";
 import { OwnCarTraces } from "./OwnCarTraces";
+import { RacePaceGrid } from "./RacePaceGrid";
 import { RadioFeed } from "./RadioFeed";
 import { StatusStrip } from "./StatusStrip";
 import { TimingTower } from "./TimingTower";
@@ -45,6 +48,7 @@ export function DataWindow() {
   // stops. `useStatusText` is keyed on the sequence for that reason.
   const status = tick ? { text: `lap ${tick.arcade.lap} · live`, transient: true } : WAITING;
   const statusText = useStatusText(status, tick?.seq ?? null);
+  const [tab, setTab] = useState<"traces" | "pace">("traces");
 
   return (
     <main className="data-window">
@@ -56,12 +60,35 @@ export function DataWindow() {
               <TimingTower arcade={tick.arcade} bulk={bulk} live={liveLap} />
               <BestsPanel bulk={bulk} />
             </div>
-            <div className="band4">
-              <OwnCarTraces tick={tick} discontinuity={discontinuity} />
-              <div className="side-column">
-                <TrackRing arcade={tick.arcade} />
-                <RadioFeed bulk={bulk} driverMain={tick.arcade.driver_main} />
-              </div>
+            <div className="right-column">
+              {/* The tab strip the delivery plan put here. Band 3 needs the
+                  full 825 px of this column - measured: with the ring still
+                  mounted its cells clip 1,101 of 1,140 - so the two worlds
+                  take turns rather than share. */}
+              <nav className="tab-strip" role="tablist">
+                {(["traces", "pace"] as const).map((id) => (
+                  <button
+                    key={id}
+                    role="tab"
+                    aria-selected={tab === id}
+                    className={tab === id ? "tab is-active" : "tab"}
+                    onClick={() => setTab(id)}
+                  >
+                    {id === "traces" ? "TRACES" : "RACE PACE"}
+                  </button>
+                ))}
+              </nav>
+              {tab === "traces" ? (
+                <div className="band4">
+                  <OwnCarTraces tick={tick} discontinuity={discontinuity} />
+                  <div className="side-column">
+                    <TrackRing arcade={tick.arcade} />
+                    <RadioFeed bulk={bulk} driverMain={tick.arcade.driver_main} />
+                  </div>
+                </div>
+              ) : (
+                <RacePaceGrid bulk={bulk} order={tick.arcade.race_order} />
+              )}
             </div>
           </div>
         ) : (

--- a/src/pitwall/ui/src/features/data/RacePaceGrid.tsx
+++ b/src/pitwall/ui/src/features/data/RacePaceGrid.tsx
@@ -1,0 +1,80 @@
+/**
+ * Band 3 - the race-pace grid, a tab of the right column.
+ *
+ * One COLUMN per driver and one ROW per lap, which is the orientation the real
+ * client uses and the one a measurement chose rather than a preference. The
+ * transposed form the sprint-5 height gate proposed was derived against a
+ * stacked band model that has since died; measured against the column model at
+ * the right column's real width, transposing gives cells 13.5 px wide against
+ * 19-22 px of text and clips 1,121 of 1,140 - it can hold a colour and nothing
+ * else, and the number in the cell is the panel's whole point.
+ *
+ * **The ring and the radio feed hide while this tab is open, and that is
+ * measured too.** With the 260 px ring column still mounted the grid gets
+ * 555 px, columns fall to 25.25 px against 25 px of text, and 1,101 of 1,140
+ * cells clip. There is no arrangement that keeps both.
+ *
+ * The lap axis scrolls, because it must: Monaco's 78 laps overflow the column
+ * on every machine in the fleet at every legible font size. It is pinned to
+ * the newest lap so the panel follows the race, and the header states the
+ * range on screen - a hidden scrollbar is not an affordance, and this window
+ * hides them globally.
+ */
+
+import { useEffect, useRef } from "react";
+
+import { racePaceGrid } from "../../lib/racePace";
+import type { Bulk } from "../../lib/bridge";
+
+export function RacePaceGrid({ bulk, order }: { bulk: Bulk | null; order: string[] }) {
+  const grid = racePaceGrid(bulk, order);
+  const scroller = useRef<HTMLDivElement | null>(null);
+
+  // Pinned to the newest lap. A race-pace grid that opens at lap 1 shows the
+  // formation lap of a race that is on lap 40, and the laps a strategist is
+  // deciding on are always the last few. Re-pinned on every reveal, which is
+  // about once every four and a half seconds.
+  useEffect(() => {
+    const box = scroller.current;
+    if (box) box.scrollTop = box.scrollHeight;
+  }, [grid.laps.length]);
+
+  const first = grid.laps[0];
+  const last = grid.laps[grid.laps.length - 1];
+
+  return (
+    <section className="card pace">
+      <header className="pace-header">
+        <span className="pace-title">RACE PACE</span>
+        <span className="pace-subtitle">colour ranks each lap against itself</span>
+        <span className="pace-range">
+          {grid.laps.length ? `LAPS ${first}-${last}` : "no laps revealed"}
+        </span>
+      </header>
+      <div className="pace-scroll" ref={scroller}>
+        <table className="pace-table">
+          <thead>
+            <tr>
+              <th className="pace-lapcol" />
+              {grid.columns.map((code) => (
+                <th key={code}>{code}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {grid.rows.map((row, index) => (
+              <tr key={grid.laps[index]}>
+                <th className="pace-lapcol">{grid.laps[index]}</th>
+                {row.map((cell, column) => (
+                  <td key={grid.columns[column]} className={`is-${cell.tone}`}>
+                    {cell.text}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/src/pitwall/ui/src/lib/racePace.ts
+++ b/src/pitwall/ui/src/lib/racePace.ts
@@ -1,0 +1,204 @@
+/**
+ * The race-pace grid: one cell per driver per lap, coloured by how that lap
+ * ranked AGAINST THE SAME LAP.
+ *
+ * This is the RaceX client's Run Timeline, the panel the research found
+ * occupies more screen area than anything else on a real wall.
+ *
+ * **The colour is a RANK within the lap, not a percentage off a session best,
+ * and the difference is the whole design.** Measured on the real Melbourne
+ * 2025 payload: against the session's fastest lap the median lap is +13.79 %
+ * and 82.4 % of the race falls past +10 %, because the race was wet and ran
+ * safety cars - so any fixed percentage band paints four fifths of the grid in
+ * one colour and says nothing. Ranked inside its own lap instead, the field
+ * splits into thirds by construction on every lap of every race, wet or dry,
+ * green or neutralised, with no threshold tuned on the one race that happens
+ * to be on this disk. It is also what "race pace" means to a strategist: who
+ * is quick RIGHT NOW, not who set the best lap two hours ago.
+ *
+ * The absolute time is in the cell, so the colour never has to carry a value
+ * the reader cannot check.
+ *
+ * One cell is purple: the session's outright fastest revealed lap. That is the
+ * same rule the tower's sector cells use, and it comes from the same module
+ * (`sessionBests`) rather than a second reduction over `bulk.drivers` - two
+ * panels disagreeing about which lap was quickest is the twin this repo pays
+ * for most often.
+ */
+
+import type { Bulk, LapRow } from "./bridge";
+import { sessionBests } from "./sessionBests";
+
+/**
+ * What a cell paints. `best` is the session's fastest; `t1`/`t2`/`t3` are the
+ * thirds of the lap's own ranking; `pit` and `out` are the in-lap and out-lap;
+ * `none` is a lap the driver has no time for, revealed or not.
+ */
+export type PaceTone = "best" | "t1" | "t2" | "t3" | "pit" | "out" | "none";
+
+export interface PaceCell {
+  text: string;
+  tone: PaceTone;
+}
+
+export interface PaceGrid {
+  /** Lap numbers, ascending. Empty until something is revealed. */
+  laps: number[];
+  /** Driver codes in WIRE order, which is the only order that holds mid-lap. */
+  columns: string[];
+  /** `rows[i][j]` is lap `laps[i]` for driver `columns[j]`. */
+  rows: PaceCell[][];
+}
+
+const EMPTY: PaceCell = { text: "", tone: "none" };
+
+/**
+ * The column order: every driver the wire names, sorted by CAR NUMBER.
+ *
+ * **Which drivers comes from the wire, the order does not, and the two halves
+ * have different reasons.** The wire's `race_order` is the only list that
+ * carries all twenty - three of Melbourne's crashed on lap 1 and have nothing
+ * but generated rows, so a grid keyed on the bulk renders seventeen columns
+ * and loses them silently. But `race_order` is ranked by POSITION, and a
+ * position-ranked grid re-sorts its own columns every time two cars swap: the
+ * reader looks back at lap 12 and it is in a different place than it was a
+ * moment ago. A car number never changes for the whole race, which is what a
+ * history panel needs and what a timing sheet has always used.
+ *
+ * A driver with no number keeps his wire position, so an unknown never
+ * collapses several columns onto one sort key.
+ */
+function stableColumns(bulk: Bulk, order: string[]): string[] {
+  const keyed = order.map((code, index) => {
+    const raw = bulk.drivers[code]?.number;
+    const number = raw === null || raw === undefined ? null : Number.parseInt(raw, 10);
+    return { code, index, number: Number.isNaN(number as number) ? null : number };
+  });
+  keyed.sort((left, right) => {
+    if (left.number === null || right.number === null) return left.index - right.index;
+    return left.number - right.number;
+  });
+  return keyed.map((entry) => entry.code);
+}
+
+/**
+ * `m:ss.d` - the broadcast form, truncated to tenths.
+ *
+ * **The truncation is what makes the grid fit at all.** Measured against the
+ * real built stylesheet at the right column's real width: twenty columns of
+ * 38.75 px hold this form with room to spare, while the same cell in seconds
+ * (`149.413`) clips 793 of 1140 cells the moment a cell carries one pixel of
+ * padding. Tenths is also the resolution the grid needs, because the ranking
+ * colour carries the ordering and the number carries the magnitude.
+ */
+export function paceLabel(seconds: number): string {
+  const minutes = Math.floor(seconds / 60);
+  const rest = seconds - minutes * 60;
+  return `${minutes}:${rest.toFixed(1).padStart(4, "0")}`;
+}
+
+/**
+ * The lap a driver has for that number, or null.
+ *
+ * A `generated` row is FastF1's synthetic stand-in for a car that did not
+ * finish the lap. It is rendered as nothing and counts towards nothing - its
+ * `Time` stamp sorts before the entire field, which is how a naive ranking
+ * puts the lap-1 crashers on the podium.
+ */
+function timedRow(row: LapRow | undefined): LapRow | null {
+  if (row === undefined || row.generated) return null;
+  return row;
+}
+
+/** In and out laps are not racing laps and never enter a ranking. */
+function isRacingLap(row: LapRow): boolean {
+  return !row.pit_in && !row.pit_out && !row.deleted && row.lap_time !== null;
+}
+
+/**
+ * Each lap's ranked racing times, so a cell can ask where it placed.
+ *
+ * Built once for the whole grid rather than per cell: a per-cell scan is
+ * O(drivers^2) per lap and this runs on every reveal.
+ */
+function rankedByLap(byDriver: Map<string, Map<number, LapRow>>, laps: number[]) {
+  const ranked = new Map<number, number[]>();
+  for (const lap of laps) {
+    const times: number[] = [];
+    for (const rows of byDriver.values()) {
+      const row = timedRow(rows.get(lap));
+      if (row && isRacingLap(row)) times.push(row.lap_time as number);
+    }
+    times.sort((left, right) => left - right);
+    ranked.set(lap, times);
+  }
+  return ranked;
+}
+
+/**
+ * Which third of the lap this time placed in.
+ *
+ * Ceil rather than floor on the boundaries, so a field of four splits 2/1/1
+ * instead of leaving the last third empty. A lap with fewer than three timed
+ * cars has no meaningful thirds and everything in it reads as the top one -
+ * which is honest: with two cars running, both ARE the field.
+ */
+function tone(times: number[], value: number): PaceTone {
+  const index = times.indexOf(value);
+  if (index < 0 || times.length < 3) return "t1";
+  const third = times.length / 3;
+  if (index < third) return "t1";
+  if (index < third * 2) return "t2";
+  return "t3";
+}
+
+/**
+ * The grid for what the clock has revealed.
+ *
+ * **Columns come from the wire's `order`, never from the bulk's keys.** Three
+ * of Melbourne's twenty drivers crashed on lap 1 and have only `generated`
+ * rows, so a grid keyed on the bulk renders seventeen columns and silently
+ * loses them. The wire always carries twenty.
+ *
+ * The bottom edge is RAGGED on purpose: the reveal is per driver and strict,
+ * and at most instants the field spans two or three different laps.
+ */
+export function racePaceGrid(bulk: Bulk | null, order: string[]): PaceGrid {
+  if (!bulk?.available) return { laps: [], columns: [...order], rows: [] };
+  const columns = stableColumns(bulk, order);
+
+  const byDriver = new Map<string, Map<number, LapRow>>();
+  let lastLap = 0;
+  for (const code of columns) {
+    const rows = new Map<number, LapRow>();
+    for (const row of bulk.drivers[code]?.laps ?? []) {
+      rows.set(row.lap, row);
+      if (!row.generated && row.lap > lastLap) lastLap = row.lap;
+    }
+    byDriver.set(code, rows);
+  }
+
+  const laps = Array.from({ length: lastLap }, (_, index) => index + 1);
+  const ranked = rankedByLap(byDriver, laps);
+  const fastest = sessionBests(bulk).lap_time[0] ?? null;
+
+  const rows = laps.map((lap) =>
+    columns.map((code) => {
+      const row = timedRow(byDriver.get(code)?.get(lap));
+      if (row === null) return EMPTY;
+      if (row.pit_in) return { text: "IN PIT", tone: "pit" as PaceTone };
+      if (row.pit_out) return { text: "OUT", tone: "out" as PaceTone };
+      if (row.lap_time === null) return EMPTY;
+      const text = paceLabel(row.lap_time);
+      // The session's fastest lap is purple wherever it appears, matching the
+      // tower's sector code. Compared on the VALUE and the driver together:
+      // two drivers can set the identical time to the millisecond, and only
+      // one of them set the session's best.
+      if (fastest && fastest.code === code && fastest.value === row.lap_time) {
+        return { text, tone: "best" as PaceTone };
+      }
+      return { text, tone: tone(ranked.get(lap) ?? [], row.lap_time) };
+    }),
+  );
+  return { laps, columns, rows };
+}

--- a/src/pitwall/ui/src/styles/data.css
+++ b/src/pitwall/ui/src/styles/data.css
@@ -805,3 +805,167 @@
   -webkit-line-clamp: 2;
   overflow: hidden;
 }
+
+/* --- The right column's tab strip, and band 3 --------------------------- */
+
+/* The two worlds take turns in this column rather than sharing it. Measured:
+ * band 3 with the ring still mounted gets 555 px, its columns fall to 25.25 px
+ * against 25 px of text, and 1,101 of 1,140 cells clip. There is no
+ * arrangement that keeps both. */
+.right-column {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 6px;
+  min-height: 0;
+}
+
+.tab-strip {
+  display: flex;
+  gap: 4px;
+}
+
+.tab {
+  background: none;
+  border: 1px solid var(--qt-border);
+  border-radius: 3px;
+  color: var(--qt-fg-3);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  padding: 3px 10px;
+}
+
+.tab.is-active {
+  background: var(--qt-elevated);
+  color: var(--qt-fg-1);
+}
+
+.pace {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px;
+  min-height: 0;
+}
+
+.pace-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 0 2px;
+}
+
+.pace-title {
+  color: var(--qt-fg-1);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 1px;
+}
+
+.pace-subtitle {
+  color: var(--qt-fg-3);
+  font-size: 10px;
+}
+
+/* The lap axis scrolls because it must - Monaco's 78 laps overflow this column
+ * on every machine at every legible size - and scrollbars are hidden globally,
+ * so this range is the affordance. It says which laps are on screen; a hidden
+ * scrollbar says nothing at all. */
+.pace-range {
+  color: var(--qt-fg-3);
+  font-family: var(--qt-mono);
+  font-size: 10px;
+  margin-left: auto;
+}
+
+.pace-scroll {
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.pace-table {
+  border-collapse: collapse;
+  font-family: var(--qt-mono);
+  /* 9 px, not the 10 the height gate blessed for the TOWER, and the screenshot
+   * is why. At 10 px `1:29.4` measures 39 px inside a 38.75 px column: nothing
+   * clips - `scrollWidth > clientWidth` counted zero of 760 cells on the live
+   * page - and the grid is still unreadable, because adjacent cells touch and
+   * twenty lap times run together into one string. At 9 px the same text is
+   * 33.2 px and leaves 5.5 px of gutter. A cell with a visible edge at 9 px
+   * reads better than a legible glyph with none. */
+  font-size: 9px;
+  font-variant-numeric: tabular-nums;
+  table-layout: fixed;
+  width: 100%;
+}
+
+/* One row-height token, one place. The tower's 20 px is a literal in this
+ * stylesheet and the sprint-5 gate asked for a token instead; band 3 does not
+ * get to add a second literal, and nothing in TSX may copy this number - a
+ * consumer that needs it reads it with `getComputedStyle`. */
+.pace-table th,
+.pace-table td {
+  height: var(--pace-row-h, 12px);
+  line-height: var(--pace-row-h, 12px);
+  overflow: hidden;
+  padding: 0 1px;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.pace-table thead th {
+  background: var(--qt-panel);
+  color: var(--qt-fg-3);
+  font-weight: 700;
+  position: sticky;
+  top: 0;
+}
+
+/* The columns are separated by SHADE rather than by a rule, because a 1 px
+ * border costs a pixel the cell does not have: twenty of them take 20 px off
+ * an 803 px row and put every lap time back over its column's width. Banding
+ * costs nothing and does the same job. */
+.pace-table tbody td:nth-child(even) {
+  background: var(--qt-elevated);
+}
+
+.pace-lapcol {
+  color: var(--qt-fg-3);
+  font-weight: 400;
+  width: 26px;
+}
+
+/* Purple is the session's outright fastest lap, the same rule and the same
+ * colour the tower's sector cells use. */
+.pace-table td.is-best {
+  color: #a78bfa;
+  font-weight: 700;
+}
+
+/* The thirds of each lap's own ranking. Ranked rather than banded because a
+ * fixed percentage off the session best puts 82.4 % of a wet, safety-car race
+ * in one colour - measured on the real Melbourne payload. */
+.pace-table td.is-t1 {
+  color: #10b981;
+}
+
+.pace-table td.is-t2 {
+  color: var(--qt-fg-2);
+}
+
+.pace-table td.is-t3 {
+  color: #f59e0b;
+}
+
+/* The in-lap and the out-lap, red in place of the time, as a timing screen
+ * shows them. */
+.pace-table td.is-pit,
+.pace-table td.is-out {
+  color: #ef4444;
+}
+
+.pace-table td.is-none {
+  color: var(--qt-fg-3);
+}


### PR DESCRIPTION
Closes #940. Sprint 6, second PR. Sits on top of #939.

## The orientation, measured

The sprint-5 height gate recommended transposing band 3. That recommendation was derived against
the STACKED band model, which died when the layout became two columns, so sprint 6 measured it
again before drawing anything - real built stylesheets, real `--qt-mono`, viewport 1485 x 833 at
`deviceScaleFactor 1.5`, the gate's own measured content box, and **the clip counted per cell**
(`scrollWidth > clientWidth`), because `overflow-x` on the container reports zero for every variant
that clips. That is the mechanism-level lie: the *table* fits, the *numbers* do not.

```
variant                           colW   text    clipped      rows     ovf
A 9px secs 149.413               38.75     39   793/1140     57/57      -3
A 9px TENTHS 1:29.4              38.75     39     0/1140     57/57      -3
A 10px tenths                    38.75     39     0/1140     52/57      55
A 10px tenths MONACO 78          38.75     39     0/1560     52/78     328
A 10px tenths WITH RING          25.25     25  1101/1140     52/57      55
B transposed 11px                13.52     22  1121/1140     20/20    -279
```

- **B is out**: 13.5 px cells against 19-22 px of text. A colour and nothing else, and the number in
  the cell is the panel's whole point.
- **The ring cannot stay**: 1,101 of 1,140 cells clip beside it. The radio feed from #939 hides with
  it; both live on the TRACES tab and the reader chose RACE PACE.
- **The gate's F4 was right and this reproduces it**: its best variant clips 793 of 1,140 the moment
  a cell carries one pixel of padding. `m:ss.d` is one character shorter and fits with real slack.

## What the screenshot found that the measurement did not

At 10 px **nothing clips** - zero of 760 cells on the live page - and the grid was still unreadable:
adjacent cells touch, and twenty lap times run together into one string. Dropped to 9 px, which
leaves a real gutter, and separated the columns by **shade rather than by a rule**: twenty 1 px
borders take 20 px off an 803 px row and put every lap time back over its column.

The same look also caught the columns re-sorting themselves. `race_order` is ranked by POSITION, so
the grid reshuffled every time two cars swapped and lap 12 moved under the reader. **Which** drivers
still comes from the wire - three of twenty have only generated rows and a bulk-keyed grid renders
seventeen - but the **order** is by car number, which never changes.

## The heat scale ranks each lap against itself

Not a percentage off the session best. Measured on the real Melbourne payload: the median lap is
**+13.79 %** off that best and **82.4 %** of the race sits past +10 %, because the race was wet and
ran safety cars. Any fixed band paints four fifths of the grid one colour and says nothing. Ranked
inside its own lap the field splits into thirds on every lap of every race, with no threshold tuned
on the one race that happens to be on this disk - and it is what "race pace" means to a strategist:
who is quick right now. One cell is purple, the session's outright fastest, from `sessionBests`
rather than a second reduction.

## What was executed

| | |
|---|---|
| `smoke-data.mjs` | **115 checks OK** (13 new) |
| `tests/surfaces/test_pitwall_tokens.py` | 11 passed - every colour is already a name in `palette.py` |
| typecheck + ruff 0.15.22 (the CI pin) | clean |
| the live app | driven, RACE PACE clicked, measured and **looked at** |

On the live page at lap 41: 20 columns in car-number order (VER 1, NOR 4, BOR 5, HAD 6, DOO 7,
GAS 10 …), 40 lap rows, **0 of 800 cells clipped**, pinned to the newest lap, `LAPS 1-40` in the
header, one purple cell matching the bests panel, and `IN PIT` across the whole field on laps 2-4 -
which is the real race, verified against the parquet: 17 cars carry both `PitInTime` and
`PitOutTime` on those laps under track status 4.

**Verified red first**, three mutations, each caught by its own check: wire-order columns, an 11 px
font, and a percentage heat scale. The third only failed once the fixture carried a **neutralised
block** - a tidy fixture cannot separate the two scales, which is the same lesson the real
distribution taught the design. Both builds were confirmed to succeed before any red was believed;
two mutation attempts did not compile and were correctly rejected as evidence.

## Named, not hidden

Monaco's 78 laps overflow this column on every machine in the fleet at every legible size, so the
lap axis scrolls - and because scrollbars are hidden globally, the header states the range on screen
(`LAPS 1-40`). A hidden scrollbar is not an affordance. The grid is pinned to the newest lap.