### PR TITLE
refactor(pitwall): the tooltips return data, and the window decides how it looks

### DIFF
--- a/src/pitwall/agent_formatters.py
+++ b/src/pitwall/agent_formatters.py
@@ -31,7 +31,6 @@ PySide6 and, through ``classify_action``, pandas.
 
 from __future__ import annotations
 
-import html
 from typing import Any
 
 from src.arcade.palette import (
@@ -283,51 +282,69 @@ def _radio_intent(event: dict[str, Any]) -> str:
     return str((event.get("analysis") or {}).get("intent") or "INFO")
 
 
-def radio_tooltip_html(r: dict[str, Any] | None) -> str:
-    """Build the Qt rich-text tooltip listing every radio and RCM in the lap.
+def radio_tooltip(r: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Every radio and RCM of the lap, as DATA the window renders itself.
 
-    The tooltip exists because the body ticker only shows the most recent
+    The tooltip exists because the body ticker shows only the most recent
     radio and the most recent RCM, and the strategist sometimes needs the
-    full transcript of the lap (e.g. several PROBLEM radios in a row, or
-    a chain of yellow flags clearing) and the body labels do not have the
-    vertical budget for that. Returning the empty string is the documented
-    Qt convention to suppress the tooltip popup, so callers can always
-    invoke ``setToolTip(radio_tooltip_html(r))`` without an explicit
-    "clear" branch.
+    whole lap - several PROBLEM radios in a row, a chain of yellows
+    clearing - which the body has no vertical budget for.
 
-    HTML primitives are limited to ``<b>``, ``<br>`` and ``&nbsp;``
-    because Qt's tooltip rich-text subset rejects CSS and most layout
-    tags. Free-text fields (driver, intent, message, RCM label) are
-    HTML-escaped so a stray ``<`` or ``&`` in a transcript cannot break
-    the tooltip's rich-text parser.
+    **It used to return Qt rich text** (`<b>`, `<br>`, `&nbsp;`, and
+    nothing else, because that is the subset `QToolTip` parses) and the
+    React side rendered it through `dangerouslySetInnerHTML`. Qt was
+    retired in sprint 7; the dialect outlived the toolkit that required
+    it. Under the hybrid this decides WHAT is said and the TSX decides how
+    it looks, so there is no markup here and no escaping either - a React
+    text node is not a parser.
+
+    **The 70-character cap is gone, and that is the point of the change.**
+    It was the BODY's width budget - `_truncate`'s docstring says so, in
+    terms of a 280-340 px QLabel at 11 px - applied to a popup that is not
+    a card and is clipped by nothing. The tooltip truncated each message
+    to exactly what the card already showed, so its only added value was
+    more messages, never more of a message. The body ticker keeps the cap;
+    it really is that narrow.
+
+    `None`, not `""`, for "no tooltip". The empty string was Qt's own
+    convention for suppressing a popup, and a falsy value that is also a
+    legitimate rendering is the sentinel shape this repo keeps paying for.
     """
     if r is None:
-        return ""
+        return None
     radio_events = r.get("radio_events") or []
     rcm_events = r.get("rcm_events") or []
     if not radio_events and not rcm_events:
-        return ""
+        return None
 
-    sections: list[str] = []
+    sections: list[dict[str, Any]] = []
     if rcm_events:
-        rcm_lines = ["<b>RCM</b>"]
-        for ev in rcm_events:
-            lap = ev.get("lap", "?")
-            label = html.escape(_rcm_label(ev))
-            msg = html.escape(_truncate(ev.get("message"), 70))
-            rcm_lines.append(f"L{lap}&nbsp;{label}: {msg}")
-        sections.append("<br>".join(rcm_lines))
-
+        sections.append(
+            {
+                "title": "RCM",
+                "rows": [
+                    {
+                        "lead": f"L{ev.get('lap', '?')} {_rcm_label(ev)}",
+                        "text": str(ev.get("message") or ""),
+                    }
+                    for ev in rcm_events
+                ],
+            }
+        )
     if radio_events:
-        radio_lines = ["<b>Radio</b>"]
-        for ev in radio_events:
-            driver = html.escape(_radio_driver(ev))
-            intent = html.escape(_radio_intent(ev))
-            msg = html.escape(_truncate(ev.get("message"), 70))
-            radio_lines.append(f'{driver}&nbsp;{intent}: "{msg}"')
-        sections.append("<br>".join(radio_lines))
-
-    return "<br><br>".join(sections)
+        sections.append(
+            {
+                "title": "Radio",
+                "rows": [
+                    {
+                        "lead": f"{_radio_driver(ev)} {_radio_intent(ev)}",
+                        "text": str(ev.get("message") or ""),
+                    }
+                    for ev in radio_events
+                ],
+            }
+        )
+    return {"sections": sections, "footer": None}
 
 
 def format_radio(r: dict[str, Any] | None) -> Formatted:
@@ -488,57 +505,46 @@ def _format_article_refs(articles: list[Any] | None) -> str:
     return "Art. " + ", ".join(head) + tail
 
 
-def rag_tooltip_html(r: dict[str, Any] | None) -> str:
-    """Build the Qt rich-text tooltip listing every regulation chunk for the lap.
+def rag_tooltip(r: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Every regulation chunk behind the lap's answer, as DATA.
 
-    The tooltip exists because the body shows only a 70-character snippet
-    of the LLM answer plus a compact article-refs line; the strategist
-    sometimes needs to read the verbatim regulation passages the answer
-    is grounded on (especially during a contested SC restart or a pit
-    sequence near a procedural article). Returning the empty string is
-    the documented Qt convention to suppress the tooltip popup, so
-    callers can always invoke ``setToolTip(rag_tooltip_html(r))`` without
-    an explicit "clear" branch.
+    The body shows a 70-character snippet of the LLM answer and a compact
+    article-refs line; the strategist sometimes needs the verbatim passages
+    the answer is grounded on, especially around a contested restart or a
+    procedural article. The question leads, so the engineer can see what
+    the orchestrator actually asked.
 
-    The original question is shown above the chunks so the engineer sees
-    what the orchestrator actually asked. Up to four chunks are rendered
-    in full (truncated at ~280 chars each); any extra retrieval results
-    collapse to a ``+N more`` footer to keep the tooltip box tight. HTML
-    primitives are limited to ``<b>``, ``<br>`` and ``&nbsp;``; free-text
-    fields (question, chunk text, article id) are HTML-escaped so a
-    stray ``<`` or ``&`` in the regulation cannot break the parser.
+    Four chunks, then a `+N more` footer, which is a bound on how much a
+    popup should carry rather than a layout constant. The per-chunk 280
+    character cap is gone with the markup: clamping is the renderer's job
+    now, and the whole reason to open this is to read the passage.
     """
     if r is None:
-        return ""
+        return None
     chunks = r.get("chunks") or []
-    question = (r.get("question") or "").strip()
     if not chunks:
-        return ""
+        return None
 
-    parts: list[str] = []
+    sections: list[dict[str, Any]] = []
+    question = (r.get("question") or "").strip()
     if question:
-        parts.append(f"<b>Question:</b><br>{html.escape(question)}")
+        sections.append({"title": "Question", "rows": [{"lead": "", "text": question}]})
 
     head = chunks[:4]
-    extra = len(chunks) - len(head)
-    for c in head:
-        article = str(c.get("article") or "").strip()
-        doc_type = str(c.get("doc_type") or "").strip()
-        year = c.get("year")
-        header_bits: list[str] = []
-        if doc_type:
-            header_bits.append(html.escape(doc_type))
-        if year is not None:
-            header_bits.append(str(year))
+    for chunk in head:
+        article = str(chunk.get("article") or "").strip()
+        doc_type = str(chunk.get("doc_type") or "").strip()
+        year = chunk.get("year")
+        bits = [bit for bit in (doc_type, None if year is None else str(year)) if bit]
         if article:
-            header_bits.append("— " + html.escape(article))
-        header = "<b>" + " ".join(header_bits) + "</b>" if header_bits else "<b>Chunk</b>"
-        body_html = html.escape(_truncate(c.get("text"), 280))
-        parts.append(f"{header}<br>{body_html}")
-    if extra > 0:
-        parts.append(f"+{extra} more")
+            bits.append(f"— {article}")
+        title = " ".join(bits) if bits else "Chunk"
+        sections.append(
+            {"title": title, "rows": [{"lead": "", "text": str(chunk.get("text") or "")}]}
+        )
 
-    return "<br><br>".join(parts)
+    extra = len(chunks) - len(head)
+    return {"sections": sections, "footer": f"+{extra} more" if extra > 0 else None}
 
 
 def format_rag(rag: dict[str, Any] | str | None, active: bool) -> Formatted:

--- a/src/pitwall/agents_view/panels.py
+++ b/src/pitwall/agents_view/panels.py
@@ -35,8 +35,8 @@ from src.pitwall.agent_formatters import (
     format_rag,
     format_situation,
     format_tire,
-    radio_tooltip_html,
-    rag_tooltip_html,
+    radio_tooltip,
+    rag_tooltip,
 )
 
 # window.py's HeaderBar.set_connection, with its three states and their
@@ -85,7 +85,7 @@ def build_header(payload: dict[str, Any], connection: str) -> dict[str, Any]:
     }
 
 
