### PR TITLE
docs: pause contributions until v3.0.0, and finish the Qt sweep the last one missed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,24 @@
 Short guide for anyone cloning the TFG to experiment, fix a bug, or
 propose a change.
 
+## Contributions are paused until v3.0.0
+
+**This is temporary, and it is about timing rather than about the work.**
+
+The repository is in the middle of heavy development: surfaces are being
+migrated (the PySide6 dashboard was retired in favour of PITWALL), the data
+plane is being rewired, and the sprints run against a sequenced plan where each
+one depends on the shape the previous one left. An incoming pull request, however
+good, lands in the middle of that and reorders it.
+
+So **pull requests are not being accepted for now**. Issues are welcome and
+genuinely useful — a well-described bug is worth more here than a patch, because
+it can be scheduled into the sprint that owns that code.
+
+**Once v3.0.0 is operational, contributions open up.** That is the milestone
+where live inference lands and the architecture stops moving underneath
+everything else; after it, this section goes away.
+
 ## Branching model
 
 Three long-lived branches, in increasing order of stability:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -70,11 +70,16 @@ f1-arcade --viewer --year 2025 --round 3 --driver VER --team "Red Bull Racing" -
 Three windows spawn from that one command:
 
 1. Arcade replay (pyglet), track · leaderboard · weather · driver info
-2. Strategy Dashboard (PySide6), orchestrator + 6 agent cards + charts
-3. Live Telemetry (PySide6), 2×2 grid Delta / Speed / Brake / Throttle
+2. **PITWALL · AGENTS**, orchestrator + 6 agent cards + charts
+3. **PITWALL · DATA**, status strip, timing tower, bests, own-car traces,
+   race pace and race trace
 
-**Docker is NOT recommended for Arcade**: pyglet + Qt need a host OpenGL
-context and a native display. Cross-platform X forwarding from a
+The two PITWALL windows are React built to static files and hosted in the
+platform webview, in one subprocess sharing a single stream client. They
+replaced a PySide6 pair in sprint 7.
+
+**Docker is NOT recommended for Arcade**: pyglet and the platform webview need a
+host OpenGL context and a native display. Cross-platform X forwarding from a
 container is fragile on Windows / Mac and has no benefit over a local
 install. Use `uv tool install` and run on the host.
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ See [`ARCHITECTURE.md`](ARCHITECTURE.md) for the one-page topology and [`docs/`]
 | Surface                            | Command                                                                                                     | When to use                                                                                          |
 | ---------------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | **CLI**                      | `f1-strat` (interactive wizard) · `f1-sim Melbourne VER "Red Bull Racing" --year 2025` (headless)                                                      | Headless Rich-based live inference panel for a single race. `f1-strat` opens an arrow-key menu (GP, driver, provider, head-to-head); `f1-sim` is the scripted form. |
-| **Arcade** (primary live UI) | `f1-arcade --viewer --year 2025 --round 3 --driver VER --team "Red Bull Racing" --driver2 LEC --strategy` | Three-window 2D race replay + PySide6 strategy dashboard + live telemetry grid. No backend required. |
+| **Arcade** (primary live UI) | `f1-arcade --viewer --year 2025 --round 3 --driver VER --team "Red Bull Racing" --driver2 LEC --strategy` | Three-window 2D race replay + the two PITWALL windows (AGENTS and DATA). No backend required. |
 | **Web app** (post-race)    | `f1-webapp` (wraps `docker compose up`)                                                               | React SPA (Vite + TypeScript + Tailwind + ECharts): telemetry dashboard, 60fps driver comparison, ML model lab, multi-agent pit-wall strategy, race analysis, and a streaming AI chat that renders tool results inline. Backed by FastAPI. |
 
 The Arcade is in the hero above. Here are the other two:
@@ -118,7 +118,8 @@ Requires Python 3.10-3.12 and an `OPENAI_API_KEY` (or `F1_LLM_PROVIDER=lmstudio`
 
 ## Project layout
 
-- [`src/arcade/`](src/arcade/): 2D race replay (pyglet) + PySide6 strategy dashboard
+- [`src/arcade/`](src/arcade/): 2D race replay (pyglet) + the TCP broadcast the followers read
+- [`src/pitwall/`](src/pitwall/): the two desktop windows (React in a webview, one stream client)
 - [`src/agents/`](src/agents/): multi-agent orchestrator (N25 → N31)
 - [`src/simulation/`](src/simulation/): `RaceReplayEngine` + `RaceStateManager`
 - [`src/telemetry/`](src/telemetry/): FastAPI backend + React web app (post-race UI, git submodule)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -460,7 +460,8 @@ Wire the multi-agent system into the FastAPI backend, expose strategy tools via 
 **Step 12: Arcade simulation UI:** ✅ COMPLETE (Phase 3.5 Proceso B, 2026-04-18)
 
 - [X] Three windows from one command: pyglet race replay, PySide6 strategy dashboard,
-      PySide6 live telemetry (2x2 pyqtgraph grid). Single launcher:
+      PySide6 live telemetry (2x2 pyqtgraph grid) — the Qt pair was retired in sprint 7
+      and replaced by the two PITWALL windows. Single launcher:
       `python -m src.arcade.main --viewer --strategy ...`
 - [X] Local strategy pipeline: `src/arcade/strategy_pipeline.py` duplicates the N31
       orchestrator body with verbose outputs. The arcade no longer calls the FastAPI
@@ -644,7 +645,7 @@ letting the roadmap contradict the CHANGELOG.
 
 | Version | Milestone | What it adds |
 |---|---|---|
-| **v2.6.0** | Arcade, modernized | A web-native trackside frontend for part of the live Arcade experience, running **alongside** the pyglet 2D replay rather than replacing it. The strategy and telemetry surfaces move to a web-native view, reusing the React app's tab and URL-contract machinery from v2.0.0. The `lap_state` contract and the agents stay unchanged. |
+| **v2.6.0** | Arcade, modernized | A trackside frontend built in **web technology** for part of the live Arcade experience, running **alongside** the pyglet 2D replay rather than replacing it. **Desktop windows, not a web app**: the strategy and telemetry surfaces move to React hosted in the platform webview, reusing the React app's tab and URL-contract machinery from v2.0.0 — they open as OS windows and need no browser and no server. The `lap_state` contract and the agents stay unchanged. |
 | **v2.8.0** | Rival Agent | A new, additive LangGraph node that predicts each nearby rival's next strategic move (pit window, compound, undercut/overcut) and feeds it to the orchestrator. Recommendations move from reactive to anticipatory. The six existing agents are untouched. |
 | **v3.0.0** | Live race inference | Real-time ingestion over the OpenF1 WebSocket (the `lap_state` contract is unchanged, so agents and orchestrator don't change), plus adaptation to the 2026 technical/sporting regulation (re-cluster, re-label compounds, drift monitoring). |
 

--- a/docs/pages/multi-agent.md
+++ b/docs/pages/multi-agent.md
@@ -73,16 +73,18 @@ graph LR
         STREAM[TelemetryStreamServer<br/>TCP 127.0.0.1:9998]
     end
 
-    subgraph pw["PITWALL subprocess (one TCP client, two webviews)"]
+    subgraph pw["PITWALL subprocess"]
+        HOST[PitwallHost<br/>ONE ArcadeStreamClient]
         AGENTS[PITWALL - AGENTS<br/>orchestrator + 6 cards]
         DATA[PITWALL - DATA<br/>tower, bests, traces, race pace]
+        HOST -->|poll by seq| AGENTS
+        HOST -->|poll by seq| DATA
     end
 
     REPLAY --> PIPE
     PIPE --> STREAM
     REPLAY --> STREAM
-    STREAM -->|TCP broadcast ~10 Hz| AGENTS
-    STREAM -->|TCP broadcast ~10 Hz| DATA
+    STREAM -->|TCP broadcast ~10 Hz| HOST
 ```
 
 Four properties are load-bearing:

--- a/docs/pages/roadmap.md
+++ b/docs/pages/roadmap.md
@@ -477,8 +477,8 @@
       <span class="rl-version"><span class="sr-only">Version: </span>v2.6.0</span>
       <span class="rl-badge planned-badge"><span class="sr-only">Status: </span>Planned</span>
     </div>
-    <p class="rl-title">Arcade, modernized: a web-native trackside frontend</p>
-    <p class="rl-summary">Bring the web app's modern frontend to part of the live Arcade experience, running alongside the pyglet 2D replay rather than replacing it. The strategy and telemetry surfaces move to a web-native view; the <code>lap_state</code> contract and the agents stay unchanged.</p>
+    <p class="rl-title">Arcade, modernized: a trackside frontend in web technology</p>
+    <p class="rl-summary">Bring the web app's modern frontend to part of the live Arcade experience, running alongside the pyglet 2D replay rather than replacing it. The strategy and telemetry surfaces move to React hosted in the platform webview - desktop windows, not a web app; the <code>lap_state</code> contract and the agents stay unchanged.</p>
   </div>
 </li>
 

--- a/documents/research/PITWALL_DELIVERY_PLAN.md
+++ b/documents/research/PITWALL_DELIVERY_PLAN.md
@@ -44,8 +44,8 @@ Commands handed over are PowerShell, one command per physical line, starting wit
 | 3 | AGENTS window, 1:1 | rewritten #285 | adversarial: is it ACTUALLY 1:1, field by field |
 | 4 | **DATA band 4: own-car traces + the ring** (REORDERED 2026-08-09, see §5) | rewritten #284 (c) | none |
 | 5 | DATA bands 1-2: status, timing table, bests | rewritten #284 (a) | none |
-| 6 | DATA band 3: race pace grid + race trace | rewritten #284 (b) | adversarial: tier discipline and fidelity claims |
-| 7 | Retire Qt, package, fix the prose | rewritten #285, new | **exit gate, then the ONE `dev -> main`** |
+| 6 | DATA band 3: race pace grid | rewritten #284 (b) | adversarial: tier discipline and fidelity claims |
+| 7 | **DATA band 3: race trace** (#944, the half sprint 6 did not build) · retire Qt · package · fix the prose | rewritten #285, #944, new | **exit gate** (the `dev -> main` promotion is deferred: Víctor, 2026-08-15) |
 | **8** | **AGENTS: the elevate pass** | new | Fable as senior dashboard designer, P0-P3 with file:line |
 | **9** | **DATA: the elevate pass** | new | same |
 

--- a/scripts/dev_pitwall_producer.py
+++ b/scripts/dev_pitwall_producer.py
@@ -1,11 +1,11 @@
 """Dev-only broadcast producer with a POPULATED strategy block.
 
 Drives the real `TelemetryStreamServer` from the real Melbourne 2025 session
-so PITWALL and the Qt dashboard can be developed against a full payload
-without launching the arcade, running the agent pipeline, or spending a
-single LLM call. Built for the sprint-3 AGENTS port, where an empty
-strategy block leaves every card in its idle state and there is nothing to
-compare against the window being replaced.
+so PITWALL can be developed against a full payload without launching the
+arcade, running the agent pipeline, or spending a single LLM call. Built for
+the sprint-3 AGENTS port, where an empty strategy block leaves every card in
+its idle state and there was nothing to compare against the Qt window it was
+replacing.
 
     python scripts/dev_pitwall_producer.py 180      # seconds to broadcast
 

--- a/scripts/run_webapp.py
+++ b/scripts/run_webapp.py
@@ -3,7 +3,7 @@
 Exposed via ``[project.scripts]`` in ``pyproject.toml`` so an installed
 checkout gives the user a single-command launcher for the post-race web
 app (FastAPI backend + React SPA) alongside ``f1-sim`` (CLI) and
-``f1-arcade`` (race replay + PySide6 dashboards).
+``f1-arcade`` (race replay + the two PITWALL windows).
 
 Running this module delegates to ``docker compose up`` at the repo root:
 compose is the canonical way to serve the web app (nginx serves the built

--- a/src/arcade/README.md
+++ b/src/arcade/README.md
@@ -1,10 +1,12 @@
-# `src/arcade/`, race replay + strategy dashboard
+# `src/arcade/`, race replay + the broadcast its followers read
 
-2D race replay (pyglet via the `arcade` library) plus the PySide6
-dashboard subprocess spawned from the same command. One invocation of
-`f1-arcade` opens three top-level windows: the arcade replay, the
-strategy dashboard (orchestrator card + six sub-agent cards + reasoning
-tabs), and the live telemetry window (2×2 circuit-comparison grid).
+2D race replay (pyglet via the `arcade` library) plus the PITWALL
+subprocess spawned from the same command. One invocation of `f1-arcade`
+opens three top-level windows: the arcade replay, **PITWALL · AGENTS**
+(orchestrator card + six sub-agent cards + reasoning tabs) and
+**PITWALL · DATA** (status strip, timing tower, bests, own-car traces,
+race pace and race trace). The PySide6 pair those two replaced was
+retired in sprint 7; `src/pitwall/` is where the followers live now.
 
 ## Run
 

--- a/src/arcade/__init__.py
+++ b/src/arcade/__init__.py
@@ -1,8 +1,12 @@
 """F1 StratLab: Arcade race replay UI.
 
-This package exposes a Python Arcade window that consumes the backend
-SSE simulation stream (/api/v1/strategy/simulate) and renders the race
-on top of a real 2D circuit, with strategic overlays that mirror the
-richness of the Rich CLI. The package is built phase by phase following
-the plan at C:/Users/victo/.claude/plans/starry-dreaming-wilkinson.md.
+A pyglet window that renders the race on a real 2D circuit with strategic
+overlays mirroring the Rich CLI, and hosts the TCP broadcast its follower
+windows read.
+
+**It does NOT consume the backend's SSE stream, and has not for a long time.**
+The strategy pipeline runs IN THIS PROCESS (`strategy_pipeline.py`, delegating
+to `src/strategy/inference/engine.py::run_lap`), so the arcade has no runtime
+dependency on FastAPI at all - which is the whole reason `f1-arcade` needs no
+backend. The leftover SSE constants in `config.py` are dead; see the note there.
 """

--- a/src/arcade/config.py
+++ b/src/arcade/config.py
@@ -173,12 +173,6 @@ CACHE_VERSION: Final[str] = "v12"  # + official classification (SessionData.offi
 # workers has hung in cold-cache runs. Flip to >1 once FastF1 is warm.
 POOL_SIZE: Final[int] = 1
 
-# --- Backend (strategy SSE) ----------------------------------------------
-BACKEND_URL: Final[str] = os.environ.get("F1_BACKEND_URL", "http://localhost:8000")
-STRATEGY_ENDPOINT: Final[str] = "/api/v1/strategy/simulate"
-SSE_RECONNECT_DELAY_S: Final[float] = 2.0
-SSE_MAX_CONSECUTIVE_FAILURES: Final[int] = 3
-SSE_BACKOFF_AFTER_FAILURES_S: Final[float] = 10.0
 
 # --- Telemetry stream (arcade -> dashboard process) ----------------------
 # Version of the broadcast payload's shape. Bump it whenever a key is

--- a/src/pitwall/agent_formatters.py
+++ b/src/pitwall/agent_formatters.py
@@ -1,5 +1,11 @@
-"""Pure formatters that turn per-agent output dicts into the tuple the
-``AgentCard`` widget renders.
+"""Pure formatters that turn per-agent output dicts into the tuple an agent
+card renders.
+
+**They outlived the widget they were written for.** These built the Qt
+``AgentCard``; PITWALL's AGENTS window now renders by calling exactly the same
+functions, which is what makes that port 1:1 by construction rather than by
+inspection - so sprint 7 MOVED this module out of ``src/arcade/dashboard/``
+instead of deleting it with the rest of the package.
 
 One function per sub-agent (Pace N25, Tire N26, Situation N27, Radio N29,
 Pit N28, RAG N30). The logic mirrors the CLI's six-row inference panel

--- a/src/pitwall/reasoning_lines.py
+++ b/src/pitwall/reasoning_lines.py
@@ -1,5 +1,9 @@
 """The reasoning tabs' second formatting layer, with no toolkit attached.
 
+Written for the Qt reasoning tabs and moved here in sprint 7 when that package
+was retired: PITWALL renders the same tabs by calling these, so the layer had a
+consumer that outlived the widget.
+
 Five per-agent `key = value` metric dumps, plus the helpers that compose a
 tab body out of an agent's reasoning and its numbers. Split out of
 `reasoning_tabs.py` for the same reason `palette.py` was split out of


### PR DESCRIPTION
Two things, both documentation that was teaching something untrue.

## 1. Contributions are paused until v3.0.0 — and it says it is temporary

The repository is mid-migration: the PySide6 dashboard was retired last week, the data plane is being rewired, and the sprints run against a sequenced plan where each one depends on the shape the previous one left. A pull request arriving in the middle of that reorders it, however good it is — which is exactly what happened, and the contributor only found out after writing the patch.

So `CONTRIBUTING.md` now says so up front, at the top, before the branching model: **pull requests are paused, issues are welcome and more useful.** A well-described bug can be scheduled into the sprint that owns that code; a patch cannot.

It states the end date rather than leaving it open: **at v3.0.0**, where live inference lands and the architecture stops moving underneath everything else, the section goes away.

## 2. The twin the Qt retirement left behind

A Fable re-run of `GATE_PITWALL_ARCH_B` found it. That sweep fixed `CONTRIBUTING`, `ARCHITECTURE` and the docs site — and missed `README.md`, `INSTALL.md`, `src/arcade/README.md`, `ROADMAP.md` and `src/arcade/__init__.py`. One copy of a rule corrected and its duplicate not, committed inside the change whose whole subject was fixing prose. Every site below was verified by reading it before editing.

- **`src/arcade/__init__.py`** claimed the package "consumes the backend SSE simulation stream". It has not since the pipeline moved in-process — which is the entire reason `f1-arcade` needs no backend. It also **published a path on one person's machine** (`C:/Users/victo/.claude/plans/…`) to everyone who reads the source.
- **The five SSE constants** that outlived the thing they configured are gone from `config.py`. Checked first: the only surviving `BACKEND_URL` reader is a same-named local in `run_webapp.py`, not an import.
- **`INSTALL.md`** still told a new user that two PySide6 windows would open from `f1-arcade`.
- **"a web-native view"** becomes what it actually is, in `ROADMAP.md` and the docs site: React hosted in the platform webview — **desktop windows, not a web app**, no browser and no server. Web technology, yes; web application, no.
- **The multi-agent Mermaid** drew two TCP arrows into the two windows while the property directly beneath it says they share ONE reader. The picture now shows the host and the two windows polling it by sequence, which is what the code does and what stops them disagreeing about which frame they are on.
- **The delivery plan's sprint table** promised "band 3: race pace grid **+ race trace**" in sprint 6. The trace shipped in sprint 7 (#944/#945). The table now says where each half landed, and records that the `dev -> main` promotion is deferred.
- **The two modules sprint 7 MOVED** — `agent_formatters.py` and `reasoning_lines.py` — were the only files that sweep did not update, so both still described themselves in the present tense as parts of a Qt window. They now say why they outlived it.

## Checks

`ruff@0.15.22` clean, `format --check` clean on 181 files, `tests/surfaces` + `tests/infra` **282 passed / 5 skipped**, and the package imports verified by execution after the constant removal. Every remaining mention of PySide6 in the touched files is historical ("was retired", "the pair those two replaced"), which is correct — the migration captures under `documents/dev_docs/migration/pitwall/` are what those sentences point at.
