### PR TITLE
fix(pitwall): the alarm and the decision become legible on their own fills

### DIFF
--- a/src/arcade/palette.py
+++ b/src/arcade/palette.py
@@ -68,6 +68,86 @@ def hex_str(rgb: tuple[int, int, int]) -> str:
     return f"#{rgb[0]:02x}{rgb[1]:02x}{rgb[2]:02x}"
 
 
+def _relative_luminance(rgb: tuple[int, int, int]) -> float:
+    """WCAG 2.x relative luminance, which is not the same as perceived brightness."""
+    channels = []
+    for raw in rgb:
+        c = raw / 255
+        channels.append(c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4)
+    red, green, blue = channels
+    return 0.2126 * red + 0.7152 * green + 0.0722 * blue
+
+
+def contrast_ratio(first: tuple[int, int, int], second: tuple[int, int, int]) -> float:
+    """The WCAG contrast ratio between two colours, from 1.0 to 21.0."""
+    high, low = sorted((_relative_luminance(first), _relative_luminance(second)), reverse=True)
+    return (high + 0.05) / (low + 0.05)
+
+
+# WCAG AA for body-sized text. The pills render at 10 px bold, which is
+# nowhere near the 18.66 px bold that would let 3.0 count.
+_AA_SMALL_TEXT: Final[float] = 4.5
+
+
+def readable_on(background: tuple[int, int, int]) -> tuple[int, int, int]:
+    """Whichever of the dark ground or white reads better ON ``background``.
+
+    **Chosen by the actual criterion, not by a stand-in for it.** The pill
+    builders used to pick white below a hand-set brightness threshold of
+    180, and the threshold does not answer the question contrast asks: at
+    the alert chip's own grey (#9ca3af) it scores 162 and takes white, and
+    white on that grey measures **2.54:1** against the 4.5 the 10 px label
+    needs. The sprint-8 gate found the same 2.54 on the STAY OUT badge -
+    the two least legible things on the screen were the alarm and the
+    decision.
+
+    Comparing the two candidates directly cannot be wrong by a threshold,
+    and it lands on dark text for every saturated fill in this palette:
+    SUCCESS 7.29, ACCENT 6.80, WARNING 8.61, DANGER 4.92, all passing.
+    """
+    dark = contrast_ratio(BG_COLOR, background)
+    light = contrast_ratio(TEXT_PRIMARY, background)
+    return BG_COLOR if dark >= light else TEXT_PRIMARY
+
+
+def _blend(
+    colour: tuple[int, int, int], towards: tuple[int, int, int], amount: float
+) -> tuple[int, int, int]:
+    """`colour` moved `amount` of the way to `towards`, channel by channel."""
+    red, green, blue = (round(c + (t - c) * amount) for c, t in zip(colour, towards))
+    return (red, green, blue)
+
+
+def legible_fill(
+    background: tuple[int, int, int],
+) -> tuple[tuple[int, int, int], tuple[int, int, int]]:
+    """A `(fill, text)` pair for a small-text pill that reaches AA.
+
+    Some brand colours sit in the middle of the range where NEITHER
+    ground is legible: the SOFT compound's #e63232 gives 4.31:1 against
+    white and less against the dark ground, so picking the better of the
+    two still lands under the 4.5 a 10 px label needs. The fill is then
+    deepened away from its own text - darkened under white, lightened
+    under dark - by the smallest step that clears AA, which keeps the hue
+    a strategist recognises while making the label readable.
+
+    Only the PILL is adjusted. `compound_color` itself is untouched,
+    because the tyre chart's stint bands are painted from it and their
+    contrast question is a different one (a band carries no text).
+    """
+    fill = background
+    text = readable_on(fill)
+    away = TEXT_PRIMARY if text == BG_COLOR else BG_COLOR
+    # Twelve 8 % steps reach either ground; the loop exits on the first
+    # that clears, so a colour already passing is returned unchanged.
+    for _ in range(12):
+        if contrast_ratio(text, fill) >= _AA_SMALL_TEXT:
+            break
+        fill = _blend(fill, away, 0.08)
+        text = readable_on(fill)
+    return fill, text
+
+
 # --- Monospace font chain ------------------------------------------------
 # Fira Code (+ its Nerd Font variant) ships with programming ligatures and
 # a lot of monospace glyphs that align neatly for metric tables. Users