-def _card(formatted: tuple, tooltip: str = "") -> dict[str, Any]:
+def _card(formatted: tuple, tooltip: dict[str, Any] | None = None) -> dict[str, Any]:
     """One formatter tuple as JSON: `(headline, colour, lines, status)`."""
     headline, headline_colour, lines, status = formatted
     glyph, glyph_colour = STATUS_GLYPHS.get(status, STATUS_GLYPHS["IDLE"])
@@ -135,10 +135,10 @@ def build_cards(latest: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
         "tire": _card(format_tire(per.get("tire"))),
         "situation": _card(format_situation(per.get("situation"))),
         "pit": _card(format_pit(per.get("pit"), active="N28" in active)),
-        "radio": _card(format_radio(radio_block), radio_tooltip_html(radio_block)),
+        "radio": _card(format_radio(radio_block), radio_tooltip(radio_block)),
         "rag": _card(
             format_rag(rag_block, active=rag_active),
-            rag_tooltip_html(rag_block) if rag_active else "",
+            rag_tooltip(rag_block) if rag_active else None,
         ),
     }
 

--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -110,7 +110,26 @@ const VIEW = {
         status: "OK",
         glyph: "●",
         glyph_colour: "#10b981",
-        tooltip: key === "radio" ? "<b>Radio</b><br>NOR: rear grip" : "",
+        // Structured, not markup. Sprint 8 turned the two tooltip formatters
+        // into data, so a string here would be the stale-stub shape this file
+        // already carries one scar from.
+        tooltip:
+          key === "radio"
+            ? {
+                sections: [
+                  {
+                    title: "Radio",
+                    rows: [
+                      {
+                        lead: "NOR PROBLEM",
+                        text: "Rear grip is going away, especially through the last sector, and the balance moves every lap.",
+                      },
+                    ],
+                  },
+                ],
+                footer: null,
+              }
+            : null,
       },
     ]),
   ),

