### PR TITLE
fix(pitwall): the scroll guard creates the overflow it needs instead of borrowing it

### DIFF
--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -1411,6 +1411,38 @@ check(paceCells.best === 1, `exactly one purple cell - the session's fastest lap
 // assertion that the string matches the data passes straight over that; this
 // one moves the panel and requires the header to move with it. The panel is
 // also the one affordance replacing a scrollbar this window hides globally.
+//
+// The overflow is FORCED rather than borrowed (#958). This block used to lean
+// on Melbourne's 57 rows overflowing the box on their own, and here they do -
+// by 18 px, one and a half rows of 12. On CI's font metrics the same 57 rows
+// fit, `scrollTop` never leaves 0, both reads return the same correct string,
+// and the check went red on `dev` the day it shipped. A guard whose probe sits
+// a row from the boundary cannot see the defect it names, so this one squeezes
+// the panel to a height that guarantees an overflow and PROVES the two
+// hypotheses are distinguishable before asserting which one ships.
+const squeeze = await pacePage.addStyleTag({
+  content: ".pace-scroll { height: 200px !important; flex: none !important; }",
+});
+const repin = () =>
+  pacePage.evaluate(() => {
+    const box = document.querySelector(".pace-scroll");
+    box.scrollTop = box.scrollHeight;
+    box.dispatchEvent(new Event("scroll"));
+  });
+await repin();
+await pacePage.waitForTimeout(150);
+const overflow = await pacePage.evaluate(() => {
+  const box = document.querySelector(".pace-scroll");
+  return {
+    hidden: box.scrollHeight - box.clientHeight,
+    row: box.querySelector("tbody tr")?.offsetHeight ?? 0,
+  };
+});
+check(
+  overflow.hidden > overflow.row,
+  `the panel really overflows before the range is asked to follow it (${overflow.hidden} px hidden, ${overflow.row} px per row)`,
+);
+
 const rangeAtBottom = await pacePage.locator(".pace-range").innerText();
 const scrolled = await pacePage.evaluate(() => {
   const box = document.querySelector(".pace-scroll");
@@ -1430,13 +1462,11 @@ check(
   rangeAtBottom.endsWith(`-${PACE_LAPS} of ${PACE_LAPS}`),
   `pinned to the bottom it ends at the newest lap, and says the race length (${rangeAtBottom})`,
 );
-// Put it back where the panel pins itself, so the checks below see the state
-// the window actually opens in.
-await pacePage.evaluate(() => {
-  const box = document.querySelector(".pace-scroll");
-  box.scrollTop = box.scrollHeight;
-  box.dispatchEvent(new Event("scroll"));
-});
+// Drop the squeeze and put the panel back where it pins itself, so the checks
+// below see the state the window actually opens in rather than a 200 px box
+// this guard invented.
+await squeeze.evaluate((tag) => tag.remove());
+await repin();
 await pacePage.waitForTimeout(150);
 
 // A lap 40 ms under a minute boundary. Splitting the minutes off BEFORE


### PR DESCRIPTION
The `pitwall-ui` job has been **red on `dev` since 2cfedc3** — the merge of #956, the PR that fixed
#949. It was green on the commit before it (23f719a). Nobody saw it because `pitwall-ui` is
`continue-on-error: true`, so the workflow still concludes `success`.

## Symptom

One check, in both the push run and the PR run of every branch since:

```
smoke-data FAILED (1):
  - the lap range follows the scroll (bottom "LAPS 1-57 of 57", top "LAPS 1-57 of 57")
```

## Cause — the guard's probe sits one and a half rows from the boundary

`scripts/smoke-data.mjs:1421` asserts that scrolling the pace panel to the top CHANGES the range
string. It never squeezes the panel; it relies on Melbourne's 57 rows overflowing the box **on their
own**.

Measured on this machine, at the smoke's own 1485x833 viewport:

```
clientHeight 678 · scrollHeight 696 · rowH 12 · rows 57
```

**18 px of overflow. One and a half rows.** The assertion holds here by an accident of Windows font
metrics. On CI's Linux metrics the same 57 rows fit, `scrollHeight == clientHeight`, `scrollTop`
never leaves 0, and both reads return the same — correct — string.

Reproduced locally by forcing the CI condition (`.pace-scroll { min-height: 720px }`), which
produces the identical message:

```
GEOMETRY {"clientHeight":720,"scrollHeight":720,"scrollTop":0,"rows":57,"rowH":12}
smoke-data FAILED (1):
  - the lap range follows the scroll (bottom "LAPS 1-57 of 57", top "LAPS 1-57 of 57")
```

**The shipped component is correct.** When every lap fits, `LAPS 1-57 of 57` is the true answer;
`RacePaceGrid.measure()` reads the scroller's geometry and says so. The defect is entirely in the
guard.

It is the same shape sprint 7 already paid for once and wrote down: *a guard whose probe sits on the
mean cannot see the defect it names*. Here the probe sits within one row of a boundary that moves
with the font stack.

## Fix

Make the guard **create** the overflow it needs instead of hoping for it, and prove the two
hypotheses are distinguishable before asserting which one ships:

1. squeeze `.pace-scroll` to a fixed height so the panel overflows by several rows,
2. assert the precondition — hidden height > one row — as its own check,
3. only then assert that the range follows the scroll,
4. drop the injected style and re-pin, so the checks below see the state the window opens in.

## Where

- `src/pitwall/ui/scripts/smoke-data.mjs:1408-1440` — the guard.
- `src/pitwall/ui/src/features/data/RacePaceGrid.tsx:56-80` — the component, correct, unchanged.
