### PR TITLE
chore(git): ignore the per-machine agent skill installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,10 @@ docs/_external_images/
 .spyderproject
 .spyproject
 .claude/
+# Agent skills installed per machine, the same way `.claude/` already is:
+# `npx skills add` writes the skill sources here and records them in the lock.
+.agents/
+skills-lock.json
 
 # ===========================
 # Environment


### PR DESCRIPTION
`npx skills add` (used this sprint to install `hallmark`) writes third-party skill sources into `.agents/` and records them in `skills-lock.json`. Both are machine-local tooling, exactly like `.claude/`, which this repo has ignored from the start.

Without the lines a `git add -A` commits somebody else's instruction files into the repo.