### PR TITLE
fix(pitwall): the five the Fable gates found in band 3

### DIFF
--- a/src/pitwall/radio_feed.py
+++ b/src/pitwall/radio_feed.py
@@ -193,7 +193,16 @@ class RadioCorpus:
         SessionTime clock, which is what blocks a finer reveal - but it orders
         two events of the same lap perfectly well, and that is all it is asked
         to do here. (No row is missing one: 0 of 2,126 across the 24 races on
-        disk. A future null would sort first within its lap, never crash.)
+        disk.
+
+        ⚠️ **A future null would NOT "sort first within its lap, never crash",
+        which is what this said.** Executed: a `NaT` compares False against
+        everything, so it does not sink to one end - it lands where it happens
+        to and takes its neighbours' order with it, rendering 05:01 before
+        05:00. A plain `None` does not sort at all: `'<' not supported between
+        instances of 'NoneType' and 'Timestamp'`. The corpus has no such row
+        today, so this is a latent shape rather than a rate - but the sentence
+        that said it was harmless was wrong twice over.)
         """
         ordered: list[tuple[tuple[int, Any], str | None, dict[str, Any]]] = []
         for row in runner.radios_df.itertuples():

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -1187,6 +1187,15 @@ const PACE_FASTEST = { code: TOWER_ORDER[3], lap: 30, time: 84.111 };
  * refuse.
  */
 const PACE_LAPPED = { code: "LAW", laps: 55 };
+/**
+ * A car that RACED and then stopped, unlike `RETIRED_CODES` who never started.
+ *
+ * The existing retirees carry zero crossings, so removing them from a reference
+ * average changes nothing - which is exactly why the fixture was 100 % blind to
+ * a reference computed over CURRENT status moving the drawn history under the
+ * reader. This one has 30 real laps behind him and then nothing.
+ */
+const PACE_RETIRED_MIDRACE = { code: TOWER_ORDER[8], laps: 30 };
 
 function paceBulk() {
   const drivers = {};
@@ -1217,11 +1226,19 @@ function paceBulk() {
     const crossings = {};
     let elapsed = 0;
     let best = null;
-    const revealed = code === PACE_LAPPED.code ? PACE_LAPPED.laps : PACE_LAPS;
+    const revealed =
+      code === PACE_LAPPED.code
+        ? PACE_LAPPED.laps
+        : code === PACE_RETIRED_MIDRACE.code
+          ? PACE_RETIRED_MIDRACE.laps
+          : PACE_LAPS;
     for (let lap = 1; lap <= revealed; lap += 1) {
       const pitIn = lap === 20 && index % 5 === 0;
       const pitOut = lap === 21 && index % 5 === 0;
       const isFastest = code === PACE_FASTEST.code && lap === PACE_FASTEST.lap;
+      // 119.96 s renders "1:60.0" if the minutes are split off BEFORE the
+      // tenths are rounded - a non-time that the cell regex below accepts.
+      const onBoundary = code === TOWER_ORDER[2] && lap === 50;
       // Laps 2-6 are the safety car, and they are in this fixture because the
       // REAL race has them: measured on Melbourne 2025, 82.4 % of laps sit
       // past +10 % of the session best, so a heat scale anchored on that best
@@ -1229,7 +1246,13 @@ function paceBulk() {
       // the two scales apart - this one can.
       const neutralised = lap >= 2 && lap <= 6;
       const green = 85 + (index % 9) * 0.4 + ((lap * 3) % 11) * 0.2;
-      const time = isFastest ? PACE_FASTEST.time : neutralised ? green * 2.4 : green;
+      const time = onBoundary
+        ? 119.96
+        : isFastest
+          ? PACE_FASTEST.time
+          : neutralised
+            ? green * 2.4
+            : green;
       // Melbourne really carries deleted racing laps - six of them - and every
       // row of this fixture used to say `deleted: false`, so the branch that
       // paints them was never entered by any check.
@@ -1259,6 +1282,29 @@ function paceBulk() {
     drivers, radio: { available: true, events: [] } };
 }
 
+/**
+ * The tower's field, with the mid-race retirement actually marked as retired.
+ *
+ * `towerField()` cannot carry it: the tower's own checks assert LEC's gaps, and
+ * a car that is OUT renders `OUT` instead. The trace reads status from the tick
+ * and laps from the bulk, so this is the only fixture where the two have to
+ * disagree - a car with 30 laps of real history who is no longer running.
+ *
+ * Left RUNNING he would pin the cap at 30 of 57, which is the OBS-4 shape the
+ * plan documents (a classified car whose telemetry stopped) and a real state -
+ * but not the one this scenario is built to test.
+ */
+function paceField() {
+  const field = towerField();
+  field[PACE_RETIRED_MIDRACE.code] = driver({
+    laps_completed: PACE_RETIRED_MIDRACE.laps,
+    progress: PACE_RETIRED_MIDRACE.laps + 0.4,
+    active: false,
+    has_finished: false,
+  });
+  return field;
+}
+
 const paceCtx = await browser.newContext({ viewport: { width: 1485, height: 833 } });
 const pacePage = await paceCtx.newPage();
 pacePage.on("pageerror", (error) => failures.push(`pageerror(pace): ${error.message}`));
@@ -1271,7 +1317,7 @@ await pacePage.addInitScript(
       get_connection: async () => "Connected",
     } };
   },
-  [tick(1, { drivers: towerField(), order: TOWER_ORDER }), paceBulk(), towerLive()],
+  [tick(1, { drivers: paceField(), order: TOWER_ORDER }), paceBulk(), towerLive()],
 );
 await pacePage.goto(url, { waitUntil: "domcontentloaded" });
 await pacePage.waitForSelector(".tab-strip", { timeout: 5000 });
@@ -1358,6 +1404,19 @@ check(paceCells.rows === PACE_LAPS, `one row per lap of the race (${paceCells.ro
 check(paceCells.pitText === "IN PIT" && paceCells.outText === "OUT",
   "the in-lap and the out-lap replace the time, as a timing screen shows them");
 check(paceCells.best === 1, `exactly one purple cell - the session's fastest lap (${paceCells.best})`);
+
+// A lap 40 ms under a minute boundary. Splitting the minutes off BEFORE
+// rounding the tenths renders "1:60.0" - a time that does not exist, and one
+// the cell regex above accepts without complaint.
+const boundaryCell = await pacePage.evaluate(() => {
+  const rows = [...document.querySelectorAll(".pace-table tbody tr")];
+  const row = rows.find((r) => r.querySelector("th")?.textContent === "50");
+  return [...(row?.querySelectorAll("td") ?? [])].map((c) => c.textContent);
+});
+check(
+  boundaryCell.includes("2:00.0") && !boundaryCell.some((t) => /:60\./.test(t ?? "")),
+  `a lap just under a minute boundary rounds up to the next minute, never :60 (${boundaryCell.filter((t) => t && t.startsWith("1:5") === false && t.includes(":")).slice(0, 3).join(",")})`,
+);
 
 // A deleted time is struck through and carries NO rank. It used to carry the
 // FASTEST one: the ranking excludes it, so `indexOf` answered -1, and -1 and
@@ -1596,6 +1655,62 @@ check(
 check(
   aboveField > 0,
   `against the field average the quick cars sit above the axis (${aboveField} points)`,
+);
+
+// A trace that stops and a race that ended are the same pixels, so the bound
+// says how far behind the race it sits. One car with a mid-race telemetry
+// dropout pins it silently otherwise (OBS-4).
+const traceRange = await pacePage.locator(".trace-band .pace-range").innerText();
+check(
+  traceRange.includes(`of ${PACE_LAPS}`),
+  `the trace says how far behind the race its bound sits (${traceRange})`,
+);
+
+// **A car that RACED and then stopped stays in the reference for the laps he
+// drove.** The reference used to be averaged over the CURRENT population, so
+// the moment a car retired he left it and every point of every line - back to
+// lap 1 - was recomputed without him: measured on the real payload, all 45 of
+// NOR's historical points moved by up to 7.6 s at one retirement. It is the
+// twin of the lap-axis bound this module already had. Computed here from the
+// fixture's own bulk rather than asserted about the mechanism.
+const historyStable = await pacePage.evaluate(
+  ([bulk, probeLap, code, retired]) => {
+    const chart = document.querySelector(".trace-band-plot")?.__pitwallChart;
+    if (!chart) return null;
+    const mean = (entries) =>
+      entries.reduce((sum, v) => sum + v, 0) / entries.length;
+    const withCrossing = (codes) =>
+      codes
+        .map((c) => bulk.drivers[c]?.crossings[probeLap])
+        .filter((v) => v !== undefined);
+    const all = Object.keys(bulk.drivers);
+    const own = bulk.drivers[code].crossings[probeLap];
+    const series = chart.getOption().series.find((x) => x.name === code);
+    const point = series?.data.find(([lap]) => lap === probeLap);
+    return {
+      cars: withCrossing(all).length,
+      // Everyone who completed this lap, retired-since or not.
+      everyone: mean(withCrossing(all)) - own,
+      // The refuted alternative: only the cars still classified NOW.
+      stillRacing: mean(withCrossing(all.filter((c) => c !== retired))) - own,
+      actual: point ? point[1] : null,
+    };
+  },
+  [paceBulk(), 10, TOWER_ORDER[0], PACE_RETIRED_MIDRACE.code],
+);
+
+// The two hypotheses must be TELLABLE APART on this fixture, or the assertion
+// below is decoration. The first version of this check chose a probe driver
+// sitting exactly on the field mean, so removing him moved nothing and the
+// guard stayed green against the very defect it names.
+check(
+  historyStable !== null &&
+    Math.abs(historyStable.everyone - historyStable.stillRacing) > 0.5,
+  `the fixture can tell the two reference populations apart (${(historyStable?.everyone - historyStable?.stillRacing)?.toFixed(3)} s)`,
+);
+check(
+  historyStable !== null && Math.abs(historyStable.everyone - historyStable.actual) < 1e-9,
+  `a retired car still counts in the laps he drove (everyone ${historyStable?.everyone?.toFixed(3)}, still-racing ${historyStable?.stillRacing?.toFixed(3)}, rendered ${historyStable?.actual?.toFixed(3)}, over ${historyStable?.cars} cars)`,
 );
 
 await paceCtx.close();

--- a/src/pitwall/ui/src/features/data/RaceTraceChart.tsx
+++ b/src/pitwall/ui/src/features/data/RaceTraceChart.tsx
@@ -171,6 +171,15 @@ export function RaceTraceChart({ bulk, arcade }: { bulk: Bulk | null; arcade: Ar
       <header className="pace-header">
         <span className="pace-title">RACE TRACE</span>
         <span className="pace-subtitle">{trace.zero}</span>
+        {/* How far the bound is behind the race, said out loud. A trace that
+            stops is indistinguishable from a race that stopped, and one car
+            with a mid-race telemetry dropout pins it silently - see
+            `RaceTrace.total`. */}
+        {trace.laps.length ? (
+          <span className="pace-range">
+            LAPS {trace.laps[0]}-{trace.laps[trace.laps.length - 1]} of {trace.total}
+          </span>
+        ) : null}
         <nav className="ref-strip" role="tablist" aria-label="reference">
           {(["leader", "field", "own"] as const).map((id) => (
             <button

--- a/src/pitwall/ui/src/lib/racePace.ts
+++ b/src/pitwall/ui/src/lib/racePace.ts
@@ -7,10 +7,16 @@
  *
  * **The colour is a RANK within the lap, not a percentage off a session best,
  * and the difference is the whole design.** Measured on the real Melbourne
- * 2025 payload: against the session's fastest lap the median lap is +13.79 %
- * and 82.4 % of the race falls past +10 %, because the race was wet and ran
- * safety cars - so any fixed percentage band paints four fifths of the grid in
- * one colour and says nothing. Ranked inside its own lap instead, the field
+ * 2025 payload, over the 776 rows this grid actually RANKS: against the
+ * session's fastest lap the median lap is +13.03 % and 80.7 % of the race falls
+ * past +10 %, because the race was wet and ran safety cars - so any fixed
+ * percentage band paints four fifths of the grid in one colour and says
+ * nothing. (This pair used to read +13.79 % / 82.4 %, which is the same
+ * arithmetic over 858 rows including the 82 pit laps and 6 deleted times the
+ * ranking EXCLUDES and the grid never colours - a figure describing a
+ * population the sentence is not about. An earlier gate certified it as "exact"
+ * by reproducing the same wrong population: replicating arithmetic is not
+ * confirming a claim.) Ranked inside its own lap instead, the field
  * splits into thirds by construction on every lap of every race, wet or dry,
  * green or neutralised, with no threshold tuned on the one race that happens
  * to be on this disk. It is also what "race pace" means to a strategist: who
@@ -99,7 +105,14 @@ export function stableColumns(bulk: Bulk, order: string[]): string[] {
 }
 
 /**
- * `m:ss.d` - the broadcast form, truncated to tenths.
+ * `m:ss.d` - the broadcast form, rounded to tenths.
+ *
+ * **Rounded, and the minutes are split off AFTERWARDS, which is not a detail.**
+ * Splitting first and rounding the remainder renders a non-time in the 50 ms
+ * under every minute boundary: 119.96 s came out as `1:60.0`, and the smoke's
+ * `^\d:\d\d\.\d$` accepts that happily. No lap of the one race on disk
+ * reaches such a value; a season will. (This docstring also used to say
+ * "truncated", which it never did.)
  *
  * **The truncation is what makes the grid fit at all.** Measured against the
  * real built stylesheet at the right column's real width: twenty columns of
@@ -109,8 +122,11 @@ export function stableColumns(bulk: Bulk, order: string[]): string[] {
  * sentence said 793, which was measured on a prototype whose synthetic times
  * were spread across the race's whole range rather than on the payload the
  * window serves - the wrong-distribution class, in a comment. The smoke's own
- * fixture clips 85, so it is about 2.4x less sensitive than the real race:
- * worth knowing before trusting an "it fits" from it.)
+ * smoke's own fixture clips materially fewer than the real race, so an "it
+ * fits" measured on the fixture is weaker evidence than one measured on the
+ * payload. No count is quoted here on purpose: the last one was written four
+ * minutes after a commit changed the fixture underneath it and was stale on
+ * arrival.)
  *
  * Tenths is also the resolution the grid needs, because the ranking colour
  * carries the ordering and the number carries the magnitude.
@@ -121,8 +137,9 @@ export function stableColumns(bulk: Bulk, order: string[]): string[] {
  * downloadable here to test it.
  */
 export function paceLabel(seconds: number): string {
-  const minutes = Math.floor(seconds / 60);
-  const rest = seconds - minutes * 60;
+  const tenths = Math.round(seconds * 10);
+  const minutes = Math.floor(tenths / 600);
+  const rest = (tenths - minutes * 600) / 10;
   return `${minutes}:${rest.toFixed(1).padStart(4, "0")}`;
 }
 

--- a/src/pitwall/ui/src/lib/raceTrace.ts
+++ b/src/pitwall/ui/src/lib/raceTrace.ts
@@ -12,12 +12,23 @@
  * crossing; a stint going off is a line bending away from its neighbours.
  * None of those are drawn - they fall out of the arithmetic.
  *
- * **The seconds come from `crossings`, which is the tower's clock and not a
- * second one.** `gapCell` already subtracts exactly these values to print the
- * GAP and INT columns, and two panels on the same screen disagreeing about the
- * same gap is the twin defect this repo pays for most often. The alternative
- * source - summing `lap_time` - drifts, because a lap time is rounded to the
- * millisecond and a race is 57 of them.
+ * **The seconds come from `crossings`, the same clock `gapCell` subtracts to
+ * print the tower's GAP and INT columns.** The alternative - summing
+ * `lap_time` - drifts, because a lap time is rounded to the millisecond and a
+ * race is 57 of them.
+ *
+ * ⚠️ **That does NOT mean the two panels always print the same number, and the
+ * claim that they cannot disagree was FALSE.** What holds, and what was
+ * measured over all 7,018 at-line pairs of Melbourne 2025 under all three
+ * references, is that the VERTICAL DISTANCE between two lines equals the
+ * difference of their crossings - the thing the panel is read with. What does
+ * not hold is agreement with the tower's GAP column, because the two answer to
+ * different leaders: the tower measures against `race_order[0]`, the wire's
+ * classified P1, and this measures against the car that crossed THAT LAP's
+ * line first. Melbourne has three at-line lead changes (laps 44, 46, 47), and
+ * in the window after VER first crosses line 44 every driver's tower GAP sits
+ * a uniform 3.737 s from the trace's end value - VER's lap-43 advantage over
+ * NOR, applied to the whole field. Both are right about their own question.
  *
  * ⚠️ **The reveal is per driver and strict, so the newest laps are ragged**,
  * and a reference averaged over a ragged edge moves under the reader: at the
@@ -58,12 +69,39 @@ export interface RaceTrace {
   lines: TraceLine[];
   /** What the zero line is, for the header to say out loud. */
   zero: string;
+  /**
+   * The race's own length, so the header can say how far behind the bound sits.
+   *
+   * **This is what stops a frozen cap being silent.** A car that took the
+   * chequered flag but lost telemetry mid-race keeps `laps_completed` stuck at
+   * the dropout - the plan carries it as OBS-4 - and being classified, he stays
+   * in the cap population and pins the whole trace there. Measured shape: a
+   * lap-20 dropout freezes the panel at 20 of 57 and nothing on screen says so,
+   * because a trace that ends is indistinguishable from a race that ended.
+   * Printing the total turns a frozen panel into a visible one.
+   */
+  total: number;
 }
 
-const EMPTY: RaceTrace = { laps: [], lines: [], zero: "" };
+const EMPTY: RaceTrace = { laps: [], lines: [], zero: "", total: 0 };
 
 /**
- * The cars the reference is computed over, and the cars that bound it.
+ * The cars that BOUND the lap axis. Not the cars the reference averages over -
+ * see `referenceTimes`, and see the defect below for why they are two lists.
+ *
+ * ⚠️ **They used to be one list, and it moved the drawn history under the
+ * reader.** This filter reads CURRENT status, so the moment a car retires it
+ * leaves the set - and if the reference were averaged over the same set, every
+ * point of every line, all the way back to lap 1, would be recomputed without
+ * him. Executed on the real payload: at LAW's retirement all 45 of NOR's
+ * historical points shift, by up to 7.612 s, in FIELD mode. Melbourne alone
+ * does that three times.
+ *
+ * It is the twin of the bound this very module introduced. `lastCommonLap`
+ * exists because a reference computed over a population that changes with the
+ * REVEAL swings every line; the identical failure on the STATUS axis went
+ * unfixed in the same file. The smoke could not see it: its retirees carry no
+ * crossings at all, so removing them from an average changes nothing.
  *
  * Two filters, and each one deletes the panel if it is missing.
  *
@@ -91,7 +129,7 @@ const EMPTY: RaceTrace = { laps: [], lines: [], zero: "" };
  * measured identical at every reveal - so this is a guard against a shape the
  * types allow, not a rate.
  */
-function population(bulk: Bulk, arcade: ArcadeState, codes: string[]): string[] {
+function capPopulation(bulk: Bulk, arcade: ArcadeState, codes: string[]): string[] {
   return codes.filter((code) => {
     const car = arcade.drivers[code];
     if (car === undefined || driverStatus(car) === "out") return false;
@@ -157,7 +195,7 @@ function lastCommonLap(bulk: Bulk, codes: string[]): number {
 function referenceTimes(
   bulk: Bulk,
   laps: number[],
-  population: string[],
+  codes: string[],
   reference: TraceReference,
   own: string,
 ): Map<number, number> {
@@ -169,7 +207,7 @@ function referenceTimes(
       continue;
     }
     const atLap: number[] = [];
-    for (const code of population) {
+    for (const code of codes) {
       const value = bulk.drivers[code]?.crossings[lap];
       if (value !== undefined) atLap.push(value);
     }
@@ -215,12 +253,17 @@ export function raceTrace(
 
   const own = arcade.driver_main;
   const ordered = stableColumns(bulk, arcade.race_order);
-  const racing = population(bulk, arcade, ordered);
-  const last = lastCommonLap(bulk, racing);
-  if (last < 1) return { ...EMPTY, zero: zeroLabel(reference, own) };
+  const last = lastCommonLap(bulk, capPopulation(bulk, arcade, ordered));
+  const total = bulk.race.total_laps;
+  if (last < 1) return { ...EMPTY, total, zero: zeroLabel(reference, own) };
 
   const laps = Array.from({ length: last }, (_, index) => index + 1);
-  const times = referenceTimes(bulk, laps, racing, reference, own);
+  // EVERY driver the wire names, not the ones still running: a car that
+  // retired on lap 30 was part of the race on laps 1-30 and belongs in those
+  // laps' reference. `referenceTimes` skips whoever has no crossing at a lap,
+  // so the set is exactly "who completed this lap" - which only ever GROWS as
+  // the reveal advances, and therefore cannot move a point already drawn.
+  const times = referenceTimes(bulk, laps, ordered, reference, own);
   const plotted = laps.filter((lap) => times.has(lap));
 
   const drawLast = ordered.filter((code) => code !== own);
@@ -237,5 +280,5 @@ export function raceTrace(
     return { code, points };
   });
 
-  return { laps: plotted, lines, zero: zeroLabel(reference, own) };
+  return { laps: plotted, lines, total, zero: zeroLabel(reference, own) };
 }


### PR DESCRIPTION
Five Fable gates ran in parallel over this programme: re-runs of `GATE_PITWALL_ARCH_A`, `GATE_PITWALL_ARCH_B`, sprint 6's correctness gate and sprint 6's band-3 design gate — all four of which had run on a weaker model while Fable was out of quota — plus a fresh exit gate over sprint 7's own work.

**None of them differ on a verdict.** ARCH-A: 11 confirmed, 4 partially right, 0 refuted, both P0s intact and every scope deletion justified. ARCH-B: 9 of 9 confirmed, reference graph rebuilt by AST. Sprint 6: 9 of 11 confirmed and the other 2 were the artefacts its own author had already recanted. Band 3: the shipped orientation stands. That debt is settled.

This PR is what they found that nobody had looked for.

## The one that matters — the trace's reference moved the drawn history

`raceTrace.ts` averaged its reference over the population that is **currently** racing. So the moment a car retired he left the set, and every point of every line, back to lap 1, was recomputed without him. Measured on the real Melbourne payload: **all 45 of NOR's historical points shift by up to 7.612 s** at LAW's retirement, in FIELD mode, and the one race on disk does that three times.

It is the twin of the bound this same module introduced. `lastCommonLap` exists precisely because a reference over a population that changes with the REVEAL swings every line; the identical failure on the STATUS axis went unfixed in the same file, in the same sprint, by me.

The cap population and the reference population are now two lists with two jobs: the cap needs cars still classified (or three lap-1 retirements pin it at zero), the reference needs whoever completed *that* lap — a set that only ever grows, and therefore cannot move a point already drawn.

**The smoke was 100 % blind to it.** Its retirees carry no crossings at all, so removing them from an average changes nothing. The fixture now has a car that raced for thirty laps and then stopped.

## And four more

- **`paceLabel` rendered `1:60.0`** in the 50 ms under every minute boundary, because the minutes were split off before the tenths were rounded — and the smoke's own `^\d:\d\d\.\d$` accepts that happily. No lap of the one race on disk reaches it; a season will.
- **The trace now says how far behind the race its bound sits** (`LAPS 1-24 of 57`). A classified car whose telemetry stopped mid-race pins the whole panel there — the plan carries it as OBS-4 — and a trace that ends is indistinguishable from a race that ended.
- **The heat scale's `+13.79 % / 82.4 %` described the wrong population.** It is 858 rows including the 82 pit laps and 6 deleted times the ranking EXCLUDES and the grid never colours. Over the 776 rows actually painted it is **+13.03 % / 80.7 %**. Re-measured here before changing it. The conclusion survives — but the earlier gate had certified the number as "exact" by reproducing the same wrong population, which is replicating arithmetic rather than confirming a claim.
- **"The two panels cannot disagree about one gap" was FALSE** — a true clause inside a false headline, which is this repo's favourite disguise. They answer to different leaders: the tower measures against the wire's classified P1, the trace against whoever crossed *that lap's* line first. Melbourne has three at-line lead changes, and after the first every driver's tower GAP sits a uniform 3.737 s from the trace's end value. What actually holds, over all 7,018 at-line pairs under all three references, is that the vertical distance between two lines equals the difference of their crossings — which is what the panel is read with.
- **`radio_feed`'s "a future null would sort first, never crash"** is wrong twice, executed: a `NaT` compares False against everything and takes its neighbours' order with it (05:01 rendered before 05:00), and a plain `None` raises `TypeError`.

## Guards

Both new guards driven RED against the defect they name, isolated build, hash confirmed different:

| mutation | red |
|---|---|
| reference over the current population again | `a retired car still counts in the laps he drove (everyone 27.200, still-racing 25.387, rendered 25.387, over 16 cars)` |
| `paceLabel` splits the minutes off before rounding | `a lap just under a minute boundary rounds up to the next minute, never :60` |

**The first version of the history guard stayed GREEN against its own defect.** It probed a driver sitting exactly on the field mean — `(index % 9) * 0.4`, and the mean of 0..8 is 4 — so removing him moved nothing. It now measures both hypotheses and asserts they are distinguishable *before* asserting which one ships.

`smoke-data` 139 → 143 checks · `smoke-agents` 18 · `tests/surfaces` 208 passed · ruff clean on the CI-pinned 0.15.22.

## Filed, not fixed here

#949 (the `LAPS` range says which laps exist, not which are on screen), #950 (`_agents_connection` is host-global, so a second AGENTS consumer never learns the producer died), #951 (the arcade skips `repair_tyre_stints`, so its tyre age disagrees with PITWALL's tower on the same screen). Sprint 9 keeps the width axis (863 of 1,140 cells clip on a 1080p laptop at 150 %), the safety-car ranking semantics, and the scroll pin.
