### PR TITLE
fix(pitwall): BESTS degrades to its leaders instead of falling off the column

### DIFF
--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -1604,6 +1604,56 @@ check(
     narrowCells.subtitle.includes("to the second"),
     `and the header says the resolution changed ("${narrowCells.subtitle}")`,
   );
+
+  // The same client's OTHER silent clip: the tower's twenty rows are fixed at
+  // 437 px, so at a 510 px column the bests card's slot is 63 - and its chrome
+  // alone is 79 before a single ranked row exists. It used to render the full
+  // 153 px panel and lose 90 of them past the column's edge, THEORETICAL
+  // included, with scrollbars hidden globally so nothing said so.
+  //
+  // Asserted as an EFFECT over the whole enumeration - every element of the card
+  // is inside the column - rather than by checking a row count, which would pass
+  // on a panel whose one remaining row still hung over the edge.
+  const bests = await narrow.evaluate(() => {
+    const column = document.querySelector(".left-column").getBoundingClientRect();
+    const card = document.querySelector(".bests");
+    const parts = [card, ...card.querySelectorAll("*")];
+    const outside = parts.filter((el) => {
+      const r = el.getBoundingClientRect();
+      return r.height > 0 && r.bottom > column.bottom + 0.5;
+    });
+    return {
+      outside: outside.length,
+      parts: parts.length,
+      worst: outside.length
+        ? +(Math.max(...outside.map((el) => el.getBoundingClientRect().bottom)) - column.bottom).toFixed(1)
+        : 0,
+      // The card is clamped to its slot, so an overflow no longer leaves the
+      // column - it becomes a scroll inside the card. Asserting BOTH is what
+      // keeps "nothing outside the column" from passing on a panel that simply
+      // moved the hiding one level in.
+      hidden: card.scrollHeight - card.clientHeight,
+      subtitle: document.querySelector(".bests-subtitle")?.textContent ?? "",
+      // The theoretical lap is the one value a wall reads off this panel that no
+      // other panel carries, so it is the one that must survive the degradation.
+      theoretical: document.querySelector(".bests-theoretical-value")?.textContent ?? "",
+      ranked: document.querySelectorAll(".bests-row").length,
+      leaders: document.querySelectorAll(".bests-leader").length,
+    };
+  });
+
+  check(
+    bests.outside === 0 && bests.hidden === 0,
+    `the bests card fits its column at the narrow client with nothing scrolled away (${bests.outside}/${bests.parts} elements over by up to ${bests.worst} px, ${bests.hidden} px hidden)`,
+  );
+  check(
+    /^\d:\d\d\.\d\d\d$/.test(bests.theoretical),
+    `and the theoretical lap survives the degradation ("${bests.theoretical}")`,
+  );
+  check(
+    bests.ranked === 0 && bests.leaders === 6 && bests.subtitle === "leaders",
+    `it degrades to the four purple holders plus THEO on one titled line, and says so (${bests.leaders} leaders, ${bests.ranked} ranked rows, "${bests.subtitle}")`,
+  );
   await narrowCtx.close();
 }
 

--- a/src/pitwall/ui/src/features/data/BestsPanel.tsx
+++ b/src/pitwall/ui/src/features/data/BestsPanel.tsx
@@ -17,6 +17,8 @@
  * in all four.
  */
 
