### PR TITLE
fix(pitwall): the connection a caller holds, and the laps it can actually see

### DIFF
--- a/src/pitwall/host.py
+++ b/src/pitwall/host.py
@@ -47,9 +47,6 @@ class PitwallHost:
         self._windows_open = window_count
         self._agents = AgentsViewBuilder()
         # The last label AGENTS was served, so that view can return on a
-        # connection change with no new tick. NOT the memory the label itself
-        # needs - see `_ever_connected`.
-        self._agents_connection: str | None = None
         # Has the socket EVER been up? This is what separates "Connecting..."
         # from "Disconnected", and it belongs to the host because both windows
         # ask. It used to be inferred from `_agents_connection`, which made the
@@ -134,7 +131,9 @@ class PitwallHost:
             return "Connected"
         return "Disconnected" if self._ever_connected else "Connecting..."
 
-    def get_agents_view(self, since_seq: int = -1) -> dict | None:
+    def get_agents_view(
+        self, since_seq: int = -1, since_connection: str | None = None
+    ) -> dict | None:
         """The whole AGENTS window, already formatted, or None when nothing changed.
 
         The window is a renderer. Every headline, body line, colour and
@@ -148,16 +147,33 @@ class PitwallHost:
         learns the arcade died: once the producer stops, `seq` stops
         advancing and a purely sequence-driven view would keep rendering
         the last frame of a dead race with a green "Connected" chip.
+
+        **`since_connection` is what the CALLER last rendered, and that is the
+        whole point (#950).** It used to be a single host field, so with two
+        consumers the first to notice the producer had died consumed the
+        transition and the second never learned about it: measured over 50
+        polls, a browser on `/agents.html` kept a green chip on a dead race
+        forever while the window beside it had already gone red. The loopback
+        server is not hypothetical - `__main__` starts it unconditionally.
+
+        A host field cannot answer "has this changed since YOU looked"; only
+        the caller knows. So it joins `since_seq` and `since_rev`, which solved
+        the identical problem for the tick and the bulk by asking rather than
+        remembering. Adding a second host field instead would have been the
+        third copy of one mistake - and the fix for its sibling is three lines
+        above, where `_ever_connected` was lifted OUT of exactly this slot.
+
+        `None` means "I have rendered nothing", so a first poll always gets a
+        view.
         """
         connection = self.get_connection()
         payload = self.get_tick(since_seq)
         if payload is None:
-            if connection == self._agents_connection:
+            if connection == since_connection:
                 return None
             payload = self._client.latest
             if payload is None:
                 return None
-        self._agents_connection = connection
         return self._agents.build(payload, connection)
 
     def get_bulk(self, since_rev: int = -1) -> dict | None:

--- a/src/pitwall/ui/package.json
+++ b/src/pitwall/ui/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && vite build",
+    "build": "tsc -b && node scripts/clean-dist.mjs && vite build",
     "typecheck": "tsc --noEmit",
     "smoke": "node scripts/smoke-agents.mjs && node scripts/smoke-data.mjs"
   },

--- a/src/pitwall/ui/scripts/clean-dist.mjs
+++ b/src/pitwall/ui/scripts/clean-dist.mjs
@@ -1,0 +1,71 @@
+/**
+ * Empty `dist/` before a build, verify it, and FAIL LOUDLY if it is still there.
+ *
+ * **Two mechanisms already tried to do this and both failed in SILENCE**, which
+ * is why this file exists and why it checks its own work rather than trusting a
+ * call that returned.
+ *
+ * 1. Vite's `emptyOutDir: true` is set in `vite.config.ts` and does not empty it.
+ * 2. `fs.rmSync(..., { force: true })` returns normally and deletes nothing on
+ *    this tree — measured down to a single file, with `force` removed so an
+ *    error could not be swallowed: `existsSync` said true before AND after, and
+ *    nothing was thrown. A filter driver on the path is the likely culprit;
+ *    the cause matters less than the fact that the return value is worthless.
+ *
+ * What the silence cost: builds accumulate, and every orphan chunk ships inside
+ * the wheel. Measured at 83 assets and 11 MB against the 6 and 1.4 MB a clean
+ * build produces — seven copies of a 1.3 MB chunk with exactly one of them live.
+ * `tests/infra/test_wheel_ships_the_ui.py` is the guard that caught it.
+ *
+ * So: try Node, verify; fall back to the platform's own delete, verify again;
+ * and only then stop the build with something a human can act on. A build that
+ * halts is recoverable in seconds. A build that quietly grows the wheel is not
+ * noticed until someone weighs it.
+ */
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DIST = resolve(dirname(fileURLToPath(import.meta.url)), "..", "dist");
+
+/** Entries still in `dist/`, or 0 when it is gone. Never throws. */
+function remaining() {
+  if (!existsSync(DIST)) return 0;
+  try {
+    return readdirSync(DIST).length;
+  } catch {
+    return -1;
+  }
+}
+
+if (remaining() !== 0) {
+  try {
+    rmSync(DIST, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  } catch (error) {
+    console.error(`clean-dist: node rm failed (${error.code ?? error.message}), trying the shell`);
+  }
+}
+
+if (remaining() !== 0) {
+  // The platform's own delete. Reached routinely on this machine, not as a
+  // last resort, so it is not treated as an error path.
+  const [command, args] =
+    process.platform === "win32"
+      ? ["cmd", ["/c", "rmdir", "/s", "/q", DIST]]
+      : ["rm", ["-rf", DIST]];
+  spawnSync(command, args, { stdio: "ignore" });
+}
+
+if (remaining() !== 0) {
+  console.error(
+    `clean-dist: dist/ still holds ${remaining()} entr(ies) after two attempts to remove it.\n` +
+      "  The build would ADD to it rather than replace it, and every stale chunk\n" +
+      "  would ship inside the wheel. Most often a running window holds the bundle\n" +
+      "  open - PITWALL renders in the platform webview, and an orphaned renderer\n" +
+      "  outlives the window that spawned it:\n" +
+      '    powershell "Get-Process msedgewebview2 -EA SilentlyContinue | Stop-Process -Force"\n' +
+      `  Then remove it by hand: rm -rf "${DIST}"`,
+  );
+  process.exit(1);
+}

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -1405,6 +1405,40 @@ check(paceCells.pitText === "IN PIT" && paceCells.outText === "OUT",
   "the in-lap and the out-lap replace the time, as a timing screen shows them");
 check(paceCells.best === 1, `exactly one purple cell - the session's fastest lap (${paceCells.best})`);
 
+// **The range says what is ON SCREEN, and the only way to check that is to
+// SCROLL.** It used to render `grid.laps[0]`, which is always 1, so the header
+// claimed `LAPS 1-57` over a panel pinned to the bottom showing 8-57. An
+// assertion that the string matches the data passes straight over that; this
+// one moves the panel and requires the header to move with it. The panel is
+// also the one affordance replacing a scrollbar this window hides globally.
+const rangeAtBottom = await pacePage.locator(".pace-range").innerText();
+const scrolled = await pacePage.evaluate(() => {
+  const box = document.querySelector(".pace-scroll");
+  box.scrollTop = 0;
+  box.dispatchEvent(new Event("scroll"));
+  return new Promise((done) => setTimeout(() => done(document.querySelector(".pace-range").textContent), 150));
+});
+check(
+  rangeAtBottom !== scrolled,
+  `the lap range follows the scroll (bottom "${rangeAtBottom}", top "${scrolled}")`,
+);
+check(
+  /^LAPS 1-\d+ of \d+$/.test(scrolled ?? ""),
+  `scrolled to the top it starts at lap 1 (${scrolled})`,
+);
+check(
+  rangeAtBottom.endsWith(`-${PACE_LAPS} of ${PACE_LAPS}`),
+  `pinned to the bottom it ends at the newest lap, and says the race length (${rangeAtBottom})`,
+);
+// Put it back where the panel pins itself, so the checks below see the state
+// the window actually opens in.
+await pacePage.evaluate(() => {
+  const box = document.querySelector(".pace-scroll");
+  box.scrollTop = box.scrollHeight;
+  box.dispatchEvent(new Event("scroll"));
+});
+await pacePage.waitForTimeout(150);
+
 // A lap 40 ms under a minute boundary. Splitting the minutes off BEFORE
 // rounding the tenths renders "1:60.0" - a time that does not exist, and one
 // the cell regex above accepts without complaint.

--- a/src/pitwall/ui/src/features/data/RacePaceGrid.tsx
+++ b/src/pitwall/ui/src/features/data/RacePaceGrid.tsx
@@ -29,7 +29,7 @@
  * hides them globally.
  */
 
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { racePaceGrid } from "../../lib/racePace";
 import type { Bulk } from "../../lib/bridge";
@@ -37,6 +37,34 @@ import type { Bulk } from "../../lib/bridge";
 export function RacePaceGrid({ bulk, order }: { bulk: Bulk | null; order: string[] }) {
   const grid = racePaceGrid(bulk, order);
   const scroller = useRef<HTMLDivElement | null>(null);
+  const [visible, setVisible] = useState<[number, number] | null>(null);
+
+  /**
+   * The laps ACTUALLY on screen, from the scroller's own geometry.
+   *
+   * **Not `grid.laps[0]`, which is the defect this replaces (#949).** That is
+   * always 1, so the header read `LAPS 1-57` while the panel - pinned to the
+   * bottom - was showing 8 to 57. This window hides scrollbars globally and
+   * the stylesheet says in as many words that this range is the affordance
+   * standing in for one, so it was wrong in exactly the case it exists for and
+   * right only when the grid fits, which is when nobody needs it.
+   *
+   * Measured off each row's own box rather than derived from a row-height
+   * constant: the height is a CSS token and a second copy of it here is the
+   * twin this repo pays for most often.
+   */
+  const measure = useCallback(() => {
+    const box = scroller.current;
+    if (!box) return;
+    const rows = [...box.querySelectorAll<HTMLElement>("tbody tr")];
+    if (rows.length === 0) return setVisible(null);
+    const top = box.scrollTop;
+    const bottom = top + box.clientHeight;
+    const shown = rows.filter((row) => row.offsetTop + row.offsetHeight > top && row.offsetTop < bottom);
+    const edges = shown.length ? shown : rows;
+    const lapOf = (row: HTMLElement) => Number(row.querySelector("th")?.textContent ?? 0);
+    setVisible([lapOf(edges[0]), lapOf(edges[edges.length - 1])]);
+  }, []);
 
   // Pinned to the newest lap. A race-pace grid that opens at lap 1 shows the
   // formation lap of a race that is on lap 40, and the laps a strategist is
@@ -45,10 +73,11 @@ export function RacePaceGrid({ bulk, order }: { bulk: Bulk | null; order: string
   useEffect(() => {
     const box = scroller.current;
     if (box) box.scrollTop = box.scrollHeight;
-  }, [grid.laps.length]);
+    measure();
+  }, [grid.laps.length, measure]);
 
-  const first = grid.laps[0];
-  const last = grid.laps[grid.laps.length - 1];
+  const total = bulk?.race.total_laps ?? grid.laps.length;
+  const [first, last] = visible ?? [grid.laps[0], grid.laps[grid.laps.length - 1]];
 
   return (
     <section className="card pace">
@@ -56,10 +85,10 @@ export function RacePaceGrid({ bulk, order }: { bulk: Bulk | null; order: string
         <span className="pace-title">RACE PACE</span>
         <span className="pace-subtitle">colour ranks each lap against itself</span>
         <span className="pace-range">
-          {grid.laps.length ? `LAPS ${first}-${last}` : "no laps revealed"}
+          {grid.laps.length ? `LAPS ${first}-${last} of ${total}` : "no laps revealed"}
         </span>
       </header>
-      <div className="pace-scroll" ref={scroller}>
+      <div className="pace-scroll" ref={scroller} onScroll={measure}>
         <table className="pace-table">
           <thead>
             <tr>

--- a/src/pitwall/ui/src/lib/agents.ts
+++ b/src/pitwall/ui/src/lib/agents.ts
@@ -165,16 +165,26 @@ export function useAgentsView(): AgentsState {
   // A ref, not state: the loop must read the newest sequence without
   // re-subscribing, and a stale closure would ask for the same view forever.
   const lastSeq = useRef(-1);
+  // The connection label this caller last RENDERED, for the same reason and by
+  // the same mechanism as the sequence beside it. The host cannot hold it: with
+  // two consumers of this view - and the loopback server is always one of them -
+  // whichever polled first would consume the transition and the other would
+  // keep a green chip on a dead race (#950).
+  const lastConnection = useRef<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     let timer: number | undefined;
 
     const poll = async () => {
-      const view = await getAgentsView<AgentsView>(lastSeq.current);
+      const view = await getAgentsView<AgentsView>(lastSeq.current, lastConnection.current);
       if (cancelled) return;
       if (view) {
         if (view.seq !== null) lastSeq.current = view.seq;
+        // The header's label is the RAW one the host passed in, not a
+        // rendering of it (`build_header` stores `connection` verbatim and
+        // derives only the colour), so it is the right thing to hand back.
+        lastConnection.current = view.header?.connection ?? null;
         setState({ view, live: true });
       }
       timer = window.setTimeout(poll, POLL_INTERVAL_MS);

--- a/src/pitwall/ui/src/lib/bridge.ts
+++ b/src/pitwall/ui/src/lib/bridge.ts
@@ -270,9 +270,13 @@ export function whenBridgeReady(): Promise<void> {
  * while a server restarts, and it is what the poll loop above already
  * handles. Throwing would kill the loop on the first hiccup.
  */
-async function fetchJson<T>(route: string, sinceSeq: number): Promise<T | null> {
+async function fetchJson<T>(
+  route: string,
+  sinceSeq: number,
+  extraQuery = "",
+): Promise<T | null> {
   try {
-    const response = await fetch(`${route}?since=${sinceSeq}`, { cache: "no-store" });
+    const response = await fetch(`${route}?since=${sinceSeq}${extraQuery}`, { cache: "no-store" });
     if (!response.ok) return null;
     return (await response.json()) as T | null;
   } catch {
@@ -353,9 +357,26 @@ export async function getConnection(): Promise<string | null> {
   }
 }
 
-export async function getAgentsView<T>(sinceSeq: number): Promise<T | null> {
-  const api = window.pywebview?.api as { get_agents_view?: (s: number) => Promise<T | null> };
-  if (api?.get_agents_view) return api.get_agents_view(sinceSeq);
+/**
+ * The AGENTS view, or null when this caller's view is current.
+ *
+ * **Two things the caller holds, not one.** The sequence says which tick it
+ * rendered; `sinceConnection` says which connection LABEL it rendered. The
+ * second exists because when the producer dies the sequence stops advancing,
+ * so a purely sequence-driven view would keep painting the last frame of a
+ * dead race behind a green chip - and the host cannot answer "changed since
+ * YOU looked" from one field it keeps for everybody. It tried, and with two
+ * consumers the second never learned (#950).
+ */
+export async function getAgentsView<T>(
+  sinceSeq: number,
+  sinceConnection: string | null,
+): Promise<T | null> {
+  const api = window.pywebview?.api as {
+    get_agents_view?: (s: number, c: string | null) => Promise<T | null>;
+  };
+  if (api?.get_agents_view) return api.get_agents_view(sinceSeq, sinceConnection);
   if (IN_A_WINDOW) return null;
-  return fetchJson<T>("/api/agents", sinceSeq);
+  const held = sinceConnection === null ? "" : `&connection=${encodeURIComponent(sinceConnection)}`;
+  return fetchJson<T>("/api/agents", sinceSeq, held);
 }

--- a/src/pitwall/webserver.py
+++ b/src/pitwall/webserver.py
@@ -62,7 +62,9 @@ class TickSource(Protocol):
 
     def get_tick(self, since_seq: int = -1) -> dict[str, Any] | None: ...
 
-    def get_agents_view(self, since_seq: int = -1) -> dict[str, Any] | None: ...
+    def get_agents_view(
+        self, since_seq: int = -1, since_connection: str | None = None
+    ) -> dict[str, Any] | None: ...
 
     def get_bulk(self, since_rev: int = -1) -> dict[str, Any] | None: ...
 
@@ -116,6 +118,18 @@ def _since(query: str) -> int:
         return -1
 
 
+def _since_connection(query: str) -> str | None:
+    """`?connection=Connected`, or None for a caller that has rendered nothing.
+
+    A string rather than a revision because that is what the label IS - there is
+    no sequence for the socket's own state to be current with. `None` is the
+    honest "I hold nothing", and it can never equal a real label, so a first
+    poll always gets a view.
+    """
+    values = parse_qs(query).get("connection")
+    return values[0] if values else None
+
+
 def _handler(bundle: dict[str, tuple[bytes, str]], source: TickSource):
     class PitwallHTTPHandler(BaseHTTPRequestHandler):
         # `BaseHTTPRequestHandler` logs every request to stderr, which at
@@ -136,7 +150,16 @@ def _handler(bundle: dict[str, tuple[bytes, str]], source: TickSource):
             # missing ONE of them fail on the routes it does implement.
             reader = _READERS.get(route)
             if reader is not None:
-                self._send_json(getattr(source, reader)(_since(parsed.query)))
+                # AGENTS carries a SECOND thing the caller holds: the connection
+                # label it last rendered. Without it the host would have to
+                # remember on the caller's behalf, and with two consumers only
+                # one of them would ever learn the producer died (#950).
+                extra = (
+                    {"since_connection": _since_connection(parsed.query)}
+                    if reader == "get_agents_view"
+                    else {}
+                )
+                self._send_json(getattr(source, reader)(_since(parsed.query), **extra))
                 return
 
             plain = _PLAIN_READERS.get(route)

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -349,15 +349,18 @@ def test_the_window_learns_the_arcade_died_even_though_no_tick_arrives():
     client = _FakeClient(_payload(seq=5), connected=True)
     host = PitwallHost(client, window_count=1)
     assert host.get_agents_view(-1)["header"]["connection"] == "Connected"
-    assert host.get_agents_view(5) is None, "nothing new, nothing changed"
+    # The caller says what it holds, on BOTH axes. `since_connection` joined
+    # `since_seq` in #950: a host field could not answer "changed since YOU
+    # looked" for two consumers, so the question is asked instead of remembered.
+    assert host.get_agents_view(5, "Connected") is None, "nothing new, nothing changed"
 
     client.connected = False
-    view = host.get_agents_view(5)
+    view = host.get_agents_view(5, "Connected")
 
     assert view is not None, "the state changed, so the window must hear about it"
     assert view["header"]["connection"] == "Disconnected"
     assert view["header"]["connection_colour"] == "#ef4444"
-    assert host.get_agents_view(5) is None, "and only once"
+    assert host.get_agents_view(5, "Disconnected") is None, "and only once"
 
 
 def test_before_the_first_connection_the_chip_says_connecting():

--- a/tests/surfaces/test_pitwall_browser_server.py
+++ b/tests/surfaces/test_pitwall_browser_server.py
@@ -32,12 +32,20 @@ class _FakeHost:
 
     def __init__(self) -> None:
         self.tick = {"seq": 7, "arcade": {"lap": 23}}
-        self.view = {"seq": 7, "header": {"session": "Melbourne · 2025"}}
+        # The real view's header ALWAYS carries the connection label - it is
+        # what the caller hands back as `since_connection` - so a stub without
+        # it could not exercise the route's second parameter at all.
+        self.view = {"seq": 7, "header": {"session": "Melbourne · 2025", "connection": "Connected"}}
 
     def get_tick(self, since_seq: int = -1):
         return None if since_seq == self.tick["seq"] else self.tick
 
-    def get_agents_view(self, since_seq: int = -1):
+    def get_agents_view(self, since_seq: int = -1, since_connection: str | None = None):
+        # Both halves of what the caller holds, as the real host takes them.
+        # The route passes `connection` through, so a stub that ignored it
+        # would let the query string rot without anything noticing (#950).
+        if since_connection is not None and since_connection != self.view["header"]["connection"]:
+            return self.view
         return None if since_seq == self.view["seq"] else self.view
 
 
@@ -83,6 +91,32 @@ def test_a_browser_gets_the_same_sequenced_payload_a_window_gets(served: str):
     assert json.loads(_get(served + "/api/tick?since=7")[2]) is None, "a seen tick must be null"
     assert json.loads(_get(served + "/api/agents?since=-1")[2])["header"]["session"].startswith(
         "Melbourne"
+    )
+
+
+def test_the_agents_route_carries_the_connection_the_caller_holds(served: str):
+    """The browser is the SECOND consumer, so the query string is load-bearing.
+
+    `/api/agents` takes two things the caller holds, not one: the sequence and
+    the connection label it last rendered. The second is what lets a browser on
+    `/agents.html` learn the producer died after the window beside it already
+    has - with the state kept host-side instead, whichever polled first consumed
+    the transition and the other kept a green chip on a dead race forever (#950).
+
+    Dropping `&connection=` from the route would leave the parameter always
+    `None`, which reads as "I hold nothing" and is silently generous rather than
+    visibly broken. This is what fails then.
+    """
+    seen = json.loads(_get(served + "/api/agents?since=-1")[2])
+    seq = seen["seq"]
+    held = seen["header"]["connection"]
+
+    # Same sequence, same label: nothing to say.
+    assert json.loads(_get(served + f"/api/agents?since={seq}&connection={held}")[2]) is None
+
+    # Same sequence, a label this caller has NOT rendered: it must be told.
+    assert (
+        json.loads(_get(served + f"/api/agents?since={seq}&connection=Disconnected")[2]) is not None
     )
 
 

--- a/tests/surfaces/test_pitwall_host.py
+++ b/tests/surfaces/test_pitwall_host.py
@@ -385,4 +385,52 @@ def test_both_windows_read_the_same_label_from_the_same_memory():
     client.connected = False
 
     assert host.get_connection() == "Disconnected"
-    assert host.get_agents_view(1)["header"]["connection"] == "Disconnected"
+    assert host.get_agents_view(1, "Connected")["header"]["connection"] == "Disconnected"
+
+
+def test_a_second_agents_consumer_also_learns_the_producer_died():
+    """The one consumer above cannot see #950, and that is why it existed.
+
+    There are TWO consumers of this view in a shipped run: the AGENTS webview
+    and `/agents.html` on the loopback server `__main__` starts unconditionally.
+    The transition used to be remembered in ONE host field, so whichever polled
+    first consumed it and the second was answered `None` forever - a green
+    "Connected" chip on a race that had stopped, measured over 50 polls.
+
+    Both callers here hold "Connected" and neither has a newer tick, which is
+    exactly the state a dead producer leaves. Both must be served.
+    """
+    client = _ConnectableClient(_tick(1), connected=True)
+    host = PitwallHost(client, window_count=2)
+    first = host.get_agents_view(-1)
+    second = host.get_agents_view(-1)
+    held = first["header"]["connection"]
+    assert held == second["header"]["connection"] == "Connected"
+
+    client.connected = False
+
+    # The window notices...
+    window = host.get_agents_view(first["seq"], held)
+    # ...and so does the browser, which polled second and holds the same label.
+    browser = host.get_agents_view(second["seq"], held)
+
+    assert window is not None, "the first consumer was not told the producer died"
+    assert browser is not None, "the SECOND consumer was not told - #950"
+    assert window["header"]["connection"] == "Disconnected"
+    assert browser["header"]["connection"] == "Disconnected"
+
+
+def test_a_caller_that_already_rendered_the_state_is_told_nothing_changed():
+    """The other half: `since_connection` must still SUPPRESS a repeat.
+
+    Without this the view would be rebuilt on every poll of a dead race, which
+    is the cost the single host field was buying and the reason it existed.
+    """
+    client = _ConnectableClient(_tick(1), connected=True)
+    host = PitwallHost(client, window_count=2)
+    view = host.get_agents_view(-1)
+
+    client.connected = False
+    host.get_agents_view(view["seq"], "Connected")
+
+    assert host.get_agents_view(view["seq"], "Disconnected") is None


### PR DESCRIPTION
Closes #950. Closes #949.

Two findings from the Fable re-runs, both a panel answering the wrong question — and one defect the last PR's own guard caught in the last PR.

## #950 — a second AGENTS consumer never learned the producer had died

`_agents_connection` was ONE host-global slot answering a per-caller question: *has this changed since **you** looked?* Only the caller knows.

There are two consumers in a shipped run: the AGENTS webview and `/agents.html` on the loopback server `__main__` starts **unconditionally**. Whichever polled first consumed the transition; the second was answered `None` forever and kept a green **Connected** chip on a race that had stopped. Measured by the gate over 50 polls.

It now joins `since_seq` and `since_rev`, which solved the identical problem for the tick and the bulk by **asking** the caller instead of remembering on its behalf. Adding a second host field would have been the third copy of one mistake — and the fix for its sibling sits three lines above, where `_ever_connected` was lifted out of exactly this slot for exactly this reason.

`None` means "I have rendered nothing", so a first poll always gets a view.

## #949 — the LAPS range said which laps EXIST, not which are on screen

`grid.laps[0]` is always 1, so the header read `LAPS 1-57` over a panel pinned to the bottom showing 8-57. This window hides scrollbars globally and the stylesheet says in as many words that **this range is the affordance standing in for one** — so it was wrong in exactly the case it exists for, and right only when the grid fits, which is when nobody needs it.

It now measures each row's own box against the scroller's viewport (not a row-height constant — the height is a CSS token and a second copy here is the twin this repo pays for), and prints the race length beside it.

## The defect the last PR's guard caught in the last PR

`test_no_asset_survives_that_no_page_references` went red on this branch: **the `dist` cleaning #954 shipped does not work.** `fs.rmSync` returns normally and deletes nothing on this tree — verified down to a single file, with `force` removed so no error could be swallowed:

```
exists: true
rm without force: returned          <- no throw
still exists: true
```

`scripts/clean-dist.mjs` now tries Node, falls back to the platform's own delete, **verifies**, and stops the build with something a human can act on rather than growing the wheel in silence. Two consecutive builds now leave 6 assets and 1.4 MB.

**And the correction that goes with it**: #954 said "`emptyOutDir: true` does not empty the directory on this platform". The platform was the wrong culprit — the first thing I found was a pile of orphaned `msedgewebview2` renderers holding the bundle open, which *also* blocks it. Both are true; the sentence blamed the one that was easier to see. Same shape as the false headline this sprint has already corrected twice.

## Guards, driven red

| mutation | red |
|---|---|
| the host remembers the connection for everybody again | `AssertionError: the SECOND consumer was not told - #950` |
| the route drops `&connection=` | `assert None is not None` |
| the range reads the data instead of the viewport | `the lap range follows the scroll (bottom "LAPS 1-57 of 57", top "LAPS 1-57 of 57")` |

## Verified on the real thing

- **Live host, two callers.** Both hold `Connected`, neither has a newer tick — the exact state a dead producer leaves. Producer killed; **both** are served `Disconnected`. Before, only the first was.
- **Real payload, real bundle**, panel squeezed to 12 visible rows with 11 overflowing: `LAPS 10-22 of 57` pinned to the bottom, `LAPS 1-12 of 57` scrolled to the top. At the full client height the 22 revealed laps fit, so the range correctly does not move — which is why the check had to force the overflow.

`tests/surfaces` + `tests/infra` **288 passed** · `smoke-data` 146 · `smoke-agents` 18 · ruff clean on the CI-pinned 0.15.22.

## Still open

**#951** is blocked on data, with the measurement recorded on the issue: `repair_tyre_stints` changes 0 of Melbourne's 927 rows, so the defect cannot be shown on the only race a curated install carries. It needs Miami 2025.
