### PR TITLE
fix(arcade): closing the replay window tears the companion down with it

### DIFF
--- a/src/arcade/app.py
+++ b/src/arcade/app.py
@@ -231,6 +231,9 @@ class F1ArcadeView(arcade.View):
         self._strategy_state = None
         self._stream_server = None
         self._pitwall_proc: subprocess.Popen | None = None
+        # Pushed onto the WINDOW (not the view) when the strategy layer starts,
+        # popped in `on_hide_view`. See `_on_window_close`.
+        self._close_handler: dict[str, object] | None = None
         self._broadcast_tick: int = 0
         # Highest frame index already put on the wire. -1 means "nothing sent
         # yet", so the first broadcast emits a single sample rather than the
@@ -433,6 +436,32 @@ class F1ArcadeView(arcade.View):
             self._stream_server = None
 
         self._spawn_pitwall()
+        # **A window CLOSE never reaches `on_hide_view`, and that is a fact about
+        # the toolkit rather than about this class.** In the installed arcade,
+        # `on_hide_view` is invoked from exactly two places: `Window.show_view`,
+        # which hides the previous view before showing the next, and the explicit
+        # `Window.hide_view`. `Window.close` calls neither - it sets `closed`,
+        # delegates to pyglet and unschedules the clock. So the teardown ran when
+        # the user navigated back to the MENU and never when they closed the
+        # window, which is the ordinary way to end a session, and PITWALL was
+        # left running against a broadcast that had stopped (#947).
+        #
+        # Registered here rather than in `__init__` because there is nothing to
+        # tear down without `--strategy`, and kept as an attribute so it can be
+        # POPPED again: a handler pushed onto the window outlives the view, and
+        # a stale one would fire this view's teardown after the user had moved on.
+        self._close_handler = {"on_close": self._on_window_close}
+        self.window.push_handlers(**self._close_handler)
+
+    def _on_window_close(self) -> None:
+        """Route a window close through the one teardown, then let pyglet close.
+
+        Returning None (rather than `True`) leaves the default handler in place,
+        so the window still closes. `on_hide_view` is idempotent by construction -
+        `_terminate` takes `None` and every field it clears is set to `None` - so
+        the menu -> viewer -> menu -> close path running it twice is harmless.
+        """
+        self.on_hide_view()
 
     def _spawn_pitwall(self) -> None:
         """Launch the PITWALL windows as a child process.
@@ -488,6 +517,12 @@ class F1ArcadeView(arcade.View):
         # One companion window survives sprint 7; the helper stays because the
         # reason it exists is about the block, not about the count.
         self._pitwall_proc = self._terminate(self._pitwall_proc, "Pitwall")
+        # Pop the close handler with the rest. Leaving it pushed is how the NEXT
+        # view's close would run THIS view's teardown - the same class of defect
+        # as the one this method exists to fix, one level up.
+        if self._close_handler is not None:
+            self.window.remove_handlers(**self._close_handler)
+            self._close_handler = None
 
     @staticmethod
     def _terminate(proc: subprocess.Popen | None, name: str) -> None:


### PR DESCRIPTION
Closes #947.

Closing the arcade replay window left the PITWALL subprocess running. The user was left with two desktop windows fed by a broadcast that had stopped, and had to kill it by hand.

## Cause

`on_hide_view` is a **view** hook. In the installed arcade it is invoked from exactly two places — `Window.show_view`, which hides the previous view before showing the next, and the explicit `Window.hide_view`. `Window.close` calls neither: it sets `closed`, delegates to pyglet and unschedules the update clock.

So the teardown ran when the user navigated **back to the menu**, and never when they **closed the window** — which is the ordinary way to end a session.

**This is not fallout from retiring Qt.** The dashboard's teardown sat on the line directly above PITWALL's inside the same unreachable method, so it was orphaned in exactly the same way. #946 removed one of those two lines; it did not change when the method runs. That is why this is its own change rather than a follow-up commit on that one.

## The fix, and the two things it is careful about

- An `on_close` handler is pushed onto the **window** when the strategy layer starts, and routes to the one teardown instead of repeating it. `_terminate` exists precisely because a second copy of that block was the twin that stopped getting fixed, and for one release the dashboard's teardown was exactly that copy.
- **The handler is popped again in `on_hide_view`.** A handler pushed onto the window outlives the view; leaving it there would let the *next* view's close run *this* view's teardown — the same class of defect this method exists to fix, one level up.
- It returns `None` rather than `True`, so pyglet's default handler still closes the window. Running the teardown twice (menu → viewer → menu → close) is harmless by construction: `_terminate` takes `None` and every field it clears is set to `None`.

It is registered inside `_init_strategy_layer` because without `--strategy` there is no companion to tear down.

## Verified by running it

Not around the helper, which already worked wherever it was called — the issue says so explicitly. `f1-arcade --viewer --strategy` on Melbourne 2025, three windows open, then close the replay window:

```
window owner pid: 24004  title: F1 StratLab - Race Replay
BEFORE  pitwall: 35288, 24208
AFTER   arcade: (none)   pitwall: (none)
RESULT: no orphan - the teardown ran
```

Before this change, the same sequence left `35288, 24208` alive.

**The first attempt at that check was invalid and is worth recording**: there are two arcade processes, and `CloseMainWindow()` went to the one that has no window, so nothing closed and the result read as "still broken". Selecting the process whose `MainWindowTitle` is the replay window is what made the check mean anything.

`tests/surfaces` + `tests/infra` 282 passed, ruff clean.