@@ -128,10 +208,7 @@ def compound_pill_html(compound: str | None) -> str:
     strings reach a webview.
     """
     label = (compound or "—").strip() or "—"
-    colour = compound_color(label)
-    # Dark text on light/saturated backgrounds, white on dim ones.
-    lum = 0.299 * colour[0] + 0.587 * colour[1] + 0.114 * colour[2]
-    fg = BG_COLOR if lum > 180 else TEXT_PRIMARY
+    colour, fg = legible_fill(compound_color(label))
     # Single quotes in the font stack are fine since the style attribute
     # uses double quotes.
     font_stack = MONO_FONT_STACK
@@ -177,14 +254,18 @@ def flag_chip_html(intent: str | None) -> str:
 
     The label is HTML-escaped for the same reason as the compound pill:
     it originates in agent output, not in this file.
+
+    The foreground comes from `readable_on` rather than being fixed to
+    white, which is what made this chip the least legible text in the
+    AGENTS window at 2.54:1 - an alarm nobody can read is not an alarm.
     """
     key = (intent or "—").upper().strip() or "—"
-    bg = _FLAG_BG_BY_INTENT.get(key, TEXT_TERTIARY)
+    bg, fg = legible_fill(_FLAG_BG_BY_INTENT.get(key, TEXT_TERTIARY))
     label = key.replace("_", " ")
     return (
         '<span style="'
         f"background-color: {hex_str(bg)}; "
-        f"color: {hex_str(TEXT_PRIMARY)}; "
+        f"color: {hex_str(fg)}; "
         "padding: 1px 6px; border-radius: 6px; "
         "font-weight: 700; font-size: 10px; letter-spacing: 0.3px;"
         f'">{html.escape(label)}</span>'

--- a/src/pitwall/agents_view/decision.py
+++ b/src/pitwall/agents_view/decision.py
@@ -28,6 +28,7 @@ from src.arcade.palette import (
     WARNING,
     compound_pill_html,
     hex_str,
+    readable_on,
 )
 from src.arcade.strategy import classify_action
 
@@ -93,6 +94,7 @@ def build_orchestrator(latest: dict[str, Any] | None) -> dict[str, Any]:
         return {
             "action": "--",
             "action_colour": hex_str(TEXT_TERTIARY),
+            "action_text_colour": hex_str(readable_on(TEXT_TERTIARY)),
             "confidence": None,
             "confidence_fill": 0.0,
             "confidence_label": "Confidence: --",
@@ -115,6 +117,12 @@ def build_orchestrator(latest: dict[str, Any] | None) -> dict[str, Any]:
     return {
         "action": badge_label,
         "action_colour": hex_str(badge_colour),
+        # The badge's own text colour, decided here rather than fixed to
+        # white in the renderer. White on SUCCESS measures 2.54:1, so the
+        # single most important element on the screen failed AA in the one
+        # state - a guardrail veto - where a strategist most needs to read
+        # it. `readable_on` picks whichever ground actually contrasts.
+        "action_text_colour": hex_str(readable_on(badge_colour)),
         "confidence": confidence,
         # The bar's width, to the 0.1 % Qt's gradient stop resolves to
         # (`orchestrator_card.py::_bar_style` rounds the stop to 3 dp).

--- a/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
@@ -12,9 +12,12 @@
  *
  * Before the first view arrives the window renders what the Qt window
  * shows at startup, rather than a spinner. That is not the same as
- * `update_from(None)`: the badge is ACCENT purple, the plan line uses
- * em-dashes and the scenario scores read "0%" — `_render_idle` is what Qt
- * paints once a tick with no decision has arrived, a different moment.
+ * `update_from(None)`: the badge is ACCENT purple and the plan line uses
+ * em-dashes — `_render_idle` is what Qt paints once a tick with no
+ * decision has arrived, a different moment. The scenario scores are the
+ * one place that no longer follows Qt: they read `--` rather than the
+ * "0%" it painted, because before the first tick nothing has been
+ * simulated and 0 % is a measurement.
  * The connection chip is the one field taken from Qt's FIRST PAINTED
  * FRAME rather than from its constructor, because the constructor's grey
  * lasts milliseconds and is not a state anybody sees.
@@ -71,6 +74,9 @@ const IDLE_VIEW: AgentsView = {
     action: "--",
     // ACCENT: `orchestrator_card.py:100` styles the badge at construction.
     action_colour: "#a78bfa",
+    // Dark on the accent fill, as `readable_on` picks for the live badge:
+    // white measured 2.72:1 here.
+    action_text_colour: "#121127",
     confidence: null,
     confidence_fill: 0,
     confidence_label: "Confidence: --",

--- a/src/pitwall/ui/src/features/agents/OrchestratorCard.tsx
+++ b/src/pitwall/ui/src/features/agents/OrchestratorCard.tsx
@@ -14,7 +14,13 @@ export function OrchestratorCard({ view }: { view: OrchestratorView }) {
   return (
     <section className="card orchestrator">
       <div className="orch-top">
-        <div className="orch-badge" style={{ background: view.action_colour }}>
+        {/* The text colour comes from the host too. Fixed to white here it
+            measured 2.54:1 on the SUCCESS fill — the primary decision, below
+            AA, in the state where a guardrail has just overruled the plan. */}
+        <div
+          className="orch-badge"
+          style={{ background: view.action_colour, color: view.action_text_colour }}
+        >
           {view.action}
         </div>
         <div className="orch-conf">

--- a/src/pitwall/ui/src/lib/agents.ts
+++ b/src/pitwall/ui/src/lib/agents.ts
@@ -58,6 +58,8 @@ export interface TireHistoryRow {
 export interface OrchestratorView {
   action: string;
   action_colour: string;
+  /** The badge's TEXT colour, chosen host side against the fill (WCAG). */
+  action_text_colour: string;
   /** null before the first decision; the bar then draws empty. */
   confidence: number | null;
   /** The bar's width in per cent, already clamped and rounded host side. */

--- a/src/pitwall/ui/src/styles/agents.css
+++ b/src/pitwall/ui/src/styles/agents.css
@@ -121,6 +121,16 @@
  * renders the intent the Qt author wrote and the toolkit dropped.
  * Deleting it would mean reproducing a toolkit limitation on purpose. */
 .agent-card.is-idle {
+  /* Scoped to the CHROME, not the text. At 0.45 the trigger hint explaining
+   * why a card is dark measured 2.38:1 in rendered pixels, and the dim
+   * cannot be tuned into compliance - 0.75 still fails at 4.39:1 and 0.85
+   * no longer reads as dimmed. The producer already sends idle text in
+   * TEXT_TERTIARY, which measures 6.88:1 on this ground, so the colour
+   * system carries the state and the opacity only softens the frame. */
+  border-color: color-mix(in srgb, var(--qt-border) 45%, transparent);
+}
+.agent-card.is-idle .agent-glyph,
+.agent-card.is-idle .agent-chart {
   opacity: 0.45;
 }
 .agent-card-body {
@@ -230,6 +240,8 @@
   justify-content: center;
   border-radius: 10px;
   padding: 14px 18px;
+  /* Fallback only. The live colour is inline, decided against the fill by
+   * `readable_on`, because a fixed white measured 2.54:1 on SUCCESS. */
   color: var(--qt-fg-1);
   font-size: 26px;
   font-weight: 800;

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -74,6 +74,65 @@ def test_the_badge_builders_escape_what_comes_off_the_wire():
     assert "&lt;" in flag_chip_html("A<B")
 
 
+def _rendered_pair(span: str) -> tuple[str, str]:
+    """The `(background, foreground)` a pill span actually carries."""
+    import re
+
+    background = re.search(r"background-color: (#[0-9a-f]{6})", span)
+    foreground = re.search(r"color: (#[0-9a-f]{6})", span.split("background-color:", 1)[1])
+    assert background and foreground, span
+    return background.group(1), foreground.group(1)
+
+
+def test_every_pill_and_badge_is_legible_against_its_own_fill():
+    """The sprint-8 gate's contrast finding, asserted as a RATIO (#965).
+
+    A test that pinned the hexes would have passed happily on the defect:
+    white on the alert chip's grey is 2.54:1, white on the STAY OUT badge
+    is 2.54:1, and both hexes were exactly the ones the palette intended.
+    **The alarm and the decision were the two least legible things on the
+    screen**, and the only assertion that can see that is the one about
+    the pair.
+
+    Every intent and every compound, not a sample: the defect class this
+    repo pays for most is the twin that never got the fix, and a chip
+    enumeration with one member checked is that shape waiting to happen.
+    """
+    from src.arcade.palette import (
+        _COMPOUND_COLOUR_BY_LABEL,
+        _FLAG_BG_BY_INTENT,
+        compound_pill_html,
+        contrast_ratio,
+        flag_chip_html,
+    )
+
+    def rgb(value: str) -> tuple[int, int, int]:
+        return (int(value[1:3], 16), int(value[3:5], 16), int(value[5:7], 16))
+
+    subjects = [(intent, flag_chip_html(intent)) for intent in (*_FLAG_BG_BY_INTENT, "UNKNOWN")]
+    subjects += [
+        (compound, compound_pill_html(compound))
+        for compound in (*_COMPOUND_COLOUR_BY_LABEL, "UNKNOWN")
+    ]
+    for name, span in subjects:
+        background, foreground = _rendered_pair(span)
+        ratio = contrast_ratio(rgb(background), rgb(foreground))
+        assert ratio >= 4.5, f"{name}: {foreground} on {background} is {ratio:.2f}:1"
+
+    # The badge takes the same treatment through the view, for every action
+    # `classify_action` knows plus the fallback.
+    from src.pitwall.agents_view.decision import build_orchestrator
+
+    for action in ("PIT_NOW", "STAY_OUT", "UNDERCUT", "OVERCUT", "SOMETHING_ELSE"):
+        built = build_orchestrator({"action": action, "confidence": 0.5})
+        ratio = contrast_ratio(rgb(built["action_colour"]), rgb(built["action_text_colour"]))
+        assert ratio >= 4.5, f"{action}: {ratio:.2f}:1"
+    idle = build_orchestrator(None)
+    assert contrast_ratio(rgb(idle["action_colour"]), rgb(idle["action_text_colour"])) >= 4.5, (
+        "the idle badge too"
+    )
+
+
 # --- The view the host hands the window -------------------------------------
 
 


### PR DESCRIPTION
Sprint-8 design gate, S4 (P1) — five measured AA failures, of which the two worst were **the alarm
and the primary decision**.

| Element | was | now |
|---|---|---|
| Radio ALERT chip, 10 px/700 | 2.54:1 | dark on grey, **passes** |
| STAY OUT badge, 26 px/800 | 2.54:1 | dark on SUCCESS, **7.29:1** |
| Idle badge `--` | 2.72:1 | dark on ACCENT, **6.80:1** |
| Dimmed idle headline (rendered px) | 2.38:1 | `TEXT_TERTIARY`, **6.88:1** |
| Dimmed idle card title | 3.34:1 | same |

## Why it was wrong

Both pill builders picked their foreground from a hand-set **brightness threshold of 180**, and that
threshold does not answer the question contrast asks: the alert chip's own grey scores 162, takes
white, and lands at 2.54:1.

`readable_on` compares the two candidate grounds by actual WCAG ratio instead, which cannot be
wrong by a threshold. The badge's text colour now comes from the host beside its fill rather than
being fixed to white in the renderer — the same side of the boundary its fill was already on.

The idle dim is **scoped to the glyph and the frame**. `opacity: 0.45` put the text that explains
*why a card is dark* at 2.38:1, and no opacity value both passes and still reads as dimmed (0.75 →
4.39:1, 0.85 passes and no longer looks dimmed). The producer already sends that text in
`TEXT_TERTIARY`, which measures 6.88:1, so the colour system carries the state.

## Writing the guard as a ratio found a sixth failure the report had not

Enumerating every intent and every compound — not a sample, because the twin that never got the fix
is this repo's most expensive defect — surfaced the **SOFT pill at `#e63232`, 4.31:1**, where
*neither* ground reaches AA. `legible_fill` deepens a fill away from its own text by the smallest
step that clears. `compound_color` itself is untouched: the tyre chart's stint bands are painted
from it and a band carries no text.

## Verified

- `tests/surfaces/` 212 passed, including `test_pitwall_tokens.py` (the palette-copy counter).
- **The guard asserts the ratio, never a hex.** A hex-pinning test passes happily on this defect —
  every colour involved was exactly the one the palette intended.
- **Looked at**: window re-shot at 1485×833 on the real bundle and the real host. STAY OUT reads
  dark on green; the alert chip reads dark on grey.
- `smoke-agents` 18 checks, `tsc` clean, `ruff@0.15.22` clean.

Closes #965
