### PR TITLE
fix(pitwall): the pace grid fits the laptop, and its newest lap stops walking

### DIFF
--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -1541,6 +1541,72 @@ check(
   `under the safety car the grid still ranks the field instead of painting it one colour (${scSpread.join(" / ")})`,
 );
 
+// --- The WIDTH axis, which the check above cannot see ---------------------
+//
+// `paceCells.clipped === 0` is asserted at 1485 x 833, the largest client in the
+// fleet, where the columns are 38.75 px and nothing clips. It passed all the way
+// through the P0: on a 1080p laptop at 150 % scaling - Windows' own recommended
+// scaling for a 13-14" screen - the client is 1265 x 593, the columns fall to
+// 27.75 px, and 495 of 514 populated cells lost their last glyph in silence.
+//
+// A guard whose probe sits at the one size where the defect does not exist is
+// the shape this file's own header warns about, so this block PROVES the two
+// widths are distinguishable - the column really is narrower - before asserting
+// that nothing clips at either.
+{
+  const narrowCtx = await browser.newContext({ viewport: { width: 1265, height: 593 } });
+  const narrow = await narrowCtx.newPage();
+  narrow.on("pageerror", (error) => failures.push(`pageerror(pace-narrow): ${error.message}`));
+  await narrow.addInitScript(
+    ([payload, bulk, live]) => {
+      window.pywebview = { api: {
+        get_tick: async (s) => (s === payload.seq ? null : payload),
+        get_bulk: async (r) => (r === bulk.rev ? null : bulk),
+        get_live_lap: async (r) => (r === live.rev ? null : live),
+        get_connection: async () => "Connected",
+      } };
+    },
+    [tick(1, { drivers: paceField(), order: TOWER_ORDER }), paceBulk(), towerLive()],
+  );
+  await narrow.goto(`http://127.0.0.1:${server.address().port}/data.html`, {
+    waitUntil: "domcontentloaded",
+  });
+  await narrow.getByRole("tab", { name: "RACE PACE" }).click();
+  await narrow.waitForSelector(".pace-table", { timeout: 5000 });
+  await narrow.waitForTimeout(400);
+
+  const narrowCells = await narrow.evaluate(() => {
+    const cells = [...document.querySelectorAll(".pace-table td")];
+    const populated = cells.filter((c) => c.textContent.trim().length > 0);
+    return {
+      column: document.querySelector(".pace-table thead th + th")?.clientWidth ?? 0,
+      populated: populated.length,
+      clipped: populated.filter((c) => c.scrollWidth > c.clientWidth).length,
+      sample: populated.find((c) => c.className === "is-t1")?.textContent ?? "",
+      pit: cells.find((c) => c.className === "is-pit")?.textContent ?? "",
+      subtitle: document.querySelector(".pace-subtitle")?.textContent ?? "",
+    };
+  });
+
+  check(
+    narrowCells.column < 32 && narrowCells.populated > 400,
+    `the narrow client really is narrower than the one above (${narrowCells.column} px per column, ${narrowCells.populated} populated cells)`,
+  );
+  check(
+    narrowCells.clipped === 0,
+    `and nothing clips there either (${narrowCells.clipped}/${narrowCells.populated} clipped)`,
+  );
+  check(
+    /^\d:\d\d$/.test(narrowCells.sample) && narrowCells.pit === "PIT",
+    `the cell coarsens instead of truncating ("${narrowCells.sample}", "${narrowCells.pit}")`,
+  );
+  check(
+    narrowCells.subtitle.includes("to the second"),
+    `and the header says the resolution changed ("${narrowCells.subtitle}")`,
+  );
+  await narrowCtx.close();
+}
+
 // --- Band 3, second panel: the race trace ---------------------------------
 
 await pacePage.getByRole("tab", { name: "RACE TRACE" }).click();

--- a/src/pitwall/ui/src/features/data/RacePaceGrid.tsx
+++ b/src/pitwall/ui/src/features/data/RacePaceGrid.tsx
@@ -17,10 +17,16 @@
  * Both of those counts come from the PROTOTYPE that chose the orientation
  * (`b3_measure.mjs`), not from this component: they describe layouts the tree
  * deliberately no longer contains, so they cannot be re-measured here and are