+import { useCallback, useEffect, useRef, useState } from "react";
+
 import type { Bulk } from "../../lib/bridge";
 import {
   sessionBests,
@@ -35,35 +37,145 @@ const SECTIONS: { field: BestField; label: string }[] = [
   { field: "lap_time", label: "LAP" },
 ];
 
+/**
+ * Whether the ranked panel fits the room the left column actually leaves it.
+ *
+ * **The room is a property of the TOWER, not of this panel, which is what makes
+ * this measurable without oscillating.** The tower's grid row is `auto` and its
+ * twenty rows are fixed at 437 px, so this card's slot is whatever the column
+ * has left - 303 px at the 1485 x 833 client and **63 px** at the 1265 x 593 one
+ * a 1080p laptop at 150 % scaling produces. It does not move when this panel
+ * renders less.
+ *
+ * The full panel's own natural height is latched the one time it renders, and
+ * never re-read in the compact form. Comparing the room against `scrollHeight`
+ * of whatever is currently rendered is the version that flips forever: 63 < 153
+ * chooses compact, compact measures 54, 63 >= 54 chooses full again.
+ */
+function useFitsRanked(card: HTMLElement | null): boolean {
+  const [compact, setCompact] = useState(false);
+  const rankedHeight = useRef<number | null>(null);
+
+  const fit = useCallback(() => {
+    const column = card?.parentElement;
+    if (!card || !column) return;
+    if (!compact) rankedHeight.current = card.scrollHeight;
+    const needed = rankedHeight.current;
+    if (needed === null) return;
+    const room = column.getBoundingClientRect().bottom - card.getBoundingClientRect().top;
+    setCompact(room < needed);
+  }, [card, compact]);
+
+  useEffect(() => {
+    const column = card?.parentElement;
+    if (!column) return;
+    fit();
+    const observer = new ResizeObserver(fit);
+    observer.observe(column);
+    return () => observer.disconnect();
+  }, [card, fit]);
+
+  return !compact;
+}
+
 export function BestsPanel({ bulk }: { bulk: Bulk | null }) {
   const bests = sessionBests(bulk);
   const theoretical = theoreticalLap(bests);
+  // State rather than a plain ref: the observer has to be attached to the node
+  // the FIRST time it exists, and a ref's assignment does not re-run an effect.
+  // The same lesson `useEChart` learned when a remounted panel left a dead chart.
+  const [card, setCard] = useState<HTMLElement | null>(null);
+  const ranked = useFitsRanked(card);
 
   return (
-    <section className="bests card">
-      <header className="bests-header">
+    <section className="bests card" ref={setCard}>
+      {/* The compact form drops the header ROW too, not just the ranks: it puts
+       * the title on the same line as the values. Keeping a separate 16 px header
+       * plus its 8 px gap left the card 65 px tall in a 63 px slot - fighting for
+       * two pixels, which a font fallback would take straight back. One line has
+       * 24 px of air. */}
+      {ranked ? (
+        <>
+          <header className="bests-header">
+            <span className="bests-title">BESTS</span>
+            <span className="bests-subtitle">session, revealed laps only</span>
+          </header>
+
+          <div className="bests-sections">
+            {SECTIONS.map(({ field, label }) => (
+              <BestsSection key={field} label={label} entries={bests[field].slice(0, RANKED)} />
+            ))}
+          </div>
+
+          <footer className="bests-theoretical">
+            <span className="bests-field-label">THEORETICAL</span>
+            <span className="bests-theoretical-value">
+              {theoretical === null ? "—" : formatTime(theoretical)}
+            </span>
+            <span className="bests-theoretical-note">
+              {theoretical === null
+                ? "waiting for a sector nobody has set yet"
+                : `${bests.s1[0].code} · ${bests.s2[0].code} · ${bests.s3[0].code}`}
+            </span>
+          </footer>
+        </>
+      ) : (
+        <BestsLeaders bests={bests} theoretical={theoretical} />
+      )}
+    </section>
+  );
+}
+
+/**
+ * One line: who holds each purple, and the theoretical.
+ *
+ * **Not "one ranked row per section", which is what the design gate prescribed
+ * and what does not fit.** Measured at the 1265 x 593 client: the card's slot is
+ * 63 px and its chrome alone - 20 px of padding, a 16 px header, two 8 px gaps
+ * and the 27 px theoretical footer - is 79 before a single row exists. One row
+ * per section needs 112. The ranks are not shrinkable here; they are droppable.
+ *
+ * What survives is what a wall reads off this panel at a glance: the four purple
+ * holders and the theoretical lap. Ranks 2 and 3 go, and the header says so
+ * rather than leaving the reader to think the panel is one row tall - which is
+ * exactly what the silent clip did.
+ */
+function BestsLeaders({
+  bests,
+  theoretical,
+}: {
+  bests: ReturnType<typeof sessionBests>;
+  theoretical: number | null;
+}) {
+  return (
+    <div className="bests-leaders">
+      <span className="bests-leader">
         <span className="bests-title">BESTS</span>
-        <span className="bests-subtitle">session, revealed laps only</span>
-      </header>
-
-      <div className="bests-sections">
-        {SECTIONS.map(({ field, label }) => (
-          <BestsSection key={field} label={label} entries={bests[field].slice(0, RANKED)} />
-        ))}
-      </div>
-
-      <footer className="bests-theoretical">
-        <span className="bests-field-label">THEORETICAL</span>
+        <span className="bests-subtitle">leaders</span>
+      </span>
+      {SECTIONS.map(({ field, label }) => {
+        const leader = bests[field][0];
+        return (
+          <span className="bests-leader" key={field}>
+            <span className="bests-field-label">{label}</span>
+            {leader === undefined ? (
+              <span className="bests-empty">—</span>
+            ) : (
+              <>
+                <span className="bests-code">{leader.code}</span>
+                <span className="bests-value">{formatTime(leader.value)}</span>
+              </>
+            )}
+          </span>
+        );
+      })}
+      <span className="bests-leader is-theoretical">
+        <span className="bests-field-label">THEO</span>
         <span className="bests-theoretical-value">
           {theoretical === null ? "—" : formatTime(theoretical)}
         </span>
-        <span className="bests-theoretical-note">
-          {theoretical === null
-            ? "waiting for a sector nobody has set yet"
-            : `${bests.s1[0].code} · ${bests.s2[0].code} · ${bests.s3[0].code}`}
-        </span>
-      </footer>
-    </section>
+      </span>
+    </div>
   );
 }
 

--- a/src/pitwall/ui/src/features/data/RacePaceGrid.tsx
+++ b/src/pitwall/ui/src/features/data/RacePaceGrid.tsx
@@ -137,10 +137,11 @@ export function RacePaceGrid({ bulk, order }: { bulk: Bulk | null; order: string
   //
   // The pin only has work to do once the table outgrows the scroller, which on a
   // 57-lap race is around lap 55. What holds the newest lap still for the other
-  // 54 is the stylesheet: the table is bottom-anchored inside a scroller that
-  // fills the card, so the row a wall reads sits at a fixed height from lap 1
-  // and the empty space - honest, the race has not happened yet - grows above
-  // the history instead of pushing it down the screen.
+  // 54 is the stylesheet: `.pace` is `align-self: end`, so the CARD grows upward
+  // from the bottom of its column and the newest row sits at a fixed height from
+  // lap 1. (Anchoring the TABLE inside a full-height card does the same thing and
+  // leaves the empty space INSIDE the card; that is what this comment described
+  // for one commit, and it is not what ships. See the `.pace` rule.)
   useEffect(() => {
     const box = scroller.current;
     if (box) box.scrollTop = box.scrollHeight;

--- a/src/pitwall/ui/src/styles/data.css
+++ b/src/pitwall/ui/src/styles/data.css
@@ -272,10 +272,23 @@
 
 /* --- Band 2 right: the bests panel ---------------------------------------- */
 
+/* `max-height: 100%` is the structural half of #979 and `BestsPanel`'s measured
+ * degradation is the other. Without it the card takes its content height and
+ * hangs over the column, where the overflow is clipped by an ancestor with
+ * nothing to reach it by - 90 px of it at the 1265 x 593 client, THEORETICAL
+ * included. Clamped, an overflow that survives the degradation is at least
+ * reachable by the wheel, which is what every other panel in this window does
+ * (`qt-base.css` hides the scrollbar, not the scrolling). */
 .bests {
+  /* Explicit, because `.card`'s padding and border are otherwise ADDED to the
+   * percentage cap and it stops binding: measured, a 63 px slot allowed an 85 px
+   * border box and the card sat 2 px over the column. */
+  box-sizing: border-box;
   padding: 10px;
   min-width: 0;
   min-height: 0;
+  max-height: 100%;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -303,15 +316,60 @@
 
 /* Four sections side by side. They spend WIDTH, which the left column has,
  * rather than height, which it does not: stacked they would be four times as
- * tall for the same twelve rows. */
+ * tall for the same twelve rows.
+ *
+ * **The LAP column is sized to its content and the three sectors share the
+ * rest**, because four equal columns are 146 px each and the LAP section's
+ * ranked rows need 153: a lap time is `1:29.601` where a sector is `31.717`, two
+ * glyphs wider, and the row also carries a delta and a compound letter. Measured
+ * on the live page, exactly two of the twelve rows overflowed - ranks 2 and 3 of
+ * LAP, the only ones carrying both. (Reported once as a property of
+ * `.bests-row`, which would have sent a fix at all twelve.) */
 .bests-sections {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(3, minmax(0, 1fr)) max-content;
   gap: 8px;
 }
 
 .bests-section {
   min-width: 0;
+}
+
+/* The compact form: one line of purple holders plus the theoretical, for the
+ * client where the ranked panel does not fit at all. Spends width, which this
+ * column has 630 px of, instead of the height it has 63 of. */
+.bests-leaders {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 4px 14px;
+  padding: 0 2px;
+  /* The same 17 px a ranked row uses, stated rather than inherited from the
+   * font: at the default line-height this line came to 20 px and the whole card
+   * to 64 in a 63 px slot - a one-pixel overhang, which `max-height` would then
+   * have turned into a one-pixel scroll instead of a fit. */
+  line-height: 17px;
+}
+
+.bests-leader {
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
+  white-space: nowrap;
+}
+
+/* The section label is a column heading in the ranked form and an inline tag
+ * here, so the rule that underlines it has to stop applying. */
+.bests-leaders .bests-field-label {
+  border-bottom: none;
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+/* The theoretical is not a purple anybody set, so it sits apart from the four
+ * that were. */
+.bests-leader.is-theoretical {
+  margin-left: auto;
 }
 
 .bests-field-label {


### PR DESCRIPTION
## What

At the 1265 x 593 client a 1080p laptop at 150 % scaling produces, the left column's content was
600 px in a 510 px row and **90 px of the BESTS card rendered past the column's edge** — ranks 2 and
3 of all four sections plus the THEORETICAL footer, clipped by an ancestor, with scrollbars hidden
globally so nothing said so. Measured: 69 of the card's 89 elements over.

## The gate's prescription does not fit, and the arithmetic says so

It asked for one ranked row per section. The card's chrome alone — 20 px padding, a 16 px header, two
8 px gaps, the 27 px footer — is **79 px before a single row exists**, against a 63 px slot. One row
per section needs 112. At this height the ranks are not shrinkable, they are droppable.

So the panel degrades to **one line**: the four purple holders and the theoretical lap, title on that
same line, `leaders` where the subtitle was. Keeping a separate header row left the card 65 px in a
63 px slot — fighting for two pixels a font fallback would take back. One line has 24 px of air.

## Measured, not guessed

The room is a property of the **tower** (its row is `auto`, its twenty rows fixed at 437 px), so it
does not move when this panel renders less — and the ranked form's own natural height is latched the
one time it renders. Comparing the room against the `scrollHeight` of whatever is currently rendered
is the version that flips forever: 63 < 153 picks compact, compact measures 54, 63 >= 54 picks ranked
again.

## Two more in the same panel

- The card is `box-sizing: border-box` with `max-height: 100%`, so it **cannot** hang over its column
  again. `.card`'s padding and border were otherwise added to the percentage and the cap stopped
  binding — measured, an 85 px border box allowed in a 63 px slot.
- The LAP section's column is sized to its content while the three sectors share the rest. Four equal
  columns are 146 px and a LAP ranked row needs 153: that is the **two of twelve** overflow the gate
  corrected me on after I reported it as a property of `.bests-row`.

## Guard

Asserts the effect over the whole enumeration: every element of the card is inside the column **and**
nothing is scrolled away inside it, so a panel that merely moved the hiding one level in still fails.
**Driven RED against the unfixed panel: 69 of 89 elements over, worst by 90 px.**

Also in this branch: a comment in `RacePaceGrid` that described the bottom-anchoring approach #990
tried and reverted. It named the wrong mechanism for one commit.

## Checks

`typecheck` clean · `smoke-data` **154 checks** · `smoke-agents` 19 · `tests/surfaces/` 225.

**Verified on the real window**, host restarted after each build: 0 elements outside the column at
1265 x 593 with the card 62 px in its 63 px slot; the ranked form untouched at 1485 x 833.

Closes #979