--- a/src/pitwall/ui/src/features/agents/AgentCard.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentCard.tsx
@@ -5,18 +5,19 @@
  * which agent it shows. Title and content arrive from the host, which
  * produced them with the Qt window's own formatters.
  *
- * `dangerouslySetInnerHTML` is deliberate and bounded. The headline and
- * the body lines can carry the compound pill and the flag chips, which
- * are HTML spans built in `src/arcade/palette.py`, and every free-text
- * field inside them is escaped there. It is Qt's restricted rich-text
- * dialect (`<b>`, `<br>`, `&nbsp;` and those spans), which is debt sprint
- * 8 unpicks - not a licence to inject arbitrary markup here.
+ * `dangerouslySetInnerHTML` survives on the headline and the body lines,
+ * which can carry the compound pill and the flag chips - HTML spans built
+ * in `src/arcade/palette.py` with every free-text field escaped there.
+ * **The tooltip no longer does**: sprint 8 turned the two tooltip
+ * formatters into structured data, so the popup below is built from
+ * fields rather than parsed out of a dead toolkit's dialect. The pills
+ * are the same debt one layer down and are filed separately.
  */
 
 import { useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
-import type { AgentCardView } from "../../lib/agents";
+import type { AgentCardView, TooltipView } from "../../lib/agents";
 
 /**
  * The popup, rendered OUTSIDE the window tree.
@@ -38,7 +39,7 @@ import type { AgentCardView } from "../../lib/agents";
 /** Breathing room between the card and the popup, and from the viewport edge. */
 const TOOLTIP_GAP = 10;
 
-function Tooltip({ html, anchor }: { html: string; anchor: DOMRect }) {
+function Tooltip({ view, anchor }: { view: TooltipView; anchor: DOMRect }) {
   const ref = useRef<HTMLSpanElement>(null);
   const [box, setBox] = useState({ left: anchor.left, top: anchor.top + 32 });
 
@@ -71,15 +72,29 @@ function Tooltip({ html, anchor }: { html: string; anchor: DOMRect }) {
       Math.min(anchor.top, window.innerHeight - height - TOOLTIP_GAP),
     );
     setBox({ left, top });
-  }, [anchor, html]);
+  }, [anchor, view]);
 
