### PR TITLE
fix(pitwall): a stop is a tyre change, not a trip down the pit lane

### DIFF
--- a/src/f1_strat_manager/tyre_stint_repair.py
+++ b/src/f1_strat_manager/tyre_stint_repair.py
@@ -113,8 +113,14 @@ class RepairReport:
         )
 
 
-def _is_real_compound(value: object) -> bool:
-    """True when the value names an actual compound rather than absent data."""
+def is_real_compound(value: object) -> bool:
+    """True when the value names an actual compound rather than absent data.
+
+    Public because it carries the sentinel rule above, and PITWALL's stop count
+    needs the same rule: a stringified missing compound must never read as
+    evidence of a tyre change. A second copy of `_COMPOUND_SENTINELS` in another
+    module is the twin this repo pays for more often than any other defect.
+    """
     if value is None or (isinstance(value, float) and pd.isna(value)):
         return False
     return str(value).strip().lower() not in _COMPOUND_SENTINELS
@@ -140,11 +146,11 @@ def _first_compound_change_after(driver_laps: pd.DataFrame, lap: int) -> Optiona
     up writing a data-loss marker over a real compound.
     """
     current = driver_laps.loc[driver_laps["LapNumber"] == lap, "Compound"]
-    if current.empty or not _is_real_compound(current.iloc[0]):
+    if current.empty or not is_real_compound(current.iloc[0]):
         return None
     later = driver_laps[driver_laps["LapNumber"] > lap]
     for _, row in later.iterrows():
-        if _is_real_compound(row["Compound"]) and row["Compound"] != current.iloc[0]:
+        if is_real_compound(row["Compound"]) and row["Compound"] != current.iloc[0]:
             return int(row["LapNumber"])
     return None
 
@@ -247,7 +253,7 @@ def _rebuild_driver(driver_laps: pd.DataFrame, report: RepairReport) -> pd.DataF
         mislabelled = in_new_stint & (lap_numbers < boundary)
 
         new_compound = at_boundary["Compound"].iloc[0]
-        if _is_real_compound(new_compound):
+        if is_real_compound(new_compound):
             repaired.loc[mislabelled, "Compound"] = new_compound
         repaired.loc[mislabelled, "Stint"] = stint_id
 

--- a/src/pitwall/session_data.py
+++ b/src/pitwall/session_data.py
@@ -43,7 +43,7 @@ from typing import Any
 
 import pandas as pd
 
-from src.f1_strat_manager.tyre_stint_repair import repair_tyre_stints
+from src.f1_strat_manager.tyre_stint_repair import is_real_compound, repair_tyre_stints
 
 logger = logging.getLogger(__name__)
 
@@ -201,6 +201,60 @@ def _theoretical(best: dict[str, Any]) -> float | None:
     if any(value is None for value in sectors):
         return None
     return round(sum(sectors), 3)
+
+
+def _tyre_stops(revealed: list[dict[str, Any]]) -> int:
+    """How many times this driver changed tyres, from the sets themselves.
+
+    **A pit entry is not a stop, and the rule is already written in this repo.**
+    `tyre_stint_repair`'s docstring states it under *"Why a pit entry alone does
+    not mean a new set"*: a stop-and-go or a drive-through sends the car down
+    the pit lane with no work done. Melbourne 2025 is a stronger case than the
+    penalty it names - the safety car led the field through the pit lane on laps
+    2, 3 AND 4, so `PitInTime` is set for all seventeen runners on all three,
+    while `Compound` stays INTERMEDIATE and `TyreLife` counts 2 -> 3 -> 4 -> 5
+    unbroken. Counting in-laps reported THREE stops for the whole field from lap
+    5 to the flag, next to a `TYRE` cell reading `I 23`.
+
+    `Stint` is not the answer either: FastF1 opens a new one on each of those
+    passes, and at Miami 2025 the column is a 446-row NaN block.
+
+    So the evidence is the SET: the compound changed, or the published age
+    dropped. Both ride the bulk already, so this costs one pass and no new field.
+
+    Generated rows are dropped BEFORE pairing rather than skipped inside the
+    loop - a car that did not finish a lap has no compound and no age, and
+    leaving it between two real rows would hide a change that spans it.
+
+    --- WHAT THIS DELIBERATELY DOES NOT CATCH ---
+    * A set refitted with the SAME compound whose published age is HIGHER than
+      the outgoing set's. `tyre_stint_repair` measures used sets starting
+      anywhere from 2 to 16, so a short first stint replaced by a used set is
+      invisible here. It errs toward missing a stop, never toward inventing one.
+    * A feed that republishes `TyreLife` as 1 on a transit, which is #988.
+      Measured over the whole of Melbourne 2025: **five cars** carry that
+      artefact - ALB and STR on lap 3, LAW on lap 4, BEA and OCO on lap 5, all
+      with the compound unchanged - so each reads one stop high. The field's
+      total goes from **82 in-laps to 36 against a true 31**; the residual 5 is
+      that artefact and belongs where it can be repaired, not here.
+
+      (An earlier version of this comment said STR alone. That figure came from
+      comparing two candidate RULES and reporting where they differed, which is
+      not the same population as where the DATA is wrong: on the other four both
+      rules agreed, and agreed wrongly.)
+    """
+    rows = [row for row in revealed if not row["generated"]]
+    changed = 0
+    for previous, current in zip(rows, rows[1:]):
+        compounds = (previous["compound"], current["compound"])
+        both_named = all(is_real_compound(value) for value in compounds)
+        refitted = both_named and compounds[0] != compounds[1]
+        ages = (previous["tyre_life"], current["tyre_life"])
+        both_aged = all(value is not None for value in ages)
+        reset = both_aged and ages[1] < ages[0]
+        if refitted or reset:
+            changed += 1
+    return changed
 
 
 class SessionLaps:
@@ -417,11 +471,11 @@ class SessionLaps:
     ) -> dict[str, Any]:
         """One driver's revealed block: rows on the wire clock, stops, bests.
 
