### PR TITLE
feat(pitwall): ship the UI bundle in the wheel, and stop shipping the wrong files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,33 @@ it can be scheduled into the sprint that owns that code.
 where live inference lands and the architecture stops moving underneath
 everything else; after it, this section goes away.
 
+## Building a release wheel
+
+**`npm run build` FIRST, then `uv build`. The order is the whole procedure.**
+
+PITWALL's two windows ARE the Vite bundle. `src/pitwall/ui/dist/` is gitignored
+build output, so a clean checkout does not have it — and a wheel built in that
+state installs an `f1-pitwall` that starts, finds no bundle, prints its build
+hint and exits 1. Measured on 2.5.1: the wheel carried three build-tool JSONs
+from the UI folder and **zero** files of the bundle.
+
+```bash
+cd src/pitwall/ui && npm ci && npm run build && cd -
+rm -rf build                     # setuptools reuses build/lib and will re-copy stale files
+uv build --wheel
+```
+
+Then verify it rather than trusting it, in a venv **outside** the repo (inside,
+`import src.pitwall` resolves to the source tree and proves nothing):
+
+```bash
+uv venv /tmp/wheeltest && VIRTUAL_ENV=/tmp/wheeltest uv pip install dist/*.whl
+cd /tmp && F1_STRAT_DATA_ROOT=<repo>/data /tmp/wheeltest/Scripts/f1-pitwall
+```
+
+Both windows must open and render real data. `pip install` without an error is
+not the check.
+
 ## Branching model
 
 Three long-lived branches, in increasing order of stability:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ f1-sim       = "scripts.run_simulation_cli:main"
 f1-arcade    = "src.arcade.main:main"
 f1-webapp    = "scripts.run_webapp:main"
 f1-eval      = "src.strategy.eval.cli:main"
+f1-pitwall   = "src.pitwall.__main__:main"
 
 [project.optional-dependencies]
 dev = [
@@ -190,11 +191,21 @@ torchvision = [
 
 [tool.setuptools.package-data]
 "*" = ["*.yaml", "*.yml", "*.json"]
+# PITWALL's two windows ARE this bundle: without it `f1-pitwall` starts, finds
+# no `dist/`, prints the build hint and exits 1. `dist/` is gitignored build
+# output, so it exists only after `npm run build` - which makes the ORDER part
+# of the release procedure, not a detail. `tests/infra/test_wheel_ships_the_ui.py`
+# is what stops a wheel shipping without it.
+"src.pitwall" = ["ui/dist/**"]
 
 [tool.setuptools.exclude-package-data]
 # Source maps never belong in a wheel; a dev-box npm build can leave them
 # under src/ and the "*" json/yaml glob above would otherwise rake them in.
 "*" = ["**/*.map"]
+# The UI's build-tool manifests are not runtime data. They were the ONLY thing
+# from `src/pitwall/ui/` that ever reached a wheel: measured on 2.5.1, three
+# JSONs in and zero bundle files, the exact inversion of what is wanted.
+"src.pitwall.ui" = ["*.json"]
 
 [tool.black]
 line-length = 100

--- a/src/pitwall/ui/package.json
+++ b/src/pitwall/ui/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && vite build",
     "typecheck": "tsc --noEmit",
     "smoke": "node scripts/smoke-agents.mjs && node scripts/smoke-data.mjs"
   },

--- a/tests/infra/test_wheel_ships_the_ui.py
+++ b/tests/infra/test_wheel_ships_the_ui.py
@@ -1,0 +1,112 @@
+"""PITWALL's windows ARE the Vite bundle, so a wheel without it installs a dead command.
+
+Measured on 2.5.1 before this existed: the wheel carried
+`src/pitwall/ui/package-lock.json`, `package.json` and `tsconfig.json` — three
+build-tool manifests — and **zero** files of the bundle, although `dist/` was
+sitting on disk at the time. The exact inversion of what is wanted, and nothing
+said so: `f1-pitwall` would have started, found no `dist/`, printed its build
+hint and exited 1.
+
+Two properties are checked here, and they are not the same kind of check:
+
+1. **`dist/` is internally consistent** — every asset a page references exists,
+   and no asset exists that no page references. That second half is the one that
+   found a real defect: `emptyOutDir: true` is set in `vite.config.ts` and does
+   NOT empty the directory on this platform, so builds accumulated. Measured at
+   the time: 83 assets and 11 MB against the 6 and 1.4 MB a hand-cleaned build
+   produces — seven copies of a 1.3 MB chunk, all but one dead, all of them
+   about to ship.
+2. **`pyproject.toml` still asks for the bundle.** This one is a MECHANISM check
+   and is labelled as such rather than dressed up: the effect — building a wheel
+   and reading it back — is a ~40 s subprocess with a build backend and a
+   network-capable isolated env, which does not belong in the unit suite. The
+   effect is verified by hand at release time, and the procedure is in
+   `CONTRIBUTING.md`: `npm run build` FIRST, then `uv build`, then install the
+   wheel into a clean venv and open the windows.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+try:  # 3.11+
+    import tomllib
+except ModuleNotFoundError:  # 3.10, which this project still supports
+    import tomli as tomllib
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+UI = REPO_ROOT / "src" / "pitwall" / "ui"
+DIST = UI / "dist"
+PAGES = ("data.html", "agents.html")
+
+
+@pytest.fixture(scope="module")
+def built_pages() -> dict[str, str]:
+    """The two built pages, or a skip naming the command that makes them.
+
+    `dist/` is gitignored build output, so a fresh clone and every CI job that
+    has not run the UI build simply does not have it. Skipping is honest there;
+    what must never happen is a wheel built in that state.
+    """
+    if not DIST.is_dir():
+        pytest.skip("src/pitwall/ui/dist is absent - run `npm run build` in src/pitwall/ui")
+    missing = [name for name in PAGES if not (DIST / name).is_file()]
+    if missing:
+        pytest.fail(f"dist/ exists but is missing {missing} - the build did not finish")
+    return {name: (DIST / name).read_text(encoding="utf-8") for name in PAGES}
+
+
+def _referenced(pages: dict[str, str]) -> set[str]:
+    """Every `assets/...` path the two pages point at."""
+    found: set[str] = set()
+    for html in pages.values():
+        found.update(re.findall(r"assets/[A-Za-z0-9_.\-]+", html))
+    return found
+
+
+def test_every_asset_a_page_references_is_on_disk(built_pages):
+    """A missing chunk renders a blank window with nothing in any log."""
+    absent = sorted(ref for ref in _referenced(built_pages) if not (DIST / ref).is_file())
+
+    assert not absent, f"the pages reference assets that are not in dist/: {absent}"
+
+
+def test_no_asset_survives_that_no_page_references(built_pages):
+    """The check that caught the accumulation, and the only one that could.
+
+    An orphan hurts nobody at runtime - the pages name the chunks they load -
+    which is exactly why it went unnoticed until a wheel was weighed. Every
+    orphan ships, and one of them is 1.3 MB.
+    """
+    referenced = _referenced(built_pages)
+    on_disk = {f"assets/{path.name}" for path in (DIST / "assets").iterdir() if path.is_file()}
+    orphans = sorted(on_disk - referenced)
+
+    assert not orphans, (
+        f"{len(orphans)} asset(s) in dist/assets are referenced by neither page, and would ship: "
+        f"{orphans[:6]}{' ...' if len(orphans) > 6 else ''}. "
+        "`npm run build` removes dist/ before building for this reason."
+    )
+
+
+def test_the_wheel_is_still_told_to_carry_the_bundle():
+    """MECHANISM, deliberately, and the docstring above says why.
+
+    Frozen the way `test_pitwall_tokens.py` freezes its hex list: the value is
+    not that this line is correct, it is that removing it fails here instead of
+    silently shipping a wheel whose `f1-pitwall` cannot start.
+    """
+    config = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    setuptools = config["tool"]["setuptools"]
+
+    assert "ui/dist/**" in setuptools["package-data"].get("src.pitwall", []), (
+        "src/pitwall/ui/dist is no longer packaged - `f1-pitwall` would install with no windows"
+    )
+    assert "f1-pitwall" in config["project"]["scripts"], "the f1-pitwall entry point disappeared"
+    # The manifests that DID ship while the bundle did not.
+    assert "*.json" in setuptools["exclude-package-data"].get("src.pitwall.ui", []), (
+        "the UI's build-tool JSONs would be packaged again"
+    )


### PR DESCRIPTION
`f1-pitwall` did not exist, and the wheel could not have run it if it had.

## Measured, not predicted

A Fable gate built a real wheel and read it back. Reproduced here before changing anything:

```
ui entries in the wheel : 3
    src/pitwall/ui/package-lock.json
    src/pitwall/ui/package.json
    src/pitwall/ui/tsconfig.json
bundle files (html/js/css) : 0
```

Three build-tool manifests the runtime never needs, and **none** of the bundle — with `src/pitwall/ui/dist/` sitting on disk at the time. PITWALL's two windows *are* that bundle, so an `f1-pitwall` installed from this wheel would start, find no `dist/`, print its build hint and exit 1.

`src/pitwall/ui/` has no `__init__.py`, but setuptools discovers it as a **namespace package**, which is exactly how the `"*" = ["*.json"]` glob reached those three files while the html/js/css it does not name stayed out.

## What changed

- `package-data` names `ui/dist/**`; `exclude-package-data` drops the UI's JSONs; `f1-pitwall` joins `[project.scripts]`.
- **The JSON leak survived the first fix**, because setuptools reuses `build/lib` and re-copied them from the previous run. `rm -rf build` is now part of the documented procedure — worth knowing before anyone debugs a packaging change that "did not take".
- **`emptyOutDir: true` does not empty the directory on this platform.** Measured: a build over an existing `dist/` leaves **83 assets and 11 MB**; the same build over a hand-cleaned one leaves **6 and 1.4 MB**. Seven copies of a 1.3 MB chunk, all but one dead, all of them about to ship. `npm run build` now removes `dist/` itself, with `node:fs` rather than a new dependency.

## Verified by running it

The only check that counts here, and `pip install` without an error is not it:

```
wheel built → uv venv OUTSIDE the repo → uv pip install → f1-pitwall, cwd anywhere but the source tree
```

(The "outside the repo" part is load-bearing: run it from the source tree and `import src.pitwall` resolves to the working copy, which proves nothing about the wheel.)

```
f1-pitwall.exe          present
ui_dist()               …/wheeltest/Lib/site-packages/src/pitwall/ui/dist
inside site-packages    True
ui_is_built()           True
bundle files            8
```

Both windows opened. The DATA window rendered the real Melbourne payload: **20 tower rows, 20 trace series, `LAPS 1-21 of 57`, 41 radio events, `lap 23 · live`** — screenshotted and read, not inferred from a log line.

## The guard

`tests/infra/test_wheel_ships_the_ui.py`. Its **orphan check** is what caught the accumulation and is the only thing that could: an orphan hurts nobody at runtime, because the pages name the chunks they load — it only costs on the way out. Driven red against a planted stale asset:

```
AssertionError: 1 asset(s) in dist/assets are referenced by neither page, and would ship:
['assets/data-STALE0000.js']
```

The third assertion in that file is a **mechanism** check on `pyproject.toml`, and it says so in its own docstring rather than pretending otherwise: the effect — build a wheel, read it back — is a ~40 s subprocess with an isolated build env and does not belong in the unit suite. It is verified by hand at release time, and `CONTRIBUTING.md` now carries that procedure.

`ruff@0.15.22` clean · `tests/infra` + `tests/surfaces` **285 passed, 5 skipped**.