- * named as prototype figures rather than as measurements of what ships. The
- * numbers that DO describe what ships were taken on the real payload in the
- * real bundle: 20 columns of 38.75 px, 0 of 1,140 cells clipped, at all three
- * client heights the fleet produces.
+ * named as prototype figures rather than as measurements of what ships.
+ *
+ * **The sentence that stood here claimed the shipped grid clips nothing, and it
+ * was measured at every client HEIGHT the fleet produces and at exactly one
+ * WIDTH.** True as stated - 20 columns of 38.75 px at the 1485 px client, 0 of
+ * 1,140 cells cut - and it read as a property of the panel. On a 1080p laptop at
+ * 150 % scaling the client is 1265 x 593, the columns are 27.75 px, and 495 of
+ * 514 populated cells lost their last glyph. The width axis had no floor and no
+ * fallback because nobody had measured it. `paceLabel`'s `coarse` form is that
+ * fallback, and `fineFormFits` below decides between them from a real cell.
  *
  * The lap axis scrolls, because it must: Monaco's 78 laps overflow the column
  * on every machine in the fleet at every legible font size. It is pinned to
@@ -34,10 +40,46 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { racePaceGrid } from "../../lib/racePace";
 import type { Bulk } from "../../lib/bridge";
 
+/**
+ * The widest numeric label the fine form can emit under ten minutes. The table
+ * is monospace, so any six glyphs measure the same and this stands in for all
+ * of them - including `IN PIT`.
+ */
+const WIDEST_FINE_LABEL = "0:00.0";
+
+/** One canvas for the page, made on first use. Null when there is no 2d context. */
+let ruler: CanvasRenderingContext2D | null | undefined;
+
+/**
+ * How wide `text` renders in a cell's OWN computed font.
+ *
+ * Measured rather than compared against a pixel constant, and the stylesheet's
+ * own comment says why: it counts on `1:29.4` measuring 33.2 px inside a
+ * 38.75 px column, which is true of JetBrains Mono at 9 px and not of whatever
+ * a machine without it falls back to. A constant tuned on one font is the
+ * threshold-tuned-on-one-race defect wearing a stylesheet.
+ *
+ * It measures the FINE form whatever the cell currently renders, which is what
+ * keeps this from oscillating: asking "does the text in the cell overflow"
+ * would answer no as soon as the coarse form landed, and flip back.
+ */
+function fineFormFits(cell: HTMLElement): boolean {
+  if (ruler === undefined) ruler = document.createElement("canvas").getContext("2d");
+  const style = window.getComputedStyle(cell);
+  const padding = parseFloat(style.paddingLeft) + parseFloat(style.paddingRight);
+  const room = cell.clientWidth - padding;
+  // No canvas: keep the tenths. Losing them is a real cost, so it is not the
+  // thing to do when the measurement is unavailable rather than negative.
+  if (ruler === null) return true;
+  ruler.font = `${style.fontWeight} ${style.fontSize} ${style.fontFamily}`;
+  return ruler.measureText(WIDEST_FINE_LABEL).width <= room;
+}
+
 export function RacePaceGrid({ bulk, order }: { bulk: Bulk | null; order: string[] }) {
-  const grid = racePaceGrid(bulk, order);
   const scroller = useRef<HTMLDivElement | null>(null);
   const [visible, setVisible] = useState<[number, number] | null>(null);
+  const [coarse, setCoarse] = useState(false);
+  const grid = racePaceGrid(bulk, order, coarse);
 
   /**
    * The laps ACTUALLY on screen, from the scroller's own geometry.
@@ -66,10 +108,39 @@ export function RacePaceGrid({ bulk, order }: { bulk: Bulk | null; order: string
     setVisible([lapOf(edges[0]), lapOf(edges[edges.length - 1])]);
   }, []);
 
+  /**
+   * Whether the tenths fit, from a real cell rather than from a breakpoint.
+   *
+   * The trigger is the COLUMN's width, which is the client width and the number
+   * of cars together - a media query would have to guess at one of them. The
+   * observer is on the scroller so a resized window re-answers it; nothing else
+   * changes width under this panel.
+   */
+  const fit = useCallback(() => {
+    const cell = scroller.current?.querySelector<HTMLElement>("thead th + th");
+    if (cell && cell.clientWidth > 0) setCoarse(!fineFormFits(cell));
+  }, []);
+
+  useEffect(() => {
+    const box = scroller.current;
+    if (!box) return;
+    fit();
+    const observer = new ResizeObserver(fit);
+    observer.observe(box);
+    return () => observer.disconnect();
+  }, [fit, grid.columns.length]);
+
   // Pinned to the newest lap. A race-pace grid that opens at lap 1 shows the
   // formation lap of a race that is on lap 40, and the laps a strategist is
   // deciding on are always the last few. Re-pinned on every reveal, which is
   // about once every four and a half seconds.
+  //
+  // The pin only has work to do once the table outgrows the scroller, which on a
+  // 57-lap race is around lap 55. What holds the newest lap still for the other
+  // 54 is the stylesheet: the table is bottom-anchored inside a scroller that
+  // fills the card, so the row a wall reads sits at a fixed height from lap 1
+  // and the empty space - honest, the race has not happened yet - grows above
+  // the history instead of pushing it down the screen.
   useEffect(() => {
     const box = scroller.current;
     if (box) box.scrollTop = box.scrollHeight;
@@ -83,7 +154,12 @@ export function RacePaceGrid({ bulk, order }: { bulk: Bulk | null; order: string
     <section className="card pace">
       <header className="pace-header">
         <span className="pace-title">RACE PACE</span>
-        <span className="pace-subtitle">colour ranks each lap against itself</span>
+        <span className="pace-subtitle">
+          colour ranks each lap against itself
+          {/* Said out loud, because a coarser number that nobody was told about
+              is the same silence the truncation was. */}
+          {coarse ? " · times to the second at this width" : ""}
+        </span>
         <span className="pace-range">
           {grid.laps.length ? `LAPS ${first}-${last} of ${total}` : "no laps revealed"}
         </span>

--- a/src/pitwall/ui/src/lib/racePace.ts
+++ b/src/pitwall/ui/src/lib/racePace.ts
@@ -135,8 +135,31 @@ export function stableColumns(bulk: Bulk, order: string[]): string[] {
  * No lap on disk approaches it - Melbourne's slowest is 149.413 s and nothing
  * reaches 300 - but a red-flagged race would, and no race with a red flag is
  * downloadable here to test it.
+ *
+ * **`coarse` drops the tenths, and it exists because the column does not always
+ * have room for them.** On a 1080p laptop at 150 % scaling - Windows' own
+ * recommended scaling for a 13-14" screen - this window's client area is
+ * 1265 x 593, the grid's twenty columns fall to 27.75 px, and the six-glyph form
+ * measures 35: `1:59.4` rendered `1:59.`, `IN PIT` rendered `IN PI`, on 495 of
+ * 514 populated cells, with `overflow: hidden` and globally hidden scrollbars so
+ * nothing said so. A trailing dot was the only tell.
+ *
+ * Four glyphs fit, so the choice was which four. `ss.d` keeps the tenths and
+ * drops the minute, which is more information for the panel's own question - the
+ * field is normally inside one minute of itself, so the tenths is the whole
+ * comparison. It is rejected anyway: on this race the safety-car laps run 2:19
+ * against a green 1:29, so `19.7` beside `59.4` reads as forty seconds apart
+ * when it is twenty, and a cell that can be MISREAD is worse than one that is
+ * openly coarser. `m:ss` loses precision the header states out loud; it never
+ * lies about magnitude. The tone still carries the ranking, which is where this
+ * panel puts the ordering anyway.
  */
-export function paceLabel(seconds: number): string {
+export function paceLabel(seconds: number, coarse = false): string {
+  if (coarse) {
+    const whole = Math.round(seconds);
+    const minutes = Math.floor(whole / 60);
+    return `${minutes}:${String(whole - minutes * 60).padStart(2, "0")}`;
+  }
   const tenths = Math.round(seconds * 10);
   const minutes = Math.floor(tenths / 600);
   const rest = (tenths - minutes * 600) / 10;
@@ -219,7 +242,7 @@ function tone(times: number[], value: number): PaceTone {
  * The bottom edge is RAGGED on purpose: the reveal is per driver and strict,
  * and at most instants the field spans two or three different laps.
  */
-export function racePaceGrid(bulk: Bulk | null, order: string[]): PaceGrid {
+export function racePaceGrid(bulk: Bulk | null, order: string[], coarse = false): PaceGrid {
   if (!bulk?.available) return { laps: [], columns: [...order], rows: [] };
   const columns = stableColumns(bulk, order);
 
@@ -242,10 +265,14 @@ export function racePaceGrid(bulk: Bulk | null, order: string[]): PaceGrid {
     columns.map((code) => {
       const row = timedRow(byDriver.get(code)?.get(lap));
       if (row === null) return EMPTY;
-      if (row.pit_in) return { text: "IN PIT", tone: "pit" as PaceTone };
+      // The two word cells shorten with the numbers. `IN PIT` is six glyphs, the
+      // same six the times could not fit, so leaving it alone would have kept
+      // the P0 alive in the one place the reader most needs the whole word -
+      // `IN PI` ran straight into its neighbour as `IN PIIN PI`.
+      if (row.pit_in) return { text: coarse ? "PIT" : "IN PIT", tone: "pit" as PaceTone };
       if (row.pit_out) return { text: "OUT", tone: "out" as PaceTone };
       if (row.lap_time === null) return EMPTY;
-      const text = paceLabel(row.lap_time);
+      const text = paceLabel(row.lap_time, coarse);
       // A deleted time is shown and struck through, as the tower already shows
       // it, and it is excluded from the ranking - which is why it cannot be
       // given a rank here. Before this branch existed it fell through to

--- a/src/pitwall/ui/src/styles/data.css
+++ b/src/pitwall/ui/src/styles/data.css
@@ -842,10 +842,29 @@
   color: var(--qt-fg-1);
 }
 
+/* **The card grows UPWARD from the bottom of the column, and that is about where
+ * the reader's eye can rest.** It used to be top-aligned and content-sized, so at
+ * lap 24 of 57 it filled 288 px of a 722 px column and the newest row - the only
+ * one a live wall reads - migrated ~12 px per lap for the whole race, 434 px in
+ * total. The pin in `RacePaceGrid` cannot help: there is nothing to scroll until
+ * the table outgrows the column, which on a 57-lap race is around lap 55.
+ *
+ * Anchoring the TABLE to the bottom of a full-height card was the first attempt
+ * and it is worse: it leaves the 426 px of empty space INSIDE the card, between
+ * the header line and the column codes, which reads as a broken panel rather
+ * than as a race that has not happened yet. Measured on the live page at a
+ * 20-lap reveal before it was reverted. Anchoring the CARD instead puts the same
+ * empty space outside it, where it is ordinary layout air.
+ *
+ * `max-height: 100%` is what keeps this honest once the table is long: without
+ * it the content-sized card would grow past the grid row and spill, and the
+ * scroller - which needs a bounded height to scroll at all - would never bound. */
 .pace {
+  align-self: end;
   display: flex;
   flex-direction: column;
   gap: 6px;
+  max-height: 100%;
   padding: 10px;
   min-height: 0;
 }
@@ -883,6 +902,13 @@
 .pace-scroll {
   min-height: 0;
   overflow-y: auto;
+}
+
+/* "Now", findable in one saccade. Every other lap number is `--qt-fg-3`; the
+ * newest one is the row every decision is about. */
+.pace-table tbody tr:last-child th.pace-lapcol {
+  color: var(--qt-fg-1);
+  font-weight: 700;
 }
 
 .pace-table {


### PR DESCRIPTION
The sprint's P0, and the panel-ergonomics finding that lives in the same component.

## 1 · The width axis nobody had modelled

On a 1080p screen at 150 % scaling — Windows' own recommended scaling for a 13-14" laptop — this
window's client area is 1265 x 593, the grid's twenty columns fall to **27.75 px**, and the
six-glyph form measures 35. **495 of 514 populated cells lost their last glyph**: `1:59.4` rendered
`1:59.`, `IN PIT` rendered `IN PI` and ran into its neighbour as `IN PIIN PI`. The tenths is the
digit the panel's own docstring says it exists to carry; `overflow` is hidden and this window hides
scrollbars globally, so a trailing dot was the only tell.

**The cell now coarsens instead of truncating.** Four glyphs fit, so the choice was which four:

- `ss.d` keeps the tenths and drops the minute, and is more information for this panel's question —
  the field is normally inside one minute of itself, so the tenths is the whole comparison.
- It is **rejected anyway**: on this race the safety-car laps run 2:19 against a green 1:29, so
  `19.7` beside `59.4` reads as forty seconds apart when it is twenty. A cell that can be MISREAD is
  worse than one that is openly coarser.
- `m:ss` loses precision the header states out loud (`· times to the second at this width`) and never
  lies about magnitude. The tone still carries the ranking, which is where this panel puts the
  ordering anyway. `IN PIT` shortens to `PIT` with the numbers — it was the same six glyphs.

Which form applies is **measured from a real cell's own computed font**, not chosen by a breakpoint:
the trigger is the column width, which is the client width and the car count together, and a pixel
constant would be the threshold-tuned-on-one-font version of a defect this repo has paid for. The
measurement is of the FINE form whatever the cell currently renders, which is what stops it
oscillating.

## 2 · The newest lap stops walking down the screen

`.pace-scroll` was content-sized and the card was top-aligned, so at lap 24 of 57 the panel filled
288 px of a 722 px column and **the newest row — the only one a live wall reads — migrated ~12 px per
lap, 434 px over a race.** The scroll pin the component carries had nothing to pin until the table
outgrew the column, which on a 57-lap race is around lap 55: it activated for the last three laps.

The card now grows **upward from the bottom of the column**.

**Anchoring the TABLE inside a full-height card was tried first and reverted.** It moves the same
426 px of empty space *inside* the card, between the header line and the column codes, which reads as
a broken panel rather than as a race that has not happened yet — measured on the live page at a
20-lap reveal before it was replaced. Anchoring the CARD puts that space outside it, where it is
ordinary layout air, and it lands the panel level with BESTS across the window.

`max-height: 100%` is what keeps it honest once the table is long: without it a content-sized card
would grow past its grid row and the scroller, which needs a bounded height to scroll at all, would
never bound.

## 3 · A docstring that was true and read as a property

The sentence claiming this grid clips nothing was measured at **every client HEIGHT the fleet
produces and at exactly one WIDTH**. Corrected in place, with the width figures beside it.

## The guard that was missing

The smoke already asserted `clipped === 0` — at 1485 x 833, the one size where there is none. It
passed all the way through the P0. A second context at 1265 x 593 now first **proves the column is
narrower there** (so the probe cannot pass for the wrong reason), then asserts nothing clips, that
the cell coarsened rather than truncated, and that the header says so.

**Driven RED against the unfixed bundle: `879/883 clipped`,** plus both other assertions.

## Checks

- `npm run typecheck` clean · `smoke-data` **151 checks** (was 147) · `smoke-agents` 19 ·
  `tests/surfaces/` 221.
- **Verified by opening the real window**, host restarted after each build so the loopback server's
  `dist/` snapshot is the measured one:
  - 1265 x 593, lap 56: **0 of 885 cells cut**, cells read `1:31` / `PIT` / `OUT`, header carries the
    note.
  - 1485 x 833: tenths intact (`1:59.4`), 0 of 885 cut, no note.
  - the newest row's bottom edge is at **y 789 with a 20-lap reveal and at y 789 with a 24-lap one**;
    at a 420 px client the card clamps, `scrollable: true`, and the pin holds the bottom.

Closes #978