+  // The markup is decided HERE, from data the host produced. It used to be a
+  // string of Qt's restricted rich-text dialect pushed through
+  // `dangerouslySetInnerHTML` - a dead toolkit's parser constraints shaping a
+  // webview popup. The content still comes from one place, so only the
+  // presentation below can drift from the Qt window's; the structure the host
+  // returns is pinned by a test.
   return createPortal(
-    <span
-      ref={ref}
-      className="agent-tooltip"
-      style={box}
-      dangerouslySetInnerHTML={{ __html: html }}
-    />,
+    <span ref={ref} className="agent-tooltip" style={box}>
+      {view.sections.map((section, index) => (
+        <span className="tip-section" key={index}>
+          <span className="tip-title">{section.title}</span>
+          {section.rows.map((row, rowIndex) => (
+            <span className="tip-row" key={rowIndex}>
+              {row.lead ? <span className="tip-lead">{row.lead}</span> : null}
+              <span className="tip-text">{row.text}</span>
+            </span>
+          ))}
+        </span>
+      ))}
+      {view.footer ? <span className="tip-footer">{view.footer}</span> : null}
+    </span>,
     document.body,
   );
 }
@@ -94,8 +109,9 @@ export function AgentCard({
   children?: React.ReactNode;
 }) {
   const idle = card.status === "IDLE";
-  // The whole card is the hover target, as in Qt, and an empty tooltip
-  // string is Qt's own convention for suppressing the popup.
+  // The whole card is the hover target, as in Qt. `null` suppresses the
+  // popup - not the empty string Qt used, because a falsy value that is also
+  // a legitimate rendering is the sentinel shape this repo keeps paying for.
   const [anchor, setAnchor] = useState<DOMRect | null>(null);
 
   return (
@@ -111,7 +127,7 @@ export function AgentCard({
         <span className="agent-title">{title}</span>
       </header>
 
-      {card.tooltip && anchor ? <Tooltip html={card.tooltip} anchor={anchor} /> : null}
+      {card.tooltip && anchor ? <Tooltip view={card.tooltip} anchor={anchor} /> : null}
 
       {/* The card scrolls here, not on the card itself, so the card is not
           a scrolling ancestor of anything. Qt clips a card that overflows

--- a/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
@@ -51,7 +51,7 @@ const IDLE_CARD: AgentCardView = {
   status: "IDLE",
   glyph: "○",
   glyph_colour: "#9ca3af",
-  tooltip: "",
+  tooltip: null,
 };
 
 const IDLE_VIEW: AgentsView = {

--- a/src/pitwall/ui/src/lib/agents.ts
+++ b/src/pitwall/ui/src/lib/agents.ts
@@ -27,8 +27,26 @@ export interface AgentCardView {
   status: "OK" | "WATCH" | "ALERT" | "IDLE";
   glyph: string;
   glyph_colour: string;
-  /** Empty string means no tooltip, which is Qt's own convention. */
-  tooltip: string;
+  /** `null` means no tooltip. Structured, never markup — see `agent_formatters.py`. */
+  tooltip: TooltipView | null;
+}
+
+/** A titled group of rows in a tooltip. `lead` is an optional label before the text. */
+export interface TooltipSection {
+  title: string;
+  rows: { lead: string; text: string }[];
+}
+
+/**
+ * What a card's tooltip SAYS. How it looks is decided here, in the TSX.
+ *
+ * Python used to return Qt's restricted rich-text dialect and this side
+ * rendered it with `dangerouslySetInnerHTML`. Qt is gone; the content still
+ * comes from one place, so only presentation can drift.
+ */
+export interface TooltipView {
+  sections: TooltipSection[];
+  footer: string | null;
 }
 
 export interface HeaderView {

--- a/src/pitwall/ui/src/styles/agents.css
+++ b/src/pitwall/ui/src/styles/agents.css
@@ -226,6 +226,44 @@
   line-height: 1.5;
 }
 
+/* The popup's own layout, which used to be `<br>` tags in a string Qt's
+ * tooltip parser could digest. Truncation lives here too: the host stopped
+ * cutting messages at 70 characters, which was the CARD's width budget
+ * applied to a popup clipped by nothing. */
+.tip-section {
+  display: block;
+  margin-bottom: 8px;
+}
+.tip-section:last-of-type {
+  margin-bottom: 0;
+}
+.tip-title {
+  display: block;
+  color: var(--qt-fg-1);
+  font-weight: 700;
+  margin-bottom: 2px;
+}
+.tip-row {
+  display: block;
+  margin-top: 2px;
+}
+.tip-lead {
+  color: var(--qt-fg-3);
+  margin-right: 6px;
+  white-space: nowrap;
+}
+.tip-text {
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.tip-footer {
+  display: block;
+  margin-top: 6px;
+  color: var(--qt-fg-3);
+}
+
 /* --- Status bar --------------------------------------------------------- */
 
 /* --- Orchestrator card (orchestrator_card.py) ---------------------------- */

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -131,6 +131,8 @@ def test_every_pill_and_badge_is_legible_against_its_own_fill():
     assert contrast_ratio(rgb(idle["action_colour"]), rgb(idle["action_text_colour"])) >= 4.5, (
         "the idle badge too"
     )
+
+
 def test_the_tooltips_return_data_and_never_markup():
     """What replaces the guarantee the hybrid gives up (#960).
 

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -131,6 +131,72 @@ def test_every_pill_and_badge_is_legible_against_its_own_fill():
     assert contrast_ratio(rgb(idle["action_colour"]), rgb(idle["action_text_colour"])) >= 4.5, (
         "the idle badge too"
     )
+def test_the_tooltips_return_data_and_never_markup():
+    """What replaces the guarantee the hybrid gives up (#960).
+
+    PITWALL renders the AGENTS window by CALLING the Qt window's own
+    formatters, which is what made the port 1:1 by construction. Two of
+    them returned Qt's restricted rich-text dialect - `<b>`, `<br>`,
+    `&nbsp;`, the subset `QToolTip` parses - and the React side rendered
+    it through `dangerouslySetInnerHTML`. Qt was retired in sprint 7; the
+    dialect outlived the toolkit that required it.
+
+    The hybrid keeps Python deciding WHAT is said and hands the TSX HOW it
+    looks. Content still comes from one place, **so only presentation can
+    drift** - and this is what keeps that true: the structure is pinned
+    here, so a sentence moving into the renderer fails a test rather than
+    quietly becoming a second source of truth.
+
+    It also pins the cap that went away. `radio_tooltip_html` truncated
+    every message to 70 characters, the same 70 the card's body ticker
+    uses, for a reason `_truncate` states in terms of a 280-340 px QLabel.
+    A webview popup is clipped by nothing; the tooltip's only added value
+    was more messages, never more of a message.
+    """
+    from src.pitwall.agent_formatters import radio_tooltip, rag_tooltip
+
+    long_message = "Rear grip is going away, especially through the last sector, " + "x" * 90
+    built = radio_tooltip(
+        {
+            "radio_events": [
+                {"driver": "NOR", "message": long_message, "analysis": {"intent": "PROBLEM"}}
+            ],
+            "rcm_events": [{"lap": 23, "flag": "YELLOW", "message": "Debris in sector 2"}],
+        }
+    )
+    assert built == {
+        "sections": [
+            {"title": "RCM", "rows": [{"lead": "L23 YELLOW", "text": "Debris in sector 2"}]},
+            {"title": "Radio", "rows": [{"lead": "NOR PROBLEM", "text": long_message}]},
+        ],
+        "footer": None,
+    }
+    assert "..." not in built["sections"][1]["rows"][0]["text"], (
+        "the popup carries the whole message; clamping is the renderer's job"
+    )
+
+    assert radio_tooltip(None) is None
+    assert radio_tooltip({"radio_events": [], "rcm_events": []}) is None, (
+        "`None` rather than an empty string: a falsy value that is also a legitimate "
+        "rendering is the sentinel shape this repo keeps paying for"
+    )
+
+    chunks = [
+        {"article": f"Article {n}", "doc_type": "Sporting Regulations", "year": 2025, "text": "t"}
+        for n in range(6)
+    ]
+    rag = rag_tooltip({"question": "how many compounds?", "chunks": chunks})
+    assert rag["sections"][0] == {
+        "title": "Question",
+        "rows": [{"lead": "", "text": "how many compounds?"}],
+    }
+    assert rag["sections"][1]["title"] == "Sporting Regulations 2025 — Article 0"
+    assert len(rag["sections"]) == 5, "the question plus four chunks"
+    assert rag["footer"] == "+2 more"
+    assert rag_tooltip({"question": "q", "chunks": []}) is None
+
+    for value in (*built["sections"], built["footer"], *rag["sections"], rag["footer"]):
+        assert "<" not in repr(value), f"markup reached the view: {value!r}"
 
 
 # --- The view the host hands the window -------------------------------------


### PR DESCRIPTION
The debt sprint 3 took on knowingly, and sprint 8 owns: #960.

PITWALL renders the AGENTS window by **calling the Qt window's own formatters**, which is what made
the port 1:1 *by construction* rather than by inspection. Two of them returned Qt's restricted
rich-text dialect — `<b>`, `<br>`, `&nbsp;`, the subset `QToolTip` parses — and React rendered it
through `dangerouslySetInnerHTML`. Qt was retired in #946. **The dialect outlived the toolkit that
required it.**

## The hybrid, as decided

| Python keeps | TypeScript takes |
|---|---|
| which cards exist, and whether one fired | the markup, entirely |
| the text of every headline and every line | layout, spacing, truncation |
| status / severity, and the palette NAME | resolving that name to a colour |
| the numbers and their units | how a tooltip is presented |

In one sentence: **the formatters return DATA, never markup.** One shape serves both tooltips, so
there is one renderer rather than two:

```python
{"sections": [{"title": "Radio", "rows": [{"lead": "NOR PROBLEM", "text": "…"}]}], "footer": None}
```

`None` replaces the empty string as "no tooltip". The empty string was **Qt's** convention for
suppressing a popup, and a falsy value that is also a legitimate rendering is the sentinel shape
this repo keeps paying for.

Neither side escapes anything now — a React text node is not a parser. `agent_formatters.py` no
longer imports `html` at all, which is the clearest statement that it has stopped producing markup.

## The concrete win, so this is not just tidiness

`radio_tooltip_html` truncated every message to **70 characters** — the *same* 70 the card's body
ticker uses, for a reason `_truncate` states in terms of "a 280-340 px QLabel at 11 px". A webview
popup is a portal clipped by nothing. So the tooltip showed exactly as much of each message as the
card already showed, and its only added value was *more messages*, never *more of a message*, while
its docstring claimed it existed for "the full transcript of the lap".

The cap is gone; the renderer clamps with CSS. **The body ticker keeps its 70** — that card really
is that narrow.

## What replaces the guarantee that is given up

Content still comes from one place, so **only presentation can drift, never content** — and that is
held by a test pinning the structured output field for field, including that no `...` survives and
that no `<` reaches the view.

## Out of scope, named so it is not mistaken for an oversight

Card **headlines and body lines** still carry markup: the compound pill and the flag chips, HTML
spans built in `src/arcade/palette.py` and rendered with `dangerouslySetInnerHTML`. Same debt one
layer down, strictly larger, and those spans carry inline colour the palette owns. It gets its own
issue rather than being smuggled in here.

`tests/surfaces/` 215 passed · `smoke-agents` 18 checks (its fixture migrated with the shape — this
file already carries one scar from a stub that was not) · `tsc` clean · `ruff@0.15.22` clean ·
**hovered and looked at**: RCM and Radio sections, leads, full messages, beside the card.

Closes #960