### PR TITLE
feat(pitwall): band 3's race trace, the panel read with a vertical ruler

### DIFF
--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -1175,6 +1175,18 @@ await emptyCtx.close();
  */
 const PACE_LAPS = 57;
 const PACE_FASTEST = { code: TOWER_ORDER[3], lap: 30, time: 84.111 };
+/**
+ * One classified car has completed FEWER laps than the rest, which is what a
+ * lapped car looks like and what bounds the race trace.
+ *
+ * LAW is already the lapped car in the tower fixture (`progress: 22.3` against
+ * everyone else's 23.9), so the two fixtures agree about who is a lap down.
+ * Without him every driver would reveal all 57 and the trace's cap - the last
+ * lap the WHOLE classified field has completed - would be indistinguishable
+ * from "the last lap anybody has", which is the ragged edge it exists to
+ * refuse.
+ */
+const PACE_LAPPED = { code: "LAW", laps: 55 };
 
 function paceBulk() {
   const drivers = {};
@@ -1202,8 +1214,11 @@ function paceBulk() {
       return;
     }
     const laps = [];
+    const crossings = {};
+    let elapsed = 0;
     let best = null;
-    for (let lap = 1; lap <= PACE_LAPS; lap += 1) {
+    const revealed = code === PACE_LAPPED.code ? PACE_LAPPED.laps : PACE_LAPS;
+    for (let lap = 1; lap <= revealed; lap += 1) {
       const pitIn = lap === 20 && index % 5 === 0;
       const pitOut = lap === 21 && index % 5 === 0;
       const isFastest = code === PACE_FASTEST.code && lap === PACE_FASTEST.lap;
@@ -1220,13 +1235,22 @@ function paceBulk() {
       // paints them was never entered by any check.
       const deleted = lap === 44 && index % 3 === 0;
       if (!pitIn && !pitOut && !deleted && (best === null || time < best)) best = time;
-      laps.push({ lap, t: lap * 90, lap_time: pitIn || pitOut ? time + 22 : time,
+      const lapTime = pitIn || pitOut ? time + 22 : time;
+      // The crossing clock is the CUMULATIVE lap time, which is what it is on
+      // the real wire and what makes the race trace mean anything: a pit stop
+      // is +22 s here, so the trace has to render it as a step of about that.
+      // Every driver used to carry `crossings: {}` and `t: lap * 90` - the same
+      // number for all twenty - so a trace built on this fixture would have
+      // been twenty flat lines at zero and every check would have passed.
+      elapsed += lapTime;
+      crossings[lap] = elapsed;
+      laps.push({ lap, t: elapsed, lap_time: lapTime,
         s1: 29, s2: 30, s3: 26, v1: 301, v2: 289, vfl: 280, vst: 321,
         position: index + 1, compound: "MEDIUM", tyre_life: lap, stint: 1,
         track_status: "1", pit_in: pitIn, pit_out: pitOut, deleted,
         generated: false, pb: false });
     }
-    drivers[code] = { number, laps_revealed: PACE_LAPS, stops: 1, crossings: {}, laps,
+    drivers[code] = { number, laps_revealed: revealed, stops: 1, crossings, laps,
       best: { lap: PACE_FASTEST.lap, lap_time: best, s1: 29, s2: 30, s3: 26,
         v1: 301, v2: 289, vfl: 280, vst: 321, compound: "MEDIUM" },
       theoretical: 85 };
@@ -1392,6 +1416,186 @@ const scSpread = ["is-t1", "is-t2", "is-t3"].map((k) => scLaps[k] ?? 0);
 check(
   scSpread.every((count) => count > 0),
   `under the safety car the grid still ranks the field instead of painting it one colour (${scSpread.join(" / ")})`,
+);
+
+// --- Band 3, second panel: the race trace ---------------------------------
+
+await pacePage.getByRole("tab", { name: "RACE TRACE" }).click();
+// Waited for and then CHECKED, rather than only waited for. The panel's empty
+// state is a real render, so a defect that collapses the trace - a reference
+// population bounded by a car the bulk has no laps for is one, and it caps the
+// whole chart at lap zero - takes the plot off the page entirely. A bare
+// `waitForSelector` turns that into a timeout and a stack trace, which names
+// nothing and reads like a flaky harness; this names it.
+const tracePlotted = await pacePage
+  .waitForSelector(".trace-band-plot", { timeout: 5000 })
+  .then(() => true)
+  .catch(() => false);
+check(tracePlotted, "the race trace draws a plot rather than its empty state");
+await pacePage.waitForTimeout(400);
+
+check((await pacePage.locator(".pace-table").count()) === 0, "the pace grid unmounts on the trace tab");
+check((await pacePage.locator(".ring").count()) === 0, "and the ring stays hidden here too");
+
+/** The trace's series and axes, read off the live ECharts instance. */
+const traceState = () =>
+  pacePage.evaluate(() => {
+    const el = document.querySelector(".trace-band-plot");
+    const chart = el && el.__pitwallChart;
+    if (!chart) return null;
+    const series = chart.getOption().series;
+    const axis = (type) => chart.getModel().getComponent(type, 0).axis.scale.getExtent();
+    return {
+      x: axis("xAxis"),
+      names: series.map((s) => s.name),
+      points: Object.fromEntries(series.map((s) => [s.name, s.data])),
+      labelled: series.filter((s) => s.endLabel?.show).map((s) => s.name),
+      zero: document.querySelector(".pace-subtitle")?.textContent ?? "",
+    };
+  });
+
+const traceLeader = await traceState();
+check(traceLeader !== null, "the race trace mounts a chart");
+
+// **The check the whole design turns on.** The reveal is per driver, so the
+// newest laps are ragged: LAW has 55 and everyone else 57. A trace plotted to
+// the last lap ANYBODY has would compute its reference at laps 56 and 57 over
+// a population of nineteen and then eighteen, and every line would swing on
+// the next reveal. It stops at the last lap ALL of them have.
+check(
+  traceLeader?.x?.[1] === PACE_LAPPED.laps,
+  `the trace stops at the last lap the whole field has completed (${traceLeader?.x?.[1]}, expected ${PACE_LAPPED.laps})`,
+);
+// And the three lap-1 retirements do NOT bound it, which is the other half:
+// they completed zero laps, so a population that included them would cap the
+// whole trace at lap 0 and render the empty state on every real race with a
+// first-lap incident. Melbourne 2025 has three.
+check(
+  (traceLeader?.x?.[1] ?? 0) > 1,
+  "a lap-1 retirement does not collapse the trace to nothing",
+);
+
+// A retired car keeps the laps he drove and gets NO point for the ones he did
+// not. These three have no crossings at all, so their series must be EMPTY -
+// never a flat line at zero, which is what a missing crossing read as a
+// default would draw, and which reads as a car circulating on the leader's
+// pace. That is the sentinel-collision class this repo has paid for twice.
+const retiredPoints = RETIRED_CODES.map((code) => traceLeader?.points[code]?.length ?? -1);
+check(
+  retiredPoints.every((count) => count === 0),
+  `a car with no crossings draws nothing rather than a flat line at zero (${retiredPoints.join(",")})`,
+);
+check(
+  RETIRED_CODES.every((code) => !(traceLeader?.labelled ?? []).includes(code)),
+  "and it is not labelled at the right-hand edge either",
+);
+
+// A pit stop is a STEP, and this is measured rather than asserted about the
+// mechanism. NOR is the fastest car in the fixture and pits on lap 20-21, each
+// of those laps carrying the stop's +22 s. Against the leader he therefore
+// falls about 44 s in two laps.
+const norLine = Object.fromEntries((traceLeader?.points.NOR ?? []).map(([lap, y]) => [lap, y]));
+const step = norLine[21] - norLine[19];
+check(
+  step <= -30,
+  `a pit stop reads as a step down of the stop's own length (${step?.toFixed(1)} s over laps 19-21)`,
+);
+
+// **The labels must not land on each other, and this is measured on the
+// RENDERED boxes.** An ECharts label is canvas text, so no selector and no
+// axis extent can see it - which is why a real overlap (ALB over HAM by 4.5 px
+// of a 9 px label) survived every other check on this page and was found by
+// looking at a screenshot. This fixture is harsher than the real race: four
+// pairs of drivers carry byte-identical cumulative times, so without the
+// de-collision their codes render exactly on top of one another.
+const labelBoxes = await pacePage.evaluate(() => {
+  const chart = document.querySelector(".trace-band-plot")?.__pitwallChart;
+  if (!chart) return { count: 0, overlaps: ["no chart"] };
+  const boxes = chart
+    .getZr()
+    .storage.getDisplayList()
+    .filter((el) => /^[A-Z]{3}$/.test(el.style?.text ?? ""))
+    .map((el) => {
+      const rect = el.getBoundingRect().clone();
+      rect.applyTransform(el.transform);
+      return { code: el.style.text, x: rect.x, y: rect.y, w: rect.width, h: rect.height };
+    });
+  const overlaps = [];
+  for (let i = 0; i < boxes.length; i += 1) {
+    for (let j = i + 1; j < boxes.length; j += 1) {
+      const a = boxes[i];
+      const b = boxes[j];
+      const dx = Math.min(a.x + a.w, b.x + b.w) - Math.max(a.x, b.x);
+      const dy = Math.min(a.y + a.h, b.y + b.h) - Math.max(a.y, b.y);
+      if (dx > 0 && dy > 0) overlaps.push(`${a.code}/${b.code} ${dx.toFixed(1)}x${dy.toFixed(1)}`);
+    }
+  }
+  return { count: boxes.length, overlaps, right: Math.max(...boxes.map((z) => z.x + z.w)),
+           canvas: chart.getWidth() };
+});
+check(
+  labelBoxes.overlaps.length === 0,
+  `no two driver codes are drawn on top of each other (${labelBoxes.overlaps.join(", ")})`,
+);
+// And the right-hand margin actually holds them. Measured once at 52 px of
+// grid: a label's right edge landed at 804 px on an 803 px canvas.
+check(
+  labelBoxes.right <= labelBoxes.canvas,
+  `no label is clipped by the canvas edge (${labelBoxes.right?.toFixed(1)} of ${labelBoxes.canvas})`,
+);
+
+// Twenty lines need twenty identities and a legend for twenty codes eats the
+// plot. Each line says its own name at its right-hand end.
+// Sixteen, not seventeen: three cars retired on lap 1 and a fourth is in
+// `race_order` while the bulk never names him. That fourth is the case that
+// used to DELETE the panel - a minimum bounded by a car with no lap data reads
+// his lap count as zero and caps the whole trace at lap zero - and the check
+// above (x max = 55) is what catches it. This one pins the count itself.
+check(
+  traceLeader?.labelled?.length === 16,
+  `every car the bulk has laps for is labelled at its end (${traceLeader?.labelled?.length}, expected 16)`,
+);
+check(
+  (traceLeader?.points[TOWER_ORDER[9]] ?? []).length === 0,
+  "a driver the bulk does not name draws no line, and does not bound the trace either",
+);
+
+// The reference switches, and the switch is the panel's whole control surface.
+// With OUR car as the zero line every one of its own points is exactly zero -
+// which is what "flat at zero" has to mean, and what a reference computed off
+// a different clock would miss by milliseconds.
+if (tracePlotted) await pacePage.getByRole("tab", { name: "NOR" }).click();
+await pacePage.waitForTimeout(300);
+const traceOwn = await traceState();
+check(
+  (traceOwn?.points.NOR ?? []).every(([, y]) => y === 0),
+  "with OWN as the reference our own line is flat at exactly zero",
+);
+check(
+  (traceOwn?.zero ?? "").includes("NOR"),
+  `and the header says what the zero line is (${traceOwn?.zero})`,
+);
+// The other lines are NOT all zero, which is the guard that separates a real
+// reference switch from a chart that quietly zeroed everything.
+check(
+  (traceOwn?.points.VER ?? []).some(([, y]) => y !== 0),
+  "while the rest of the field is measured against it",
+);
+
+// FIELD is a third distinct answer, not a relabelled LEADER. Against the mean
+// the leaders sit ABOVE the axis; against the leader nothing can.
+if (tracePlotted) await pacePage.getByRole("tab", { name: "FIELD" }).click();
+await pacePage.waitForTimeout(300);
+const traceField = await traceState();
+const aboveField = Object.values(traceField?.points ?? {}).flat().filter(([, y]) => y > 0).length;
+const aboveLeader = Object.values(traceLeader?.points ?? {}).flat().filter(([, y]) => y > 0).length;
+check(
+  aboveLeader === 0,
+  `nothing is ahead of the car leading the lap (${aboveLeader} points above zero)`,
+);
+check(
+  aboveField > 0,
+  `against the field average the quick cars sit above the axis (${aboveField} points)`,
 );
 
 await paceCtx.close();

--- a/src/pitwall/ui/src/features/data/DataWindow.tsx
+++ b/src/pitwall/ui/src/features/data/DataWindow.tsx
@@ -26,6 +26,7 @@ import { useState } from "react";
 import { BestsPanel } from "./BestsPanel";
 import { OwnCarTraces } from "./OwnCarTraces";
 import { RacePaceGrid } from "./RacePaceGrid";
+import { RaceTraceChart } from "./RaceTraceChart";
 import { RadioFeed } from "./RadioFeed";
 import { StatusStrip } from "./StatusStrip";
 import { TimingTower } from "./TimingTower";
@@ -38,6 +39,19 @@ import { useTick } from "../../lib/useTick";
 
 const WAITING = { text: "Waiting for arcade stream…", transient: false } as const;
 
+/**
+ * The right column's tabs, in the order a strategist reaches for them.
+ *
+ * A list rather than three literals in the JSX, so the id a button carries and
+ * the id the panel below switches on cannot drift apart - which is exactly how
+ * a fourth tab would arrive rendering the third one's panel.
+ */
+const TABS = [
+  ["traces", "TRACES"],
+  ["pace", "RACE PACE"],
+  ["trace", "RACE TRACE"],
+] as const;
+
 export function DataWindow() {
   const { tick, discontinuity, live } = useTick();
   const connection = useConnection();
@@ -48,7 +62,7 @@ export function DataWindow() {
   // stops. `useStatusText` is keyed on the sequence for that reason.
   const status = tick ? { text: `lap ${tick.arcade.lap} · live`, transient: true } : WAITING;
   const statusText = useStatusText(status, tick?.seq ?? null);
-  const [tab, setTab] = useState<"traces" | "pace">("traces");
+  const [tab, setTab] = useState<"traces" | "pace" | "trace">("traces");
 
   return (
     <main className="data-window">
@@ -64,9 +78,17 @@ export function DataWindow() {
               {/* The tab strip the delivery plan put here. Band 3 needs the
                   full 825 px of this column - measured: with the ring still
                   mounted its cells clip 1,101 of 1,140 - so the two worlds
-                  take turns rather than share. */}
+                  take turns rather than share.
+
+                  Band 3 is TWO panels, not one, and they answer questions the
+                  other cannot: the grid says how quick each lap was, the trace
+                  says where everyone is. Splitting them across two tabs rather
+                  than stacking them is the same column arithmetic again - a
+                  grid squeezed to half this height stops showing enough laps to
+                  be a history, and a trace at 300 px stops resolving the gaps
+                  it exists to show. */}
               <nav className="tab-strip" role="tablist">
-                {(["traces", "pace"] as const).map((id) => (
+                {TABS.map(([id, label]) => (
                   <button
                     key={id}
                     role="tab"
@@ -74,11 +96,11 @@ export function DataWindow() {
                     className={tab === id ? "tab is-active" : "tab"}
                     onClick={() => setTab(id)}
                   >
-                    {id === "traces" ? "TRACES" : "RACE PACE"}
+                    {label}
                   </button>
                 ))}
               </nav>
-              {tab === "traces" ? (
+              {tab === "traces" && (
                 <div className="band4">
                   <OwnCarTraces tick={tick} discontinuity={discontinuity} />
                   <div className="side-column">
@@ -86,9 +108,9 @@ export function DataWindow() {
                     <RadioFeed bulk={bulk} driverMain={tick.arcade.driver_main} />
                   </div>
                 </div>
-              ) : (
-                <RacePaceGrid bulk={bulk} order={tick.arcade.race_order} />
               )}
+              {tab === "pace" && <RacePaceGrid bulk={bulk} order={tick.arcade.race_order} />}
+              {tab === "trace" && <RaceTraceChart bulk={bulk} arcade={tick.arcade} />}
             </div>
           </div>
         ) : (

--- a/src/pitwall/ui/src/features/data/RaceTraceChart.tsx
+++ b/src/pitwall/ui/src/features/data/RaceTraceChart.tsx
@@ -1,0 +1,201 @@
+/**
+ * Band 3's second half: the race trace, a tab of the right column.
+ *
+ * The panel is read with a ruler held VERTICALLY. One cut down the chart at a
+ * lap gives every gap in the race at that lap at once, which is the question
+ * the race-pace grid beside it cannot answer - a grid of lap times says who
+ * was quick and never says who is where.
+ *
+ * **The three references are the panel's only control, and each one answers a
+ * different question.** LEADER draws the race the way a broadcast graphic
+ * does. FIELD spreads the leaders above the axis so a midfield battle is not
+ * squashed against the top of the plot. OWN puts our car flat on zero, which
+ * is the pit wall's own question: a line climbing towards zero is a car coming
+ * for us, and the lap it reaches zero is the lap it arrives.
+ *
+ * Twenty lines need twenty identities, and a legend for twenty codes eats a
+ * third of the plot. ECharts labels each line at its right-hand END instead,
+ * which is where a race trace has always been read and where the lines are
+ * furthest apart - by the end of a race the field is strung out, so the labels
+ * separate exactly where the data does.
+ *
+ * The colours are the wire's `driver_colors`, as the tower and the ring
+ * already take them. A driver the wire has no colour for draws in the axis
+ * grey rather than in an invented hue - this repo has already found five
+ * copies of the arcade palette and none of them is going to be the sixth.
+ *
+ * ⚠️ **Those colours are TEAM colours, so the end label is the only thing that
+ * tells two team-mates apart.** Measured on the real Melbourne payload: ten
+ * colours across twenty cars, every one of them shared by exactly two drivers
+ * (VER/LAW both `rgb(6,0,239)`, LEC/HAM both `rgb(232,0,32)`, and so on). The
+ * tower has the same property and answers it with a code per row; here the
+ * answer is the code at the end of the line, which is why the de-collision
+ * below is load-bearing rather than polish. Dashing the second car of each
+ * team is the broadcast solution and is deliberately NOT taken: a dashed line
+ * already means BROADCAST-TIER data on band 4, one tab away, and two meanings
+ * for one stroke on one window is worse than two lines of one colour.
+ */
+
+import { useMemo, useState } from "react";
+import type { EChartsOption } from "echarts";
+
+import { AXIS_TEXT, CURSOR_LINE, useEChart, valueAxis } from "../../lib/chart";
+import { driverStatus } from "../../lib/driverStatus";
+import { raceTrace } from "../../lib/raceTrace";
+import type { TraceReference } from "../../lib/raceTrace";
+import type { ArcadeState, Bulk } from "../../lib/bridge";
+
+/** The own car is drawn heavier than the nineteen it has to be picked out of. */
+const OWN_WIDTH = 2;
+const FIELD_WIDTH = 1;
+
+function colourOf(arcade: ArcadeState, code: string): string {
+  const rgb = arcade.driver_colors[code];
+  // Never a CSS custom property here, unlike the tower's version of this: an
+  // ECharts canvas cannot resolve `var(--qt-fg-1)` and would draw the series
+  // in its own default palette, which is the one colour set on this window
+  // that answers to nothing.
+  return rgb ? `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})` : AXIS_TEXT;
+}
+
+/** `+12.3` / `-4.5` - the sign is the whole reading, so it is always printed. */
+function signedSeconds(value: number): string {
+  return `${value > 0 ? "+" : ""}${value.toFixed(1)}`;
+}
+
+export function RaceTraceChart({ bulk, arcade }: { bulk: Bulk | null; arcade: ArcadeState }) {
+  const [reference, setReference] = useState<TraceReference>("leader");
+  const own = arcade.driver_main;
+
+  // **The signature, not the objects, and this is the plan's directive rather
+  // than a micro-optimisation.** `arcade` is a fresh object ten times a
+  // second, so memoising on it would rebuild twenty series and call
+  // `setOption({notMerge: true})` at 10 Hz for content that changes once every
+  // four and a half seconds - P3 finding A6, which is on this window's list of
+  // things to prevent rather than repeat. What the trace actually depends on
+  // is the reveal, the reference, who is racing and who has stopped.
+  const stopped = arcade.race_order
+    .filter((code) => {
+      const car = arcade.drivers[code];
+      return car === undefined || driverStatus(car) === "out";
+    })
+    .join(",");
+  const signature = `${bulk?.rev ?? -1}|${reference}|${own}|${arcade.race_order.join(",")}|${stopped}`;
+
+  const trace = useMemo(
+    () => raceTrace(bulk, arcade, reference),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [signature],
+  );
+
+  const option = useMemo<EChartsOption>(() => {
+    const first = trace.laps[0] ?? 1;
+    const last = trace.laps[trace.laps.length - 1] ?? 1;
+    return {
+      backgroundColor: "transparent",
+      // Same answer as band 4's traces and for a weaker version of the same
+      // reason: `useEChart` passes `notMerge: true`, so every reveal looks to
+      // ECharts like a brand-new series and it plays the ENTRANCE sweep, not
+      // the zeroed update duration. Twenty lines growing in from the left
+      // every four and a half seconds is not an entrance, it is a flicker.
+      animation: false,
+      animationDurationUpdate: 0,
+      // The right margin is the end labels' room. Measured on the real payload:
+      // the rightmost label's edge lands at 776 px on an 803 px canvas, so 52
+      // clears it. Without the margin the codes are cut by the plot edge and the
+      // panel loses the only identification it has.
+      grid: { left: 52, right: 52, top: 10, bottom: 34, containLabel: false },
+      xAxis: valueAxis({ name: "Lap", nameGap: 20, min: first, max: last }),
+      yAxis: {
+        ...valueAxis({ name: "Δ (s)", nameGap: 38, scale: true }),
+        axisLabel: {
+          color: AXIS_TEXT,
+          fontSize: 10,
+          formatter: (value: number) => signedSeconds(value),
+        },
+      },
+      series: trace.lines.map((line) => {
+        const colour = colourOf(arcade, line.code);
+        const isOwn = line.code === own;
+        return {
+          type: "line" as const,
+          name: line.code,
+          data: line.points,
+          symbol: "none" as const,
+          lineStyle: { color: colour, width: isOwn ? OWN_WIDTH : FIELD_WIDTH },
+          itemStyle: { color: colour },
+          // The zero line hangs off the first series, as band 4's cursor does.
+          markLine: line.code === trace.lines[0]?.code
+            ? {
+                silent: true,
+                symbol: "none" as const,
+                label: { show: false },
+                data: [{ yAxis: 0, lineStyle: { color: CURSOR_LINE, width: 1, type: "solid" } }],
+              }
+            : undefined,
+          endLabel: {
+            show: line.points.length > 0,
+            formatter: line.code,
+            color: colour,
+            fontSize: 9,
+            fontWeight: isOwn ? ("bold" as const) : ("normal" as const),
+            distance: 3,
+          },
+          // **Two labels land on the same pixels, and only the screenshot said
+          // so.** Measured on the real Melbourne payload in the real bundle:
+          // ALB's and HAM's codes overlapped by 4.5 px of their 9 px height,
+          // because the midfield is where cars run a second apart and a second
+          // is four pixels on a 676 px plot spanning 77 s. Nothing else could
+          // see it - not the axis extents, not any of the smoke's checks -
+          // because an ECharts label is canvas text and not a DOM node.
+          //
+          // `shiftY` nudges the colliding label down instead of dropping it.
+          // `hideOverlap` is the other option ECharts offers and it is the
+          // wrong one here: the label IS the identification, so hiding it
+          // leaves an anonymous line, and it would hide exactly the labels a
+          // strategist is most likely to be reading - two cars a second apart
+          // are two cars racing each other.
+          labelLayout: { moveOverlap: "shiftY" as const, hideOverlap: false },
+        };
+      }),
+    };
+    // `arcade` is read only for its colours and the own code, both of which
+    // are already in the signature; see the note above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [trace, own]);
+
+  const host = useEChart(trace.lines.length ? option : null);
+
+  return (
+    <section className="card trace-band">
+      <header className="pace-header">
+        <span className="pace-title">RACE TRACE</span>
+        <span className="pace-subtitle">{trace.zero}</span>
+        <nav className="ref-strip" role="tablist" aria-label="reference">
+          {(["leader", "field", "own"] as const).map((id) => (
+            <button
+              key={id}
+              role="tab"
+              aria-selected={reference === id}
+              className={reference === id ? "ref is-active" : "ref"}
+              onClick={() => setReference(id)}
+            >
+              {id === "own" ? own : id.toUpperCase()}
+            </button>
+          ))}
+        </nav>
+      </header>
+      {trace.lines.length ? (
+        <div className="trace-band-plot" ref={host} />
+      ) : (
+        // A trace with nothing to draw SAYS so. An empty plot and a race whose
+        // field has not yet completed a common lap are the same pixels
+        // otherwise, which is the twin the radio feed's own empty state
+        // already had to grow.
+        <p className="trace-band-empty">
+          No lap the whole classified field has completed yet.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/pitwall/ui/src/lib/racePace.ts
+++ b/src/pitwall/ui/src/lib/racePace.ts
@@ -79,8 +79,13 @@ const EMPTY: PaceCell = { text: "", tone: "none" };
  * one unknown at wire index 1, car 44 rendered FIRST, ahead of car 1. Sorting
  * on a pair - the number, then the wire index - is a total order by
  * construction and cannot do that.
+ *
+ * Exported because the race trace orders its series the same way and for the
+ * same reason. A second copy of this comparator is the twin defect this repo
+ * pays for more than any other - and it would be the third copy of the sort,
+ * not the second, since the version that shipped here was already wrong once.
  */
-function stableColumns(bulk: Bulk, order: string[]): string[] {
+export function stableColumns(bulk: Bulk, order: string[]): string[] {
   const keyed = order.map((code, index) => {
     const raw = bulk.drivers[code]?.number;
     const number = raw === null || raw === undefined ? null : Number.parseInt(raw, 10);

--- a/src/pitwall/ui/src/lib/raceTrace.ts
+++ b/src/pitwall/ui/src/lib/raceTrace.ts
@@ -1,0 +1,241 @@
+/**
+ * The race trace: accumulated time against a reference, one line per driver.
+ *
+ * The panel a strategist reads with a RULER held vertically. At any lap the
+ * vertical distance between two lines IS the gap between those cars at that
+ * moment, so one cut across the chart answers the whole grid's worth of
+ * intervals at once - which is the pit-wall question the race-pace grid
+ * cannot answer, because a grid of lap times says who was quick and never
+ * says who is where.
+ *
+ * A pit stop is a STEP down of about the stop's own length; an overtake is a
+ * crossing; a stint going off is a line bending away from its neighbours.
+ * None of those are drawn - they fall out of the arithmetic.
+ *
+ * **The seconds come from `crossings`, which is the tower's clock and not a
+ * second one.** `gapCell` already subtracts exactly these values to print the
+ * GAP and INT columns, and two panels on the same screen disagreeing about the
+ * same gap is the twin defect this repo pays for most often. The alternative
+ * source - summing `lap_time` - drifts, because a lap time is rounded to the
+ * millisecond and a race is 57 of them.
+ *
+ * ⚠️ **The reveal is per driver and strict, so the newest laps are ragged**,
+ * and a reference averaged over a ragged edge moves under the reader: at the
+ * instant the leader has revealed lap 27 and the field lap 25, a field average
+ * at lap 27 is an average of the two cars in front, which drags every line
+ * towards zero and then springs back on the next reveal. The race-pace grid
+ * can be ragged because each of its cells is its own claim; a trace cannot,
+ * because every point is measured against a shared line. So the trace stops at
+ * the last lap the whole classified field has completed - see `lastCommonLap`.
+ */
+
+import type { ArcadeState, Bulk } from "./bridge";
+import { driverStatus } from "./driverStatus";
+import { stableColumns } from "./racePace";
+
+/**
+ * What y = 0 means.
+ *
+ * `leader` is the classic form and the one that shows the race's shape: the
+ * car in front at that lap sits on zero and everyone else hangs below it.
+ * `field` is the mean of the classified field, which spreads the leaders above
+ * the axis and makes a midfield battle legible instead of squashing it against
+ * the top. `own` puts OUR car flat on zero, which is the pit wall's own
+ * question - everything above is a car that is ahead, everything below is a
+ * car that is behind, and a line climbing towards zero is a car coming for us.
+ */
+export type TraceReference = "leader" | "field" | "own";
+
+export interface TraceLine {
+  code: string;
+  /** `[lap, seconds ahead of the reference]`, ascending by lap. */
+  points: [number, number][];
+}
+
+export interface RaceTrace {
+  /** The laps plotted: 1..`lastCommonLap`, or empty when there is nothing to plot. */
+  laps: number[];
+  lines: TraceLine[];
+  /** What the zero line is, for the header to say out loud. */
+  zero: string;
+}
+
+const EMPTY: RaceTrace = { laps: [], lines: [], zero: "" };
+
+/**
+ * The cars the reference is computed over, and the cars that bound it.
+ *
+ * Two filters, and each one deletes the panel if it is missing.
+ *
+ * **Still classified - running or finished, never the retired.** The
+ * population exists to bound the plot at a lap EVERYONE has, and a car that
+ * crashed on lap 1 has completed zero, so including the retired would pin the
+ * whole trace at lap 0 on any race with a first-lap incident. Melbourne 2025
+ * has three. `driverStatus` rather than `active` alone, for the reason its own
+ * module records: at the end of a race nineteen of twenty cars read as
+ * inactive, the winner included, because taking the flag stops the broadcast
+ * exactly as crashing does.
+ *
+ * **And named by the BULK, which is the half that is easy to leave out.** The
+ * race-pace grid deliberately takes its columns from the wire and renders a
+ * blank column for a car the bulk does not name - so a car in `race_order`
+ * with no bulk entry is a state this window already has, and one the fixture
+ * carries. Bounding a MINIMUM by such a car reads his lap count as zero and
+ * caps the whole trace at lap zero: the panel disappears, blaming a reveal
+ * that is fine. We have no lap data for him, so he cannot enter an average and
+ * cannot bound one either.
+ *
+ * The cost of that second filter, stated rather than buried: a car the bulk
+ * has no entry for is silently absent from the field average. On the real
+ * payload the set is empty - `race_order` and `Object.keys(bulk.drivers)` were
+ * measured identical at every reveal - so this is a guard against a shape the
+ * types allow, not a rate.
+ */
+function population(bulk: Bulk, arcade: ArcadeState, codes: string[]): string[] {
+  return codes.filter((code) => {
+    const car = arcade.drivers[code];
+    if (car === undefined || driverStatus(car) === "out") return false;
+    return bulk.drivers[code] !== undefined;
+  });
+}
+
+/** The highest lap this driver has a crossing for, or 0 when he has none. */
+function lastCrossing(crossings: Record<number, number>): number {
+  let last = 0;
+  for (const key of Object.keys(crossings)) {
+    const lap = Number(key);
+    if (lap > last) last = lap;
+  }
+  return last;
+}
+
+/**
+ * The last lap every classified car has completed.
+ *
+ * This is the trace's whole answer to the ragged reveal edge, and it is a
+ * MINIMUM rather than a threshold on purpose: no fraction of the field to tune
+ * on the one race that happens to be on this disk, and no lap where the
+ * reference is computed over a different population than the lap below it.
+ *
+ * The cost, stated so nobody files it as a bug with both tabs open: the trace
+ * ends one to two laps behind the race-pace grid, because the grid shows every
+ * lap ANY car has and this shows every lap ALL of them have. They are
+ * answering different questions - the grid "how quick was that lap", the trace
+ * "where is everyone" - and the second is only answerable on a lap the whole
+ * field has driven.
+ *
+ * A lapped car bounds it too, and correctly: while he has not completed lap
+ * 27, no reference at lap 27 can include him.
+ */
+function lastCommonLap(bulk: Bulk, codes: string[]): number {
+  let common = Infinity;
+  for (const code of codes) {
+    // Every code here is named by the bulk - `population` guarantees it - so
+    // an empty crossing map means "revealed nothing yet", which genuinely
+    // bounds the trace at zero and renders the empty state.
+    //
+    // The `?.` is nevertheless not decoration, and the cost asymmetry is why:
+    // a bare dereference throws inside a React render, and a throw here takes
+    // the WHOLE DATA window down - tower, bests, status strip and all - for an
+    // invariant that lives in a different function. Measured: removing the
+    // bulk filter from `population` did exactly that, and the harness stopped
+    // reporting anything at all rather than reporting the trace. Degrading to
+    // "revealed nothing" costs one lap of the plot and keeps the window up.
+    common = Math.min(common, lastCrossing(bulk.drivers[code]?.crossings ?? {}));
+  }
+  return Number.isFinite(common) ? common : 0;
+}
+
+/**
+ * The zero line, lap by lap.
+ *
+ * Null at a lap the reference does not exist for, which only `own` can produce
+ * - our car may itself be the one that retired - and which drops the lap from
+ * every line rather than substituting a plausible number for it. A reference
+ * nobody can check is worse than a shorter chart.
+ */
+function referenceTimes(
+  bulk: Bulk,
+  laps: number[],
+  population: string[],
+  reference: TraceReference,
+  own: string,
+): Map<number, number> {
+  const times = new Map<number, number>();
+  for (const lap of laps) {
+    if (reference === "own") {
+      const value = bulk.drivers[own]?.crossings[lap];
+      if (value !== undefined) times.set(lap, value);
+      continue;
+    }
+    const atLap: number[] = [];
+    for (const code of population) {
+      const value = bulk.drivers[code]?.crossings[lap];
+      if (value !== undefined) atLap.push(value);
+    }
+    if (atLap.length === 0) continue;
+    if (reference === "leader") {
+      times.set(lap, Math.min(...atLap));
+    } else {
+      times.set(lap, atLap.reduce((sum, value) => sum + value, 0) / atLap.length);
+    }
+  }
+  return times;
+}
+
+/** The header's description of the zero line, in the reader's words. */
+function zeroLabel(reference: TraceReference, own: string): string {
+  if (reference === "leader") return "zero is the car leading that lap";
+  if (reference === "field") return "zero is the classified field's average";
+  return `zero is ${own}`;
+}
+
+/**
+ * Every driver's accumulated time against the reference.
+ *
+ * Positive is AHEAD. A car that has taken twelve seconds less than the
+ * reference to reach the same lap is twelve seconds up the road, so it plots
+ * twelve above the axis - which is the direction the eye already reads a
+ * position from, and the direction the gap columns of the tower above it grow.
+ *
+ * A retired car keeps every lap he actually drove; his line simply ends. That
+ * is not a special case in the code and should not become one: his crossings
+ * stop, so his points stop.
+ *
+ * Series order is `stableColumns`', imported rather than re-derived, with our
+ * own car moved LAST so it draws on top of the nineteen it has to be picked
+ * out from.
+ */
+export function raceTrace(
+  bulk: Bulk | null,
+  arcade: ArcadeState,
+  reference: TraceReference,
+): RaceTrace {
+  if (!bulk?.available) return EMPTY;
+
+  const own = arcade.driver_main;
+  const ordered = stableColumns(bulk, arcade.race_order);
+  const racing = population(bulk, arcade, ordered);
+  const last = lastCommonLap(bulk, racing);
+  if (last < 1) return { ...EMPTY, zero: zeroLabel(reference, own) };
+
+  const laps = Array.from({ length: last }, (_, index) => index + 1);
+  const times = referenceTimes(bulk, laps, racing, reference, own);
+  const plotted = laps.filter((lap) => times.has(lap));
+
+  const drawLast = ordered.filter((code) => code !== own);
+  if (ordered.includes(own)) drawLast.push(own);
+
+  const lines = drawLast.map((code) => {
+    const crossings = bulk.drivers[code]?.crossings ?? {};
+    const points: [number, number][] = [];
+    for (const lap of plotted) {
+      const value = crossings[lap];
+      if (value === undefined) continue;
+      points.push([lap, (times.get(lap) as number) - value]);
+    }
+    return { code, points };
+  });
+
+  return { laps: plotted, lines, zero: zeroLabel(reference, own) };
+}

--- a/src/pitwall/ui/src/styles/data.css
+++ b/src/pitwall/ui/src/styles/data.css
@@ -984,3 +984,54 @@
 .pace-table td.is-none {
   color: var(--qt-fg-3);
 }
+
+/* --- Band 3's second panel: the race trace ------------------------------- */
+
+.trace-band {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px;
+  min-height: 0;
+}
+
+/* The plot takes whatever the header leaves, and `min-height: 0` is what makes
+ * that true inside a flex column: without it the div takes its content height,
+ * ECharts measures zero and renders a canvas nothing ever appears on. */
+.trace-band-plot {
+  flex: 1;
+  min-height: 0;
+}
+
+.trace-band-empty {
+  color: var(--qt-fg-3);
+  font-size: 11px;
+  margin: auto;
+}
+
+/* The reference selector. It is the panel's ONLY control, so it sits in the
+ * header on the right where the pace grid puts its lap range - the same slot
+ * doing the same job, telling the reader what they are looking at. */
+.ref-strip {
+  display: flex;
+  gap: 3px;
+  margin-left: auto;
+}
+
+.ref {
+  background: none;
+  border: 1px solid var(--qt-border);
+  border-radius: 3px;
+  color: var(--qt-fg-3);
+  cursor: pointer;
+  font-family: var(--qt-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  padding: 1px 6px;
+}
+
+.ref.is-active {
+  background: var(--qt-elevated);
+  color: var(--qt-fg-1);
+}


### PR DESCRIPTION
Closes #944.

Band 3's second half. Sprint 6 shipped the race-pace grid and the tab strip; this is the race trace the same sprint was scoped for, so the delivery plan's sprint table stops promising something the tree does not contain.

## What it does

One line per driver of accumulated time against a reference, x = lap. The panel is read with a ruler held **vertically**: at any lap the vertical distance between two lines IS the gap between those cars, so one cut across the chart answers the whole grid's worth of intervals at once. Pit stops appear as steps, overtakes as crossings, a stint going off as a line bending away from its neighbours - none of them drawn, all of them arithmetic.

Three references, the panel's only control: **LEADER**, **FIELD** (the classified field's average) and **OWN** (our car flat on zero, so a line climbing towards zero is a car coming for us).

## The decisions, and what each one costs

**The seconds come from `crossings`.** `gapCell` already subtracts exactly these values to print the tower's GAP and INT, and two panels on one screen disagreeing about the same gap is this repo's most-repeated defect. Summing `lap_time` instead drifts - each is rounded to the millisecond and a race is 57 of them.

**The trace stops at the last lap the whole classified field has completed.** The reveal is per driver, so the newest laps are ragged; a reference averaged over a shrinking population swings every line on the next reveal and then springs back. A grid can be ragged because each cell is its own claim; a trace cannot, because every point is measured against a shared line. The accepted cost, so nobody files it: **the trace ends one to two laps behind the grid.**

**The reference population is classified AND named by the bulk**, and each filter deletes the panel if missing. Without the first, Melbourne's three lap-1 retirements cap the trace at lap zero. Without the second, a car in `race_order` the bulk has no entry for does the same - a state the grid already handles by rendering a blank column, and one the fixture carries.

**`stableColumns` is imported, not rewritten.** It would have been the third copy of that comparator, and the version that shipped was already wrong once.

## Verified against the real thing, not the fixture

Real Melbourne payload, live producer, live host, the DATA window's own 1485 x 833 client:

- 20 series, **17 drawn** - the three lap-1 retirements have no crossings and draw nothing, rather than a flat line at zero.
- **The trace does not contradict the tower.** Computed off one snapshot: for the 15 drivers whose `laps_revealed` equals the trace's cap, the trace's end value is the tower's GAP to 1e-6, sign-flipped. The two that differ are the two that had revealed one lap more, which the tower measures at that later lap by its own documented rule.
- The three references produce three different pictures: LEADER -66.6..0 with nothing above the axis, FIELD -30.0..+36.6 with 178 points above it.

## What the screenshot found that no number did

**Two end labels were drawn on top of each other** - ALB over HAM by 4.5 px of their 9 px height, and ALO over ANT by 0.8. An ECharts label is canvas text, so no selector, no axis extent and none of the page's checks could see it. The panel's only identification mechanism was partly unreadable, and it matters more than it looks: `driver_colors` are TEAM colours, ten of them across twenty cars, so the label is the only thing telling two team-mates apart.

Fixed with `labelLayout: { moveOverlap: "shiftY" }`, and the smoke now measures the **rendered label boxes** and fails on any overlap.

## Guards, each driven RED against the defect it names

Isolated mutation, build hash confirmed different every time, tree restored and 139/139 green afterwards.

| mutation | what went red |
|---|---|
| cap = the last lap ANYBODY has | `the trace stops at the last lap the whole field has completed (57, expected 55)` |
| a missing crossing defaults to 0 | 5 red, incl. `a car with no crossings draws nothing rather than a flat line at zero (55,55,55)` |
| population ignores the bulk | 10 red, incl. `the race trace draws a plot rather than its empty state` |
| FIELD is a relabelled LEADER | `against the field average the quick cars sit above the axis (0 points)` |
| no label de-collision | `no two driver codes are drawn on top of each other (BOR/LEC 15.6x9.0, VER/STR 16.2x9.0, RUS/HUL 17.8x0.3, BEA/HAM 17.0x9.0)` |

`smoke-data` 121 -> 139 checks. `smoke-agents` 18. `tests/surfaces` 225 passed, including the closed hex whitelist - no new colour enters `data.css`.

## Three things this cost, recorded because they will happen again

1. **The loopback server snapshots `dist` at startup.** After `npm run build` it kept serving the previous hash, so four label measurements in a row described code that was no longer in the tree - and one of them produced a confident, wrong conclusion ("`moveOverlap` does not apply to `endLabel`") that the corrected measurement refuted. Confirming the *build* landed is not confirming the *server* serves it.
2. **A comparison between two captures taken at different laps** briefly looked like a real disagreement between the trace and the tower. It was the wrong pair, not a bug.
3. **Two red-check mutations were not red checks**: one emptied the panel instead of widening it, and one did not compile.

## Out of scope

The trace's own polish belongs to sprint 9's DATA elevate pass. Two known properties are documented in place rather than fixed here: team-mates share a line colour (dashing the second car is the broadcast answer and is deliberately not taken, because a dashed line already means BROADCAST-TIER one tab away), and three labels inside one label-height would defeat the de-collision - the smoke reports that rather than shipping it quietly.
