### PR TITLE
docs(pitwall): record what sprint 7 did, and that the promotion was deferred

### DIFF
--- a/documents/research/PITWALL_DELIVERY_PLAN.md
+++ b/documents/research/PITWALL_DELIVERY_PLAN.md
@@ -22,11 +22,21 @@ Same shape every time, because the value is in the repetition:
    optional: `gh` puts the PR title in the merge-commit body and release-please parses it, which is
    how the CHANGELOG got duplicated twice before.
 5. **CI green on every PR**, not just at the end of the sprint.
-6. **NOTHING reaches `main` until PITWALL is finished** (Víctor, 2026-08-07). Every sprint lands on
-   `dev` and stops there; the single `dev -> main` promotion happens once, after sprint 7's exit
-   gate. Consequence, accepted deliberately: because issues stay open until the work is on `main`,
-   **#841-#844 and the rewritten #281/#284/#285 all stay open for the whole programme.** The open
-   list will not shrink for seven sprints. That is the rule working, not a backlog leak.
+6. **NOTHING reaches `main` until PITWALL is finished** (Víctor, 2026-08-07), and **"finished" now
+   means after sprint 9, not sprint 7** (Víctor, 2026-08-16: *"seguimos dev hasta acabar todos los
+   sprints"*). Every sprint lands on `dev` and stops there; there is exactly one `dev -> main`
+   promotion and it comes after the LAST sprint's exit gate.
+
+   Consequence, accepted deliberately and now larger than it was: because issues stay open until the
+   work is on `main`, **#841-#844, the rewritten #281/#284/#285, #921-#940, #944, #949, #950 and
+   #951 all stay open for the whole programme**, and sprints 8 and 9 will add to that list rather
+   than shrink it. The open list will not go down for nine sprints. That is the rule working, not a
+   backlog leak — and the reason to say so twice is that a growing open list is exactly what
+   pressure to promote early looks like.
+
+   Sprint 7's exit gate ran anyway, on Fable, and found that sprint's worst defect. **Deferring the
+   promotion did not defer the gate**, and it should not in 8 or 9 either: the gate is what makes
+   "all the sub-issues merged" not the closing argument.
 7. **Close the sprint**: update `MEMORY.md` plus the sprint's topic file, then write the next
    handoff prompt (task, compact, memory pointers).
 
@@ -47,7 +57,7 @@ Commands handed over are PowerShell, one command per physical line, starting wit
 | 6 | DATA band 3: race pace grid | rewritten #284 (b) | adversarial: tier discipline and fidelity claims |
 | 7 | **DATA band 3: race trace** (#944, the half sprint 6 did not build) · retire Qt · package · fix the prose | rewritten #285, #944, new | **exit gate** (the `dev -> main` promotion is deferred: Víctor, 2026-08-15) |
 | **8** | **AGENTS: the elevate pass** | new | Fable as senior dashboard designer, P0-P3 with file:line |
-| **9** | **DATA: the elevate pass** | new | same |
+| **9** | **DATA: the elevate pass** | new | same, **then the ONE `dev -> main` of the whole programme** |
 
 ### Sprints 8 and 9: where the 1:1 constraint is LIFTED
 
@@ -489,9 +499,11 @@ Note that this promotion is also what un-gates release PR #712 (`chore(main): re
 has been held open waiting for PITWALL to exist. Do not merge it before this point.
 
 > **What happened instead:** the exit gate ran, on Fable, and found the sprint's worst defect. The
-> promotion did not — Víctor deferred it on 2026-08-15, so the whole programme is still on `dev`.
-> Nothing technical is holding it: the gate is done and CI is green on every PR. The temptation this
-> paragraph warns about was avoided in the other direction, by the gate rather than by the merge.
+> promotion did not. Víctor deferred it on 2026-08-15 and then settled it on 2026-08-16 — **the
+> single promotion moves to the end of sprint 9**, so this is no longer "the promotion of the whole
+> programme" and §0.6 is where that rule now lives. Nothing technical was holding it: the gate was
+> done and CI green on every PR. The temptation this paragraph warns about was avoided in the other
+> direction, by the gate rather than by the merge.
 
 ---
 

--- a/documents/research/PITWALL_DELIVERY_PLAN.md
+++ b/documents/research/PITWALL_DELIVERY_PLAN.md
@@ -403,7 +403,51 @@ makes about what it is showing.
 
 ---
 
-## 6. Sprint 7 — retire Qt, package, fix the prose
+## 6. Sprint 7 — the race trace, retire Qt, package, fix the prose
+
+> ### ✅ DONE, 2026-08-15/16 — on `dev`, and the promotion was DEFERRED
+>
+> Everything below was executed. What follows is what actually happened, so the section stops
+> reading as a plan for work that has shipped.
+>
+> | PR | What |
+> |---|---|
+> | #945 | **The race trace** (#944) — the half of band 3 sprint 6 was scoped for and did not build. Víctor's call: build it now rather than promote a half-built band. |
+> | #946 | Qt retired: 13 modules, the two live formatters moved to `src/pitwall/`, `pyside6` + `pyqtgraph` out of `pyproject.toml` and `uv.lock`. |
+> | #952 | The five the Fable gates found in band 3. |
+> | #953 | Contributions paused until v3.0.0, and the Qt prose sweep this one's first pass missed. |
+> | #954 | The Vite bundle ships in the wheel; `f1-pitwall` did not exist and now does. |
+> | #955 | Closing the replay window tears the companion down (#947). |
+> | #956 | The connection a caller holds (#950) and the laps it can actually see (#949). |
+>
+> **⛔ The single `dev -> main` promotion did NOT happen.** Víctor, 2026-08-15: everything lands on
+> `dev` with green CI and stops. So #841-#844, #281, #284, #285, #921-#940 and #944 all stay OPEN,
+> and release PR #712 stays held. **When to promote is now a scheduling decision, not a technical
+> one** — nothing blocks it.
+>
+> **The exit gate ran on Fable, and so did four re-runs**, which settled the standing debt that
+> every gate run while Fable was out of quota was provisional. **None of them differed on a
+> verdict**: ARCH-A 11 confirmed / 4 partial / 0 refuted with both P0s intact and every scope
+> deletion justified, ARCH-B 9/9, sprint-6 correctness 9/11 (the other two were its own author's
+> recanted artefacts), the band-3 orientation upheld. What they bought was the **11 findings nobody
+> had looked for**. Reports: `~/.claude/plans/pitwall-sprint7/fable-gates/`.
+>
+> **Three things this sprint learned that outlive it:**
+>
+> 1. `src/pitwall/__main__`'s loopback server **snapshots `dist/` at startup** — confirming a build
+>    landed is not confirming the server serves it, and four measurements in a row once described a
+>    bundle no longer in the tree.
+> 2. Node's `fs.rmSync` **returns normally and deletes nothing** on this tree, so the build's own
+>    cleaning step was a silent no-op and every stale chunk shipped. `scripts/clean-dist.mjs` now
+>    verifies its own work and stops the build loudly.
+> 3. **A guard whose probe sits on the mean cannot see the defect it names.** One shipped green
+>    against its own bug until it was made to prove the two hypotheses are distinguishable first.
+>
+> Still open: **#951** (the arcade skips `repair_tyre_stints`, so its tyre age disagrees with the
+> tower) is **blocked on data** — the repair changes 0 of Melbourne's 927 rows, and Melbourne is the
+> only race a curated install carries. Sprint 9 keeps the width axis (863 of 1,140 cells clip on a
+> 1080p laptop at 150 %) and the safety-car ranking semantics.
+
 
 ⛔ **Two modules under `src/arcade/dashboard/` MOVE, they do not get deleted.** Sprint 3 made
 PITWALL render the AGENTS window by calling the Qt window's own formatters, which is what makes
@@ -443,6 +487,11 @@ once. Only after that promotion do #841-#844, #281, #284 and #285 close.
 
 Note that this promotion is also what un-gates release PR #712 (`chore(main): release 2.6.0`), which
 has been held open waiting for PITWALL to exist. Do not merge it before this point.
+
+> **What happened instead:** the exit gate ran, on Fable, and found the sprint's worst defect. The
+> promotion did not — Víctor deferred it on 2026-08-15, so the whole programme is still on `dev`.
+> Nothing technical is holding it: the gate is done and CI is green on every PR. The temptation this
+> paragraph warns about was avoided in the other direction, by the gate rather than by the merge.
 
 ---
 


### PR DESCRIPTION
Section 6 read as a plan for work that has shipped. It now records what sprint 7 actually did, so the next reader is not executing a brief that was already carried out.

## What it now says

- **The seven PRs**, including the two the plan did not anticipate: the race trace (#944/#945), which sprint 6 was scoped for and did not build, and the wheel (#954), where a Fable gate stopped predicting and measured — three build-tool JSONs in, zero bundle files.
- **The `dev -> main` promotion did NOT happen.** Víctor deferred it on 2026-08-15, so the whole programme is still on `dev` and #841-#844, #281, #284, #285, #921-#940, #944, #949, #950 and #951 all stay OPEN. Release PR #712 stays held. **Nothing technical is holding it** — the exit gate ran and CI is green on every PR — so it is now a scheduling decision.
- **The five Fable gates settled the standing re-run debt and none differed on a verdict**: ARCH-A 11 confirmed / 4 partial / 0 refuted with both P0s intact and every scope deletion justified, ARCH-B 9/9, sprint-6 correctness 9/11, the band-3 orientation upheld. What they bought was the 11 findings nobody had looked for.
- **Three mechanisms this sprint learned the hard way**, all of them silent failures: the loopback server snapshotting `dist/` at startup, Node's `fs.rmSync` returning normally while deleting nothing, and a guard whose probe sat on the field mean passing against its own defect.

The paragraph that ended in "the single `dev -> main` of the whole programme" keeps its warning — *never close work this size on "all the sub-issues merged"* — and gains what actually happened beneath it: the gate ran and found the sprint's worst defect; the promotion did not. The temptation that paragraph warns about was avoided, by the gate rather than by the merge.

Docs only. `ruff@0.15.22` clean.
