### PR TITLE
fix(pitwall): the four the sprint-6 exit gate found

### DIFF
--- a/src/pitwall/host.py
+++ b/src/pitwall/host.py
@@ -296,9 +296,21 @@ class PitwallHost:
         comes to serve the previous race - which is the twin this repo pays for
         most often, and which F7 caught between these very two channels one
         sprint ago.
+
+        **And the malformed-tick return clears them, which it did not.** One
+        invalidation point is not enough if there is an early return above it:
+        a tick naming no race sent the TABLE to its unavailable payload while
+        `_masked_view` went on serving the previous race's radio out of a
+        corpus this method had skipped over - 46 messages of a race the panel
+        beside it had already given up on. Not reachable from today's producer,
+        which always publishes an int year and a str location, and fixed anyway
+        because the branch exists to be defensive and was not.
         """
         year, location = arcade.get("year"), arcade.get("location")
         if not isinstance(year, int) or not isinstance(location, str):
+            self._session_key = None
+            self._session = None
+            self._radio = None
             return None
         if self._session_key != (year, location):
             self._session_key = (year, location)

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -1178,8 +1178,15 @@ const PACE_FASTEST = { code: TOWER_ORDER[3], lap: 30, time: 84.111 };
 
 function paceBulk() {
   const drivers = {};
+  // One driver has no car number and one is missing from the bulk entirely.
+  // Both are typed as possible (`DriverLaps.number` is `string | null`) and
+  // neither appeared in any fixture, so the guards below could not see an
+  // intransitive sort or a column keyed on the bulk.
+  const NO_NUMBER = TOWER_ORDER[6];
+  const ABSENT_FROM_BULK = TOWER_ORDER[9];
   TOWER_ORDER.forEach((code, index) => {
-    const number = String((index * 7 + 1) % 88);
+    if (code === ABSENT_FROM_BULK) return;
+    const number = code === NO_NUMBER ? null : String((index * 7 + 1) % 88);
     if (RETIRED_CODES.includes(code)) {
       // Generated-only: rendered, counted in nothing.
       drivers[code] = {
@@ -1208,11 +1215,15 @@ function paceBulk() {
       const neutralised = lap >= 2 && lap <= 6;
       const green = 85 + (index % 9) * 0.4 + ((lap * 3) % 11) * 0.2;
       const time = isFastest ? PACE_FASTEST.time : neutralised ? green * 2.4 : green;
-      if (!pitIn && !pitOut && (best === null || time < best)) best = time;
+      // Melbourne really carries deleted racing laps - six of them - and every
+      // row of this fixture used to say `deleted: false`, so the branch that
+      // paints them was never entered by any check.
+      const deleted = lap === 44 && index % 3 === 0;
+      if (!pitIn && !pitOut && !deleted && (best === null || time < best)) best = time;
       laps.push({ lap, t: lap * 90, lap_time: pitIn || pitOut ? time + 22 : time,
         s1: 29, s2: 30, s3: 26, v1: 301, v2: 289, vfl: 280, vst: 321,
         position: index + 1, compound: "MEDIUM", tyre_life: lap, stint: 1,
-        track_status: "1", pit_in: pitIn, pit_out: pitOut, deleted: false,
+        track_status: "1", pit_in: pitIn, pit_out: pitOut, deleted,
         generated: false, pb: false });
     }
     drivers[code] = { number, laps_revealed: PACE_LAPS, stops: 1, crossings: {}, laps,
@@ -1258,7 +1269,38 @@ check((await pacePage.locator(".radio-feed").count()) === 0, "and the radio feed
 const paceHead = await pacePage.evaluate(() =>
   [...document.querySelectorAll(".pace-table thead th")].slice(1).map((h) => h.textContent),
 );
-check(paceHead.length === 20, `twenty columns, including the three with only generated rows (${paceHead.length})`);
+check(paceHead.length === 20, `every driver the wire names gets a column (${paceHead.length})`);
+// One of them is absent from `bulk.drivers` altogether. The design says the
+// wire decides WHO races; a grid that reduced over the bulk instead would be
+// one column short and nothing would say so. (The reason once given for this -
+// "the bulk renders seventeen" - was false: `masked_view` iterates every driver
+// it loaded, so the bulk carries all twenty at every reveal. The rule stands;
+// its old justification did not, and this check replaces it.)
+check(
+  paceHead.includes(TOWER_ORDER[9]),
+  "a driver the bulk does not name still gets his column from the wire",
+);
+// Ascending by car number, with the unknown at the END rather than acting as a
+// barrier. Two orderings in one comparator is intransitive: measured on the
+// real bundle with one unknown at wire index 1, car 44 rendered ahead of car 1.
+const paceNumbers = await pacePage.evaluate(
+  ([head, bulkNumbers]) => head.map((code) => bulkNumbers[code] ?? null),
+  [paceHead, Object.fromEntries(Object.entries(paceBulk().drivers).map(([c, d]) => [c, d.number === null ? null : Number(d.number)]))],
+);
+const knownNumbers = paceNumbers.filter((n) => n !== null);
+check(
+  knownNumbers.every((n, i) => i === 0 || knownNumbers[i - 1] <= n),
+  `columns ascend by car number (${knownNumbers.join(",")})`,
+);
+// Every unknown at the END, as a suffix. There are two of them here - the
+// driver with a null number and the one the bulk never names - and the
+// assertion is that no numbered car sits behind either, which is exactly what
+// the intransitive comparator did: it stranded the cars before the unknown.
+const firstNull = paceNumbers.indexOf(null);
+check(
+  firstNull === -1 || paceNumbers.slice(firstNull).every((n) => n === null),
+  `unknown numbers sort to the end instead of stranding the cars before them (${paceNumbers.join(",")})`,
+);
 check(
   new Set(paceHead).size === 20 && paceHead.every((code) => TOWER_ORDER.includes(code)),
   "every driver the wire names gets a column, exactly once",
@@ -1292,6 +1334,32 @@ check(paceCells.rows === PACE_LAPS, `one row per lap of the race (${paceCells.ro
 check(paceCells.pitText === "IN PIT" && paceCells.outText === "OUT",
   "the in-lap and the out-lap replace the time, as a timing screen shows them");
 check(paceCells.best === 1, `exactly one purple cell - the session's fastest lap (${paceCells.best})`);
+
+// A deleted time is struck through and carries NO rank. It used to carry the
+// FASTEST one: the ranking excludes it, so `indexOf` answered -1, and -1 and
+// "top third" shared a branch. Measured on the real race, GAS's lap 54 was
+// last of fourteen and rendered the same green as the quickest.
+const deletedCells = await pacePage.evaluate(() => {
+  const rows = [...document.querySelectorAll(".pace-table tbody tr")];
+  const row = rows.find((r) => r.querySelector("th")?.textContent === "44");
+  const cells = [...(row?.querySelectorAll("td") ?? [])];
+  const struck = cells.filter((c) => c.className === "is-deleted");
+  return {
+    struck: struck.length,
+    line: struck[0] ? getComputedStyle(struck[0]).textDecorationLine : null,
+    text: struck[0]?.textContent ?? "",
+    fastestToned: cells.filter((c) => c.className === "is-t1").length,
+  };
+});
+check(deletedCells.struck > 0, `the deleted laps reach the grid (${deletedCells.struck})`);
+check(
+  deletedCells.line === "line-through",
+  `a deleted time is struck through, as the tower already shows it (${deletedCells.line})`,
+);
+check(
+  /^\d:\d\d\.\d$/.test(deletedCells.text),
+  `and it still shows its time rather than vanishing (${deletedCells.text})`,
+);
 
 // The reason the colour ranks each lap against ITSELF. Anchored on the session
 // best with fixed percentage bands, 82.4 % of the real Melbourne payload lands

--- a/src/pitwall/ui/src/features/data/RacePaceGrid.tsx
+++ b/src/pitwall/ui/src/features/data/RacePaceGrid.tsx
@@ -14,6 +14,14 @@
  * 555 px, columns fall to 25.25 px against 25 px of text, and 1,101 of 1,140
  * cells clip. There is no arrangement that keeps both.
  *
+ * Both of those counts come from the PROTOTYPE that chose the orientation
+ * (`b3_measure.mjs`), not from this component: they describe layouts the tree
+ * deliberately no longer contains, so they cannot be re-measured here and are
+ * named as prototype figures rather than as measurements of what ships. The
+ * numbers that DO describe what ships were taken on the real payload in the
+ * real bundle: 20 columns of 38.75 px, 0 of 1,140 cells clipped, at all three
+ * client heights the fleet produces.
+ *
  * The lap axis scrolls, because it must: Monaco's 78 laps overflow the column
  * on every machine in the fleet at every legible font size. It is pinned to
  * the newest lap so the panel follows the race, and the header states the

--- a/src/pitwall/ui/src/lib/racePace.ts
+++ b/src/pitwall/ui/src/lib/racePace.ts
@@ -32,9 +32,10 @@ import { sessionBests } from "./sessionBests";
 /**
  * What a cell paints. `best` is the session's fastest; `t1`/`t2`/`t3` are the
  * thirds of the lap's own ranking; `pit` and `out` are the in-lap and out-lap;
- * `none` is a lap the driver has no time for, revealed or not.
+ * `deleted` is a time the stewards took away; `none` is a lap the driver has
+ * no time for, revealed or not.
  */
-export type PaceTone = "best" | "t1" | "t2" | "t3" | "pit" | "out" | "none";
+export type PaceTone = "best" | "t1" | "t2" | "t3" | "pit" | "out" | "deleted" | "none";
 
 export interface PaceCell {
   text: string;
@@ -56,17 +57,28 @@ const EMPTY: PaceCell = { text: "", tone: "none" };
  * The column order: every driver the wire names, sorted by CAR NUMBER.
  *
  * **Which drivers comes from the wire, the order does not, and the two halves
- * have different reasons.** The wire's `race_order` is the only list that
- * carries all twenty - three of Melbourne's crashed on lap 1 and have nothing
- * but generated rows, so a grid keyed on the bulk renders seventeen columns
- * and loses them silently. But `race_order` is ranked by POSITION, and a
+ * have different reasons.** `race_order` is the wire's own list of who is in
+ * this race, published by the producer that ranks them, so the grid never
+ * re-derives it. (It is NOT true that the bulk would render seventeen columns:
+ * `SessionLaps.masked_view` iterates every driver it loaded, so a car with
+ * nothing revealed still gets an entry with an empty `laps` array - measured
+ * on the live host, `bulk.drivers` has all twenty keys at every reveal. That
+ * claim was wrong in this docstring, in the smoke's own message and in the
+ * pull request; the design stands, its stated reason did not.) But
+ * `race_order` is ranked by POSITION, and a
  * position-ranked grid re-sorts its own columns every time two cars swap: the
  * reader looks back at lap 12 and it is in a different place than it was a
  * moment ago. A car number never changes for the whole race, which is what a
  * history panel needs and what a timing sheet has always used.
  *
- * A driver with no number keeps his wire position, so an unknown never
- * collapses several columns onto one sort key.
+ * A driver with no number sorts to the END, in wire order among his own kind.
+ * **Not "keeps his wire position", which is what this said and did.** Two
+ * different orderings inside one comparator is not a consistent order: with
+ * A(44), B(no number) and C(1) it answers A<B, B<C and C<A, and the result is
+ * whatever the engine's sort happens to do. Executed on the real bundle with
+ * one unknown at wire index 1, car 44 rendered FIRST, ahead of car 1. Sorting
+ * on a pair - the number, then the wire index - is a total order by
+ * construction and cannot do that.
  */
 function stableColumns(bulk: Bulk, order: string[]): string[] {
   const keyed = order.map((code, index) => {
@@ -75,8 +87,8 @@ function stableColumns(bulk: Bulk, order: string[]): string[] {
     return { code, index, number: Number.isNaN(number as number) ? null : number };
   });
   keyed.sort((left, right) => {
-    if (left.number === null || right.number === null) return left.index - right.index;
-    return left.number - right.number;
+    const byNumber = (left.number ?? Infinity) - (right.number ?? Infinity);
+    return byNumber !== 0 ? byNumber : left.index - right.index;
   });
   return keyed.map((entry) => entry.code);
 }
@@ -138,14 +150,26 @@ function rankedByLap(byDriver: Map<string, Map<number, LapRow>>, laps: number[])
 /**
  * Which third of the lap this time placed in.
  *
- * Ceil rather than floor on the boundaries, so a field of four splits 2/1/1
- * instead of leaving the last third empty. A lap with fewer than three timed
- * cars has no meaningful thirds and everything in it reads as the top one -
- * which is honest: with two cars running, both ARE the field.
+ * The boundaries are compared against a FRACTIONAL third rather than a rounded
+ * one, so a field of four splits 2/1/1 instead of leaving the last third empty.
+ * A lap with fewer than three timed cars has no meaningful thirds and
+ * everything in it reads as the top one - which is honest: with two cars
+ * running, both ARE the field.
+ *
+ * **A value that is not in the ranking is not the fastest third.** It used to
+ * be: `indexOf` answers -1 for a time the ranking excludes, and the guard read
+ * `index < 0 || times.length < 3` and returned `t1` for both. A deleted lap
+ * took that branch and was painted the green the legend means as "quickest
+ * third" - measured on the real race, GAS's lap 54 ranked 14th of 14 and
+ * rendered the same colour as the quickest. Callers now hand deleted rows
+ * their own tone and never reach here; if anything else ever does, `none` is
+ * the honest answer, because "we do not know where this placed" is not a claim
+ * about pace.
  */
 function tone(times: number[], value: number): PaceTone {
+  if (times.length < 3) return "t1";
   const index = times.indexOf(value);
-  if (index < 0 || times.length < 3) return "t1";
+  if (index < 0) return "none";
   const third = times.length / 3;
   if (index < third) return "t1";
   if (index < third * 2) return "t2";
@@ -155,10 +179,8 @@ function tone(times: number[], value: number): PaceTone {
 /**
  * The grid for what the clock has revealed.
  *
- * **Columns come from the wire's `order`, never from the bulk's keys.** Three
- * of Melbourne's twenty drivers crashed on lap 1 and have only `generated`
- * rows, so a grid keyed on the bulk renders seventeen columns and silently
- * loses them. The wire always carries twenty.
+ * Columns come from the wire's `order` and are sorted by car number; see
+ * `stableColumns` for why each half is decided where it is.
  *
  * The bottom edge is RAGGED on purpose: the reveal is per driver and strict,
  * and at most instants the field spans two or three different laps.
@@ -190,6 +212,13 @@ export function racePaceGrid(bulk: Bulk | null, order: string[]): PaceGrid {
       if (row.pit_out) return { text: "OUT", tone: "out" as PaceTone };
       if (row.lap_time === null) return EMPTY;
       const text = paceLabel(row.lap_time);
+      // A deleted time is shown and struck through, as the tower already shows
+      // it, and it is excluded from the ranking - which is why it cannot be
+      // given a rank here. Before this branch existed it fell through to
+      // `tone`, whose `indexOf` answered -1, and -1 rendered as the quickest
+      // third: on the real race the slowest car on the lap wore the same green
+      // as the fastest.
+      if (row.deleted) return { text, tone: "deleted" as PaceTone };
       // The session's fastest lap is purple wherever it appears, matching the
       // tower's sector code. Compared on the VALUE and the driver together:
       // two drivers can set the identical time to the millisecond, and only

--- a/src/pitwall/ui/src/lib/racePace.ts
+++ b/src/pitwall/ui/src/lib/racePace.ts
@@ -99,9 +99,21 @@ function stableColumns(bulk: Bulk, order: string[]): string[] {
  * **The truncation is what makes the grid fit at all.** Measured against the
  * real built stylesheet at the right column's real width: twenty columns of
  * 38.75 px hold this form with room to spare, while the same cell in seconds
- * (`149.413`) clips 793 of 1140 cells the moment a cell carries one pixel of
- * padding. Tenths is also the resolution the grid needs, because the ranking
- * colour carries the ordering and the number carries the magnitude.
+ * (`149.413`) clips **205 of 1,140 cells on the real Melbourne payload**, at
+ * all three client heights the fleet produces. (An earlier version of this
+ * sentence said 793, which was measured on a prototype whose synthetic times
+ * were spread across the race's whole range rather than on the payload the
+ * window serves - the wrong-distribution class, in a comment. The smoke's own
+ * fixture clips 85, so it is about 2.4x less sensitive than the real race:
+ * worth knowing before trusting an "it fits" from it.)
+ *
+ * Tenths is also the resolution the grid needs, because the ranking colour
+ * carries the ordering and the number carries the magnitude.
+ *
+ * **It runs to seven characters from ten minutes upward** (`600 -> "10:00.0"`).
+ * No lap on disk approaches it - Melbourne's slowest is 149.413 s and nothing
+ * reaches 300 - but a red-flagged race would, and no race with a red flag is
+ * downloadable here to test it.
  */
 export function paceLabel(seconds: number): string {
   const minutes = Math.floor(seconds / 60);

--- a/src/pitwall/ui/src/styles/data.css
+++ b/src/pitwall/ui/src/styles/data.css
@@ -959,6 +959,15 @@
   color: #f59e0b;
 }
 
+/* A time the stewards took away. Struck through and stepped back, which is
+ * what the tower already does to a deleted LAST - the two panels showing the
+ * same lap differently is the twin this repo pays for. It carries no rank
+ * because the ranking excludes it; it used to carry the FASTEST one. */
+.pace-table td.is-deleted {
+  color: var(--qt-fg-3);
+  text-decoration: line-through;
+}
+
 /* The in-lap and the out-lap, red in place of the time, as a timing screen
  * shows them. */
 .pace-table td.is-pit,

--- a/src/pitwall/ui/src/styles/data.css
+++ b/src/pitwall/ui/src/styles/data.css
@@ -899,6 +899,12 @@
   font-variant-numeric: tabular-nums;
   table-layout: fixed;
   width: 100%;
+  /* Defined HERE, once. It used to exist only as a `var(--pace-row-h, 12px)`
+   * fallback in the two declarations below - a token nothing ever set, so the
+   * fallback always applied and the literal was written TWICE, one more copy
+   * than the tower's single `height: 20px`, under a comment claiming the
+   * opposite. */
+  --pace-row-h: 12px;
 }
 
 /* One row-height token, one place. The tower's 20 px is a literal in this
@@ -907,8 +913,8 @@
  * consumer that needs it reads it with `getComputedStyle`. */
 .pace-table th,
 .pace-table td {
-  height: var(--pace-row-h, 12px);
-  line-height: var(--pace-row-h, 12px);
+  height: var(--pace-row-h);
+  line-height: var(--pace-row-h);
   overflow: hidden;
   padding: 0 1px;
   text-align: center;

--- a/tests/surfaces/test_pitwall_radio_feed.py
+++ b/tests/surfaces/test_pitwall_radio_feed.py
@@ -86,8 +86,11 @@ def test_the_feed_carries_driver_radio_under_real_driver_codes():
     radios = _of_kind(everything, "radio")
     assert radios, "the race's driver radio never reaches the feed"
     speakers = {event["driver"] for event in radios}
+    # Membership in the grid is the whole assertion. A length check was here
+    # too and it was decoration: the degradation this file exists to pin
+    # produced `D12`, which is three characters long, so it satisfied the very
+    # rule it was written to break.
     assert speakers <= set(codes), f"radio attributed to non-drivers: {speakers - set(codes)}"
-    assert all(len(code) == 3 for code in speakers), f"synthetic codes in the feed: {speakers}"
 
 
 def test_a_radio_waits_for_its_own_driver_and_an_rcm_waits_for_the_leader():

--- a/tests/surfaces/test_pitwall_radio_feed.py
+++ b/tests/surfaces/test_pitwall_radio_feed.py
@@ -200,3 +200,36 @@ def test_the_feed_rides_in_the_bulk_and_a_race_switch_empties_it():
     assert switched["radio"] == {"available": False, "events": []}, (
         "the previous race's radio stayed on screen beside a table that had gone empty"
     )
+
+
+def test_a_tick_that_names_no_race_takes_the_feed_down_with_the_table():
+    """The malformed-tick return has to clear the corpus, and it did not.
+
+    `_session_for` returns early when the tick's year or location is not the
+    type it expects - above the block that reloads both the laps and the radio.
+    So the table fell to its unavailable payload while `_masked_view` went on
+    serving the PREVIOUS race's messages out of a corpus the early return had
+    skipped: 46 of them, beside a table that had already given up.
+
+    Not reachable from today's producer, which always publishes an int year and
+    a str location. It is guarded because the branch exists to be defensive and
+    was not, and because this is the exact twin shape the sprint before paid
+    for between these same two channels.
+    """
+    codes = _codes_or_skip()
+    _corpus_or_skip()
+    client = _FakeClient(_tick(dict.fromkeys(codes, 24)))
+    host = PitwallHost(client, window_count=1)
+
+    served = host.get_bulk(-1)
+    assert served["radio"]["events"], "the feed never loaded, so the case cannot be exercised"
+
+    malformed = _tick(dict.fromkeys(codes, 24))
+    malformed["arcade"].pop("location")
+    client.latest = malformed
+    answered = host.get_bulk(served["rev"])
+
+    assert answered["available"] is False, "the table did not go to its unavailable payload"
+    assert answered["radio"] == {"available": False, "events": []}, (
+        "the table went empty and the previous race's radio stayed on screen beside it"
+    )


### PR DESCRIPTION
Sprint 6, third PR. The adversarial exit gate over #939 and #941 found four defects, all of them in
this sprint's own work, and one of them visible on the real race. Report:
`~/.claude/plans/pitwall-sprint6/correctness-gate.md`. Refs #938, #940 — both stay open until `main`.

## F1 — HIGH — a deleted lap was painted the FASTEST tone

`isRacingLap` excludes deleted times from the ranking, and then `racePaceGrid` rendered the row
anyway: it branched on `pit_in`, `pit_out` and `lap_time === null` and **never on `deleted`**, so it
fell through to `tone()`, where `times.indexOf(value)` answers **-1** and the first line read
`if (index < 0 || times.length < 3) return "t1"`.

**"This time is not in the ranking" and "top third of the field" were the same answer.** Measured on
the real Melbourne payload, in the real bundle:

```
GAS lap 54: 94.967s ranks 14/14 among the lap's racing times -> honest t3, RENDERED t1
ANT lap 16: 97.326s ranks 17/17                              -> honest t3, RENDERED t1
LAW lap 28: 91.084s ranks 15/17                              -> honest t3, RENDERED t1
```

The slowest car on the lap wore the same green the legend means as *quickest third*. And the twin:
the tower already strikes a deleted `LAST` through, so the two panels described the same lap
differently on the same screen. Deleted rows now carry their own tone, struck through and stepped
back; a value with no rank can no longer come back as the fastest one.

## F2 — the malformed-tick return skipped the invalidation it exists for

`_session_for` returns early when the tick's year or location is not the type it expects — **above**
the block that reloads both readers. So `_masked_view` served `unavailable()` for the table and went
on calling the previous race's corpus:

```
location is None -> table available: True -> False | radio available: True -> True | events: 46 -> 46
```

46 messages of a race the panel beside them had already given up on. Not reachable from today's
producer, which always publishes an int year and a str location — fixed because the branch exists to
be defensive and was not, and because this is the exact F7 shape the previous sprint paid for
between these same two channels.

## F3 — the justification for taking the columns from the wire was FALSE

Repeated in the module docstring, the function docstring, the smoke's own check message, the PR body
and issue #940:

> "Three of Melbourne's twenty crashed on lap 1 and have only generated rows, so a grid keyed on the
> bulk renders seventeen columns."

Measured on the live host: `bulk.drivers` has **twenty** keys at every reveal, because
`SessionLaps.masked_view` iterates every driver it loaded and a car with nothing revealed still gets
an entry with an empty `laps` array. The design stands — `race_order` is the wire's own list and
avoids a second reduction — but the reason did not, and a future reader who "simplified" on the
strength of it would have found every guard green. Rewritten everywhere, and the check that asserted
it is replaced by one that can actually fail: **a driver the bulk does not name still gets a column.**

## F4 — `stableColumns` was not a consistent order

Two different orderings in one comparator is intransitive: with car 44, an unknown and car 1 it
answers 44 < unknown, unknown < 1 and 1 < 44. Executed on the real bundle with one unknown at wire
index 1, **car 44 rendered ahead of car 1** — the unknown acted as a barrier and stranded everything
before it. It sorts on a pair now, `(number ?? Infinity, wire index)`, which is a total order by
construction. Unknowns go to the end instead of splitting the grid.

## The fixtures could not see any of it

Every one of `paceBulk`'s 1,140 rows said `deleted: false`; all twenty drivers carried a distinct
valid number; all twenty were present in `bulk.drivers`. The fixture now carries a deleted lap, a
driver with no number and a driver the bulk never names — which is the same lesson this sprint
already learned once, when the heat-scale check could not separate ranking from percentage bands
until the fixture grew a safety-car block.

## Executed

| | |
|---|---|
| `tests/surfaces` | **225 passed** (1 new) |
| `smoke-data.mjs` | **121 checks OK** (6 new) |
| typecheck + ruff 0.15.22 | clean |

**All four verified RED against the reverted code**, and the build was confirmed to succeed first.
The sort failure printed the strand itself: `1,8,15,22,29,36,4,11,...` — car 4 behind car 36.