-        `stops` counts in-laps rather than `max(stint) - 1`. The two agree on
-        every driver of a healthy race, which is exactly how the wrong one
-        gets chosen: Miami 2025's raw frame carries a 446-row NaN `Stint`
-        block, and a stint-based count reads zero stops for most of the field
-        late in the race.
+        `stops` counts TYRE-SET TRANSITIONS; see `_tyre_stops`. It used to
+        count in-laps, and the docstring that chose that read *"the two agree
+        on every driver of a healthy race, which is exactly how the wrong one
+        gets chosen"* - a true clause under a false headline, because on the
+        one race a curated install carries NEITHER counts stops.
 
         `crossings` is the lap-quantised clock the gap column subtracts. It
         holds real rows only - a generated row's `Time` stamp sorts before
@@ -444,7 +498,7 @@ class SessionLaps:
         best = _best_of(revealed)
         view = {
             "laps_revealed": revealed_to,
-            "stops": sum(1 for row in revealed if row["pit_in"]),
+            "stops": _tyre_stops(revealed),
             "laps": laps,
             "crossings": crossings,
             "best": best,

--- a/tests/surfaces/test_pitwall_session_data.py
+++ b/tests/surfaces/test_pitwall_session_data.py
@@ -250,33 +250,170 @@ def test_lap_one_has_no_first_sector_and_that_is_not_a_zero():
 # --- Stops, and the race nobody has locally ---------------------------------
 
 
-def test_stops_are_counted_from_the_pit_lane_not_from_the_stint_column():
-    """Both derivations agree on a healthy race, which is how the wrong one gets
-    chosen. Miami 2025's raw frame carries a 446-row NaN `Stint` block, and a
-    stint-based count reads zero stops for most of the field late in the race.
+def _stint_frame(
+    compounds: list[str],
+    tyre_life: list[float | None],
+    pit_in: list[float | None],
+    pit_out: list[float | None],
+    stint: list[float] | None = None,
+) -> dict[str, list[dict]]:
+    """One driver's rows with the tyre columns a stop count reads.
 
-    The frame below is that shape: stint metadata absent, pit stops real.
+    Separate from `_frame` because that one hardcodes a single compound and no
+    age at all, which is precisely why the fixture it feeds could not tell a
+    stop from a pit-lane transit.
     """
+    count = len(compounds)
     laps = pd.DataFrame(
         {
-            "Driver": ["NOR"] * 6,
-            "DriverNumber": ["4"] * 6,
-            "LapNumber": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
-            "Time": pd.to_timedelta([90, 180, 270, 365, 455, 545], unit="s"),
-            "LapTime": pd.to_timedelta([90, 90, 90, 95, 90, 90], unit="s"),
-            "Stint": [float("nan")] * 6,
-            "PitInTime": pd.to_timedelta([None, None, 270, None, None, None], unit="s"),
-            "PitOutTime": pd.to_timedelta([None, None, None, 300, None, None], unit="s"),
-            "Compound": ["MEDIUM"] * 6,
-            "Position": [1.0] * 6,
+            "Driver": ["NOR"] * count,
+            "DriverNumber": ["4"] * count,
+            "LapNumber": [float(index + 1) for index in range(count)],
+            "Time": pd.to_timedelta([90 * (index + 1) for index in range(count)], unit="s"),
+            "LapTime": pd.to_timedelta([90.0] * count, unit="s"),
+            "Stint": stint if stint is not None else [float("nan")] * count,
+            "TyreLife": tyre_life,
+            "PitInTime": pd.to_timedelta(pit_in, unit="s"),
+            "PitOutTime": pd.to_timedelta(pit_out, unit="s"),
+            "Compound": compounds,
+            "Position": [1.0] * count,
         }
     )
-    session = SessionLaps(2025, "Nowhere", {"NOR": [_row(laps, i) for i in range(6)]}, {"NOR": "4"})
+    return {"NOR": [_row(laps, index) for index in range(count)]}
+
+
+def test_a_stop_is_a_tyre_change_and_the_stint_column_is_not_asked():
+    """Miami 2025's shape: the `Stint` metadata is a NaN block, the stop is real.
+
+    **The fixture now carries the EVIDENCE a stop leaves**, which the version
+    before this one did not: it held one compound for all six laps and no
+    `TyreLife` column at all, so it could not distinguish a tyre change from a
+    car driving down the pit lane and out again. It passed only because the
+    count it pinned looked at `PitInTime` alone - the defect. The stop is on lap
+    3 and the out-lap is 4, so the set that appears on lap 4 is a new one.
+    """
+    session = SessionLaps(
+        2025,
+        "Nowhere",
+        _stint_frame(
+            compounds=["MEDIUM"] * 3 + ["HARD"] * 3,
+            tyre_life=[1.0, 2.0, 3.0, 1.0, 2.0, 3.0],
+            pit_in=[None, None, 270, None, None, None],
+            pit_out=[None, None, None, 300, None, None],
+        ),
+        {"NOR": "4"},
+    )
 
     view = session.masked_view({"NOR": 6}, 0.0)
 
     assert view["drivers"]["NOR"]["stops"] == 1
     assert all(row["stint"] is None for row in view["drivers"]["NOR"]["laps"])
+
+
+def test_a_pit_lane_transit_that_changed_nothing_is_not_a_stop():
+    """The safety-car parade, and the drive-through penalty `tyre_stint_repair`
+    names: the car goes down the pit lane, no work is done, the set carries on.
+
+    Three consecutive in-laps, compound unchanged, age counting up through all
+    of them - the exact shape all seventeen Melbourne runners have on laps 2-4.
+    Counting in-laps answers 3 here, which is what shipped.
+    """
+    session = SessionLaps(
+        2025,
+        "Nowhere",
+        _stint_frame(
+            compounds=["INTERMEDIATE"] * 6,
+            tyre_life=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            pit_in=[None, 180, 270, 360, None, None],
+            pit_out=[None, None, 300, 390, 480, None],
+            # FastF1 opens a new stint on each pass even though nothing changed,
+            # which is the other derivation this must not be talked into.
+            stint=[1.0, 1.0, 2.0, 3.0, 4.0, 4.0],
+        ),
+        {"NOR": "4"},
+    )
+
+    view = session.masked_view({"NOR": 6}, 0.0)
+
+    assert view["drivers"]["NOR"]["stops"] == 0
+
+
+def test_the_same_compound_refitted_is_still_a_stop():
+    """A stop is not always a compound change: the age reset carries this one.
+
+    Without the age half of the rule this would read zero, and 743 of the 2594
+    stint transitions across the shipped races fit the same compound again
+    (`tyre_stint_repair`'s own census).
+    """
+    session = SessionLaps(
+        2025,
+        "Nowhere",
+        _stint_frame(
+            compounds=["HARD"] * 6,
+            tyre_life=[18.0, 19.0, 20.0, 1.0, 2.0, 3.0],
+            pit_in=[None, None, 270, None, None, None],
+            pit_out=[None, None, None, 300, None, None],
+        ),
+        {"NOR": "4"},
+    )
+
+    assert session.masked_view({"NOR": 6}, 0.0)["drivers"]["NOR"]["stops"] == 1
+
+
+def test_a_stringified_missing_compound_is_not_evidence_of_a_tyre_change():
+    """`tyre_stint_repair`'s sentinel rule, imported rather than copied.
+
+    The extractor stringifies an absent compound, so "MEDIUM" -> "nan" -> "MEDIUM"
+    is data loss and must not read as two stops.
+    """
+    session = SessionLaps(
+        2025,
+        "Nowhere",
+        _stint_frame(
+            compounds=["MEDIUM", "MEDIUM", "nan", "unknown", "MEDIUM", "MEDIUM"],
+            tyre_life=[1.0, 2.0, None, None, 5.0, 6.0],
+            pit_in=[None] * 6,
+            pit_out=[None] * 6,
+        ),
+        {"NOR": "4"},
+    )
+
+    assert session.masked_view({"NOR": 6}, 0.0)["drivers"]["NOR"]["stops"] == 0
+
+
+def test_the_real_race_never_reports_a_stop_nobody_made():
+    """The effect on the race that ships, not the mechanism.
+
+    Melbourne 2025: the safety car led the field through the pit lane on laps 2,
+    3 and 4, so `PitInTime` is set for all seventeen runners on each. At lap 24
+    not one car has changed tyres; NOR's real stops are laps 35 and 45.
+
+    Five cars read one stop high and it is #988's artefact, not this rule's: the
+    feed republishes their `TyreLife` as 1 on one of the transits. They are named
+    below rather than absorbed into a tolerance, so the day #988 lands this test
+    fails and says which line to change. Everyone else is exact.
+    """
+    session = _session_or_skip()
+    reveal = _all_revealed(session)
+    # The exact five, with the transit that corrupts each: ALB and STR on lap 3,
+    # LAW on lap 4, BEA and OCO on lap 5. See #988.
+    republished = {"ALB", "BEA", "LAW", "OCO", "STR"}
+
+    early = session.masked_view({code: 24 for code in reveal}, 0.0)["drivers"]
+    for code, driver in early.items():
+        expected = 1 if code in republished else 0
+        assert driver["stops"] == expected, f"{code} at lap 24"
+    # Counting in-laps gave the field 51 here, on a lap where nobody has stopped.
+    assert sum(driver["stops"] for driver in early.values()) == len(republished)
+
+    final = session.masked_view(reveal, 0.0)["drivers"]
+    # Melbourne 2025 was wet-dry-wet, so every real stop is a compound change.
+    assert final["NOR"]["stops"] == 2
+    # ALO retired on lap 32, before his first real stop, having transited three times.
+    assert final["ALO"]["stops"] == 0
+    # SAI, DOO and HAD have only generated rows: no laps, no transits, no stops.
+    assert [final[code]["stops"] for code in ("SAI", "DOO", "HAD")] == [0, 0, 0]
+    assert sum(driver["stops"] for driver in final.values()) == 36, "31 real + #988's five"
 
 
 def _row(frame: pd.DataFrame, index: int) -> dict:


### PR DESCRIPTION
## What

The timing tower's `STOPS` column counted pit-lane entries. It now counts tyre-set transitions.

## Why

Melbourne 2025 is the race that breaks the old count. The safety car led the field through the pit
lane on laps 2, 3 **and** 4, so `PitInTime` is set for all seventeen runners on each of them while
`Compound` stays INTERMEDIATE and `TyreLife` counts 2 → 3 → 4 → 5 unbroken. The column reported
**three stops for the whole field from lap 5 to the flag** and printed the contradiction in the
neighbouring cell: `STOPS 3` beside `TYRE I 23`. ALO, who retired on the set he started on, read
three stops on a 32-lap-old tyre.

**The rule was already written in this repo.** `tyre_stint_repair`'s docstring states it under *"Why
a pit entry alone does not mean a new set"*, with a served drive-through penalty as the worked case.
This consumer contradicted a rule its own dependency documents. Its enabling docstring was the
shape this repo keeps paying for: *"the two agree on every driver of a healthy race"* is TRUE here —
and on this race neither of the two counts stops.

`Stint` is no answer either: FastF1 opens a new one on each of those passes, and at Miami 2025 the
column is a 446-row NaN block.

## How

- A stop is evidenced by the SET: a real compound change, or a published age that dropped. Both
  already ride the bulk, so this costs one pass over rows the reader already holds and no new field.
- Generated rows are dropped **before** pairing rather than skipped inside the loop, so a change that
  spans one is not hidden by it.
- The compound-sentinel rule is **imported** from `tyre_stint_repair` rather than copied, which is why
  `is_real_compound` stops being private. A stringified missing compound must never read as evidence
  of a tyre change.

## Numbers

Across the field, whole race: **82 in-laps → 36, against a true 31.** Twelve cars are exact.

The residual five are one artefact, not this rule's error: the feed republishes `TyreLife` as 1 on one
of the transits for ALB, BEA, LAW, OCO and STR. Filed as #988 and pinned **by name** in the test, so
the day it is repaired this test fails and says which line to change.

## The test that pinned the old behaviour is replaced, not adjusted

`test_stops_are_counted_from_the_pit_lane_not_from_the_stint_column` held one compound for six laps
and no `TyreLife` column at all. It could not distinguish a tyre change from a car driving down the
pit lane and out again — it passed because the thing it pinned only looked at `PitInTime`. The new
fixture carries the evidence a stop leaves, and three more cases join it: the transit, the
same-compound refit, and the stringified-absent compound.

## Checks

- `tests/surfaces/` **225 passed**; the 18 `tyre_stint_repair` tests pass unchanged.
- `uvx ruff@0.15.22 check` + `format --check` clean on the three files.
- **Both new guards driven RED against the old count first** — `VER at lap 24: 3 == 0`.
- **Verified on the real window**, not on the suite: host restarted, live payload, lap 49 — the
  twelve clean cars read 2, ALO reads `0` beside `I 32`, and the five in #988 read one high.

## Out of scope

#988 itself, which is where the residual belongs.

Closes #981
