### PR TITLE
fix(pitwall): the scenario panel says which plan was taken, and which was only scored

### DIFF
--- a/src/pitwall/agents_view/builder.py
+++ b/src/pitwall/agents_view/builder.py
@@ -61,7 +61,13 @@ class AgentsViewBuilder:
             "seq": payload.get("seq"),
             "header": build_header(payload, connection),
             "orchestrator": build_orchestrator(latest or None),
-            "scenarios": build_scenarios(latest.get("scenario_scores") if latest else None),
+            # The action goes in with the scores: a guardrail can veto the
+            # Monte Carlo winner, and a panel that does not know which plan
+            # was ENACTED crowns the one that was overruled (#962).
+            "scenarios": build_scenarios(
+                latest.get("scenario_scores") if latest else None,
+                latest.get("action") if latest else None,
+            ),
             "reasoning": build_reasoning(latest or None),
             "cards": build_cards(latest or None),
             "charts": {

--- a/src/pitwall/agents_view/decision.py
+++ b/src/pitwall/agents_view/decision.py
@@ -133,13 +133,40 @@ def build_orchestrator(latest: dict[str, Any] | None) -> dict[str, Any]:
     }
 
 
-def build_scenarios(scores: dict[str, Any] | None) -> list[dict[str, Any]]:
-    """Four rows: label, bar fill in [0, 1], signed score, winner flag.
+# The narrowest bar a SCORED candidate may draw. It exists so that "was
+# scored and came last" cannot render as "was never scored" (#963): min-max
+# sends the worst candidate to zero by construction, and an absent one draws
+# zero too, so the two were the same pixels - an executed diff over the two
+# bar strips found nought differing pixels.
+_SCORED_FLOOR = 0.06
+
+
+def build_scenarios(
+    scores: dict[str, Any] | None,
+    enacted_action: str | None = None,
+) -> list[dict[str, Any]]:
+    """Four rows: label, bar fill in [0, 1], signed score, and who owns the call.
 
     The fill is min-max normalised across whichever of the four keys are
-    present, so the winner always reaches full width and the worst draws
-    an empty bar whatever the signs. An absent key draws nothing and
-    prints `--`, which is not the same as a score of zero.
+    present, floored at `_SCORED_FLOOR` so a scored candidate always draws
+    ink. An absent key draws NO TRACK AT ALL and prints `--`; that is what
+    keeps "nobody scored this" distinguishable from "this one came last",
+    which the sentence used to claim while the pixels said otherwise.
+
+    **The bar encodes RANK, not margin.** Min-max over signed gains is the
+    only scale-free comparison available here, so `+0.70` against `+0.69`
+    still draws the same widths as `+0.70` against `+0.10`; the number
+    beside the bar is what carries the margin. Changing that is a decision
+    about what the bar MEANS and needs its own argument.
+
+    `enacted_action` is the action the orchestrator actually published, and
+    it is not always the Monte Carlo winner - a guardrail can veto the top
+    scenario (#962). When they diverge the panel used to crown the vetoed
+    plan in full ACCENT while the badge one card up said the opposite, so
+    the "why" panel read as the opposite of the call. The enacted row now
+    takes the highlight; the vetoed winner KEEPS ITS FILL, because the
+    Monte Carlo really did score it highest and that is true, and loses
+    only the regalia, gaining a `VETOED` mark instead.
     """
     raw: dict[str, float] = {}
     for key, value in (scores or {}).items():
@@ -149,6 +176,13 @@ def build_scenarios(scores: dict[str, Any] | None) -> list[dict[str, Any]]:
             continue
 
     winner = max(raw, key=raw.get) if raw else None
+    enacted = str(enacted_action or "").upper() or None
+    # With no action published - the idle branch, and any producer that has
+    # not sent one - the winner keeps the highlight, which is exactly the
+    # behaviour every state but the vetoed one already had.
+    highlighted = enacted if enacted in raw else winner
+    vetoed_key = winner if (highlighted != winner and winner is not None) else None
+
     if raw:
         lo, hi = min(raw.values()), max(raw.values())
         span = (hi - lo) or 1.0
@@ -159,8 +193,19 @@ def build_scenarios(scores: dict[str, Any] | None) -> list[dict[str, Any]]:
     for key in SCENARIO_KEYS:
         present = key in raw
         value = raw.get(key, lo)
-        fill = min(1.0, max(0.0, (value - lo) / span)) if present else 0.0
-        is_winner = present and key == winner
+        scaled = min(1.0, max(0.0, (value - lo) / span))
+        fill = max(scaled, _SCORED_FLOOR) if present else 0.0
+        is_highlighted = present and key == highlighted
+        is_vetoed = key == vetoed_key
+        if is_highlighted:
+            accent = ACCENT
+            score_colour = TEXT_PRIMARY
+        elif is_vetoed:
+            accent = TEXT_TERTIARY
+            score_colour = TEXT_TERTIARY
+        else:
+            accent = TEXT_SECONDARY
+            score_colour = TEXT_SECONDARY
         rows.append(
             {
                 "key": key,
@@ -173,10 +218,17 @@ def build_scenarios(scores: dict[str, Any] | None) -> list[dict[str, Any]]:
                 # keep out of it.
                 "fill_pct": round(fill * 100, 1),
                 "score": f"{value:+.2f}" if present else "  --",
-                "is_winner": is_winner,
-                "bar_colour": hex_str(ACCENT if is_winner else TEXT_SECONDARY),
-                "label_colour": hex_str(ACCENT if is_winner else TEXT_SECONDARY),
-                "score_colour": hex_str(TEXT_PRIMARY if is_winner else TEXT_SECONDARY),
+                # `is_winner` still means what it always meant - the top
+                # Monte Carlo score - so a consumer asking "what did the
+                # simulation prefer" still gets an honest answer. Whether
+                # that plan was ENACTED is the separate flag beside it.
+                "is_winner": present and key == winner,
+                "is_enacted": is_highlighted,
+                "is_scored": present,
+                "note": "VETOED" if is_vetoed else "",
+                "bar_colour": hex_str(accent),
+                "label_colour": hex_str(accent),
+                "score_colour": hex_str(score_colour),
             }
         )
     return rows

--- a/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
@@ -87,13 +87,20 @@ const IDLE_VIEW: AgentsView = {
     ["PIT_NOW", "PIT"],
     ["UNDERCUT", "UCUT"],
     ["OVERCUT", "OCUT"],
+    // `--`, not the `0%` this used to claim. Before the first tick nothing
+    // has been simulated, and "0 %" is a measurement — in a unit the live
+    // view never uses, since a live absent scenario prints `--`. The same
+    // window rendered "no data" three different ways.
   ].map(([key, label]) => ({
     key,
     label,
     fill: 0,
     fill_pct: 0,
-    score: "  0%",
+    score: "  --",
     is_winner: false,
+    is_enacted: false,
+    is_scored: false,
+    note: "",
     bar_colour: "#d1d5db",
     label_colour: "#d1d5db",
     score_colour: "#d1d5db",

--- a/src/pitwall/ui/src/features/agents/ScenarioBars.tsx
+++ b/src/pitwall/ui/src/features/agents/ScenarioBars.tsx
@@ -1,11 +1,19 @@
 /**
  * Four horizontal bars: STAY / PIT / UCUT / OCUT.
  *
- * 1:1 with `scenario_bars.py`. The normalisation, the winner and the
- * `--` for an absent scenario are all decided host side — the Monte
- * Carlo scores are signed and often all negative, and getting the shift
- * or the tie-break wrong changes which row reads as the winner, which is
- * not something a renderer should be able to do.
+ * The normalisation, the winner, the enacted plan and the `--` for an
+ * absent scenario are all decided host side — the Monte Carlo scores are
+ * signed and often all negative, and getting the shift or the tie-break
+ * wrong changes which row reads as the winner, which is not something a
+ * renderer should be able to do.
+ *
+ * Two things this renders that it did not, both from the sprint-8 gate.
+ * A row nobody scored draws **no track**, so it cannot be mistaken for
+ * the one that came last (#963) — those were the same pixels before, an
+ * executed diff found nought differing. And a Monte Carlo winner the
+ * orchestrator overruled carries a `VETOED` mark (#962), because a "why"
+ * panel crowning the plan that was not taken reads as the opposite of
+ * the call.
  */
 
 import type { ScenarioRow } from "../../lib/agents";
@@ -19,12 +27,13 @@ export function ScenarioBars({ rows }: { rows: ScenarioRow[] }) {
           <span className="scenario-label" style={{ color: row.label_colour }}>
             {row.label}
           </span>
-          <span className="scenario-bar">
+          <span className={row.is_scored ? "scenario-bar" : "scenario-bar is-unscored"}>
             <span
               className="scenario-bar-fill"
               style={{ width: `${row.fill_pct}%`, background: row.bar_colour }}
             />
           </span>
+          {row.note ? <span className="scenario-note">{row.note}</span> : null}
           <span className="scenario-score" style={{ color: row.score_colour }}>
             {row.score}
           </span>

--- a/src/pitwall/ui/src/lib/agents.ts
+++ b/src/pitwall/ui/src/lib/agents.ts
@@ -82,7 +82,14 @@ export interface ScenarioRow {
   /** The same value as a percentage, rounded host side; this is the width. */
   fill_pct: number;
   score: string;
+  /** The top Monte Carlo score. NOT necessarily the plan that was enacted. */
   is_winner: boolean;
+  /** The plan the orchestrator actually published, which a guardrail can move. */
+  is_enacted: boolean;
+  /** Whether this scenario was scored at all. An unscored row draws no track. */
+  is_scored: boolean;
+  /** `VETOED` on a winner the enacted action overruled, empty otherwise. */
+  note: string;
   bar_colour: string;
   label_colour: string;
   score_colour: string;

--- a/src/pitwall/ui/src/styles/agents.css
+++ b/src/pitwall/ui/src/styles/agents.css
@@ -315,9 +315,25 @@
   overflow: hidden;
   display: block;
 }
+/* A scenario nobody scored keeps its lane but loses its track, so the row
+ * reads as "not on the table" rather than as "scored last". Both drew an
+ * identical empty track before (#963). */
+.scenario-bar.is-unscored {
+  border-color: transparent;
+  background: transparent;
+}
 .scenario-bar-fill {
   display: block;
   height: 100%;
+}
+/* `VETOED`, on a Monte Carlo winner the orchestrator overruled (#962). It
+ * sits between the bar and the score because that is where the eye already
+ * is when it asks why the widest bar is not the call. */
+.scenario-note {
+  color: var(--qt-fg-3);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
 }
 .scenario-score {
   width: 46px;

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -451,7 +451,9 @@ def test_the_scenario_bars_normalise_across_scores_that_are_all_negative():
     }
 
     assert rows["PIT_NOW"]["fill"] == 1.0 and rows["PIT_NOW"]["is_winner"]
-    assert rows["OVERCUT"]["fill"] == 0.0
+    # The worst SCORED candidate keeps a floor rather than vanishing (#963);
+    # what it may not do is draw the same bar as a scenario nobody scored.
+    assert rows["OVERCUT"]["fill"] == 0.06
     assert rows["UNDERCUT"]["fill"] == pytest.approx((-0.50 + 1.30) / 1.20)
     assert rows["STAY_OUT"]["score"] == "-0.90"
     assert rows["PIT_NOW"]["bar_colour"] == "#a78bfa", "the winner is the accent"
@@ -477,7 +479,7 @@ def test_the_percentage_the_bar_actually_renders_is_on_the_0_to_100_scale():
     }
 
     assert rows["PIT_NOW"]["fill_pct"] == 100.0, "the winner fills the bar, in percent"
-    assert rows["OVERCUT"]["fill_pct"] == 0.0
+    assert rows["OVERCUT"]["fill_pct"] == 6.0
     assert rows["UNDERCUT"]["fill_pct"] == pytest.approx(66.7, abs=0.05)
     for row in rows.values():
         assert row["fill_pct"] == pytest.approx(row["fill"] * 100, abs=0.05), (
@@ -500,6 +502,70 @@ def test_a_scenario_the_orchestrator_did_not_score_draws_nothing_and_prints_dash
         "UNDERCUT",
         "OVERCUT",
     ], "all four rows exist even with no scores at all"
+
+
+def test_a_scored_last_place_is_distinguishable_from_a_scenario_nobody_scored():
+    """The claim the docstring above made and the pixels denied (#963).
+
+    Min-max sends the worst scored candidate to zero BY CONSTRUCTION, and
+    an absent one drew zero too, so `--` and `+0.29` rendered the same
+    empty track - a pixel diff over the two bar strips of the live window
+    found nought differing pixels. Asserting each row's own fill in
+    isolation cannot see that: the defect is that TWO rows agree, so the
+    assertion has to be about the pair.
+
+    The worst case is n = 2, where min-max collapses the whole scale.
+    """
+    from src.pitwall.agents_view.decision import build_scenarios
+
+    rows = {row["key"]: row for row in build_scenarios({"PIT_NOW": 0.71, "STAY_OUT": 0.29})}
+    scored_last, never_scored = rows["STAY_OUT"], rows["UNDERCUT"]
+
+    assert scored_last["is_scored"] and not never_scored["is_scored"]
+    assert scored_last["fill_pct"] > never_scored["fill_pct"], (
+        "a candidate the simulation scored must draw ink a candidate it never considered does not"
+    )
+    assert scored_last["score"] == "+0.29" and never_scored["score"] == "  --"
+
+
+def test_a_guardrail_veto_moves_the_crown_to_the_plan_that_was_ENACTED():
+    """The sprint-8 gate's P0 (#962).
+
+    A guardrail can overrule the Monte Carlo winner, and the panel that
+    explains the call used to keep crowning the overruled plan in full
+    ACCENT while the badge one card up said the opposite. The two panels
+    disagreed about which strategy the system was executing.
+
+    What must NOT change is the winner's fill: the simulation really did
+    score it highest, and hiding that would replace one lie with another.
+    """
+    from src.pitwall.agents_view.decision import build_scenarios
+
+    rows = {
+        row["key"]: row
+        for row in build_scenarios({"PIT_NOW": 0.71, "STAY_OUT": 0.29}, enacted_action="STAY_OUT")
+    }
+
+    assert rows["PIT_NOW"]["is_winner"], "the simulation's preference is still reported honestly"
+    assert rows["PIT_NOW"]["fill_pct"] == 100.0, "and it keeps the width it earned"
+    assert rows["PIT_NOW"]["note"] == "VETOED"
+    assert not rows["PIT_NOW"]["is_enacted"]
+    assert rows["STAY_OUT"]["is_enacted"], "the call the orchestrator published takes the highlight"
+    assert rows["STAY_OUT"]["label_colour"] == "#a78bfa"
+    assert rows["PIT_NOW"]["label_colour"] != "#a78bfa", "the vetoed plan loses the regalia"
+
+
+def test_with_no_veto_the_winner_keeps_the_crown_and_nothing_is_marked():
+    """The unvetoed path is the common one and must be untouched by #962."""
+    from src.pitwall.agents_view.decision import build_scenarios
+
+    scores = {"PIT_NOW": 0.71, "STAY_OUT": 0.29}
+    for action in ("PIT_NOW", None):
+        rows = {row["key"]: row for row in build_scenarios(scores, enacted_action=action)}
+        assert rows["PIT_NOW"]["is_enacted"] and rows["PIT_NOW"]["label_colour"] == "#a78bfa"
+        assert all(row["note"] == "" for row in rows.values()), (
+            f"nothing is vetoed when the enacted action is {action!r}"
+        )
 
 
 def test_the_action_badge_comes_from_classify_action_and_is_not_a_second_table():


### PR DESCRIPTION
Two findings from the sprint-8 design gate, one panel — `documents/audits/GATE_PITWALL_AGENTS_DESIGN.md` S1 (P0) and S2 (P1).

## The P0: the panel that explains the call was showing the opposite of it

In the guardrail state the badge says **STAY OUT**; one card below, the scenario panel crowned
**PIT** — full accent bar, widest fill, brightest score — while STAY, the plan actually being
executed, drew an empty grey bar. The only connective tissue was an 11 px red line.

`build_scenarios` only ever knew the Monte Carlo scores, so it had no way to know a guardrail had
overruled them. It now takes the enacted action, and:

- the enacted row takes the highlight,
- **the overruled winner keeps its fill** — the simulation really did score it highest and hiding
  that would replace one lie with another — and is marked `VETOED`.

`is_winner` still means exactly what it always meant, so anything asking "what did the simulation
prefer" still gets an honest answer; whether that plan was *enacted* is the separate flag beside it.

## The P1: why that was hard to see

Min-max normalisation sends the worst scored candidate to zero **by construction**, and an unscored
one drew zero too. A runner-up at `+0.29` and a scenario nobody scored were the same pixels — the
gate's executed diff over the two bar strips found **0 differing**.

A scored row now floors at 6 %, and an unscored row draws **no track at all**. That is what
`build_scenarios`' own docstring already claimed (*"not the same as a score of zero"*) and the
screen denied. The bar still encodes **rank, not margin** — that limitation is now written down
where the arithmetic is, rather than left to be rediscovered.

The idle view also stops printing a measured `0%` for four scenarios nothing has simulated, in a
unit the live view never uses.

## Verified

- `tests/surfaces/test_pitwall_agents_view.py` 41 passed.
- **The new guard asserts the PAIR, not each row**: the defect was that two rows *agreed*, which no
  per-row assertion can see. A second test holds the unvetoed path unchanged for both
  `enacted_action="PIT_NOW"` and `None`.
- **Looked at, not just diffed**: the window re-shot at 1485×833 on the real bundle and the real
  host for both states. Guardrail — STAY purple and filled, PIT grey and `VETOED`, UCUT/OCUT with no
  track. Happy path — unchanged except the runner-up now draws ink.
- `smoke-agents` 18 checks, `smoke-data` 147 checks, `ruff@0.15.22` clean.

Closes #962, closes #963
