### PR TITLE
fix(pitwall): the window says which state it is in

### DIFF
--- a/documents/audits/GATE_PITWALL_DATA_ITERATION_1.md
+++ b/documents/audits/GATE_PITWALL_DATA_ITERATION_1.md
@@ -1,0 +1,405 @@
+# DESIGN ITERATION GATE 1 — PITWALL DATA (telemetry) window
+
+**Date:** 2026-08-18 · **Auditor:** design-iteration gate (second pass; first pass = `GATE_PITWALL_DATA_DESIGN.md`, findings D1-D17, all reported FIXED on this branch)
+**Branch:** `fix/pitwall-bests-degrade-honestly`
+**Bundle measured:** the one the live loopback server snapshotted at startup —
+`dist/assets/data-p-ZIuEWG.js` + `data-jT2Ts2gb.css` + `qt-base-86dNR9Zk.css` + `qt-base-DsVXPXSy.js`.
+No rebuild performed; the served bundle is the measured bundle.
+**Session measured:** real Melbourne 2025, real producer (`scripts/dev_pitwall_producer.py`),
+mid-race (lap 27/57 at gate start, `track_status: 1`, playback 2x), loopback
+`http://127.0.0.1:53843/data.html`.
+**Inputs:** the 10 `features/data/*.tsx` files, the 15 `lib/*.ts` files (incl. the new
+`neutralised.ts`), `styles/data.css` + `qt-base.css`, `session_data.py`, the new
+`src/arcade/track_status.py`, live endpoints, and 16 before/after captures in
+`~/.claude/plans/pitwall-sprint9/shots/`.
+**Probe:** `src/pitwall/ui/scripts/_iter_probe.mjs` (my own copy, extended from the author's
+`_probe_s9.mjs`; untracked, delete before PR).
+
+**What this gate judges:** whether the seven fixes made the window BETTER — including whether any
+fix overshot, introduced a new imbalance, or is now the loudest wrong thing on screen. Not a
+correctness audit.
+
+---
+
+## Checklist (written before any verdict)
+
+- [x] V1. D4/D11 pace grid: `m:ss` degrade + bottom-anchored card — better/worse/mixed.
+- [x] V2. D5 BESTS one-line degrade — deliberate density change or broken-looking?
+- [x] V3. D6/D2/D17 safety car: rail + shaded band + filled chip — and the band's 0.12 alpha.
+- [x] V4. D7 `P.EXIT` out-lap relabel.
+- [x] V5. D10 own-trace z-order over rival dashes.
+- [x] V6. D9/D15/D16 radio scroll, blind-list retirement filter, 26px targets.
+- [x] V7. D1 STOPS = tyre-set transitions.
+- [x] A1. Author suspicion: SC band too heavy at 0.12 over a third of the plot — measure.
+- [x] A2. Bottom-anchored card early-race: small panel + tall air column.
+- [x] A3. Narrow-client `m:ss`: is the grid still worth its area without tenths?
+- [x] A4. Rail vs `is-t3` amber text distinguishability at 9 px.
+- [x] B1. Four telemetry charts' x-axis labels at 1265x593 (untouched).
+- [x] B2. Track ring nose-to-tail under SC (untouched).
+- [x] B3. Planned #982 dead-producer treatment — right shape?
+- [x] B4. What is now the loudest wrong thing on the window.
+
+Findings and verdicts appended below as they are confirmed.
+
+---
+
+## Part 1 — Verdict per change
+
+### V1 · D4/D11 — the pace grid's `m:ss` degrade and the bottom-anchored card — **BETTER**, with one caveat on the captures
+
+**The narrow client is transformed.** Before (`pace-1265x593.png`): `1:59.1:57.2:24.` and
+`IN PIIN PIIN PI` — truncated glyph soup that actively misread. After (`after-pace-1265x593.png`
+and live): clean `1:31` cells, `PIT`, `EXIT`, and the subtitle says out loud
+*"times to the second at this width"*. Measured on the SERVED bundle at 1265x593
+(`_iter_probe.mjs`): first data column 27 px, coarse form active, the only non-numeric cell
+texts on the whole grid are `EXIT` and `PIT` — zero truncation. The honest-subtitle move
+(`RacePaceGrid.tsx:162`) is exactly right: the degrade is announced, not silent.
+
+**Is the grid still worth its area without tenths (author question A3)? Yes.** The panel's
+subtitle states its own contract — "colour ranks each lap against itself" — and the tone channel
+carries the ranking untouched; `m:ss` only loses intra-second discrimination between cells the
+colour already ranks. The alternative `ss.d` was rightly rejected (`racePace.ts:155-163`): a
+2:19 SC lap rendering `19.7` beside a green `59.4` misreads magnitude, and a cell that can be
+misread is worse than one that is openly coarser.
+
+**Caveat — two of the after-captures predate the D7 fix.** `after-pace-1485x833.png` and
+`after-pace-1265x593.png` render the out-lap as `OUT` (crop verified pixel-level), while
+`sc-rail-pace.png` and the served bundle render `P.EXIT`/`EXIT` (live probe: cell texts are
+`EXIT`/`PIT` only). Anyone judging D7 from those two files would call it unfixed. Refresh them
+before they mislead a third pass.
+
+### V1b · The bottom-anchored card early-race (author suspicion A2) — **BETTER, keep it, do not touch it**
+
+At lap 7 (`sc-rail-pace.png`) the card is a ~140 px strip at the bottom of a ~615 px void, and
+at zero laps it is a header strip alone. That looks bottom-heavy — and it is still the right
+answer, for the reason the fix names (`RacePaceGrid.tsx:133-144` + `data.css:955-963`): the
+newest lap is the row every decision is about, and it now sits at a FIXED height from lap 1 to
+lap 57 instead of migrating ~12 px per lap for 30+ laps. A fixed eye line for the whole race is
+worth fifteen laps of empty column, and the void is honest — the grid literally has nothing to
+show there yet. Every alternative costs more: void inside a full-height card was tried and
+correctly reverted (426 px of dead space INSIDE a bordered panel reads as a rendering bug);
+newest-lap-first row order would pin the row at the top but make the grid's vertical time axis
+run backwards against the race trace's horizontal one; a top-aligned card with a mid-race
+switch to anchored reintroduces the migration exactly once, at the worst moment. Accept the
+early-race air.
+
+One stale capture here too: `after-pace-earlyrace.png` shows the header at the TOP and the code
+row at the BOTTOM of a full-height card — that is the reverted table-anchor build, not what
+ships (`.pace` is content-sized, `align-self: end`, so the header rides with the card at the
+bottom). Refresh it.
+
+### V2 · D5 — BESTS one-line degrade — **BETTER**, and it is honestly two lines, not one
+
+`bests-final-1265x593.png` + live probe at 1265x593: the card renders the `leaders` form,
+62 px tall in the 63 px slot, `BESTS leaders · S1 VER 31.103 · S2 PIA 18.319 · S3 NOR 37.812 ·
+LAP NOR 1:27.695` with `THEO 1:27.234` right-aligned below. It reads as a deliberate density
+change, not a broken panel — three things sell it: the word `leaders` where the subtitle was
+(the header says what got dropped), the unchanged typography (same field labels, same purple
+weight), and `is-theoretical { margin-left: auto }` (`data.css:383-385`), which makes the
+wrapped THEO read as a footer rather than as overflow. Compare the BEFORE at this client: rows
+2-3 and THEORETICAL silently amputated mid-panel. No contest.
+
+**But the code's own account of it is wrong at this exact client.** `BestsPanel.tsx:92-96`
+says the compact form "puts the title on the same line as the values... One line has 24 px of
+air", and `data.css:359-363` pins `line-height: 17px` against a one-pixel overhang. Measured:
+`.bests-leaders` is **40 px tall — it wraps to two lines at 1265** (THEO top 531 vs first
+leader top 509), and the card is 62 in 63 — the 24 px of air is spent. It fits, and it looks
+fine, but the margin the comment claims does not exist, and the card is `overflow-y: auto`
+(`data.css:303`) with globally hidden scrollbars — one more wrap (a slightly narrower window,
+a wider font fallback) and a third line slides under the fold in silence, which is D5's
+original failure mode one wrap away. See finding N3.
+
+### V3 · D6/D2/D17 — the safety-car treatment — **MIXED: right design, two wrong numbers**
+
+**The rail (D6): right.** A 2 px amber border on the lap-number gutter
+(`data.css:1069-1071`), keyed in the subtitle (`pace-legend-rail`, only when a marked lap is on
+the panel — `RacePaceGrid.tsx:165-170`), labelled on hover. On `sc-rail-pace.png` contiguous
+neutralised laps merge into one continuous rail — clean, and clearly a MARK rather than a value.
+**Author question A4 (rail vs `is-t3` amber text at 9 px): distinguishable in practice.** Same
+hue, different channel — the rail is a positional line in the gutter, `is-t3` is glyphs inside
+a cell; on the real capture nothing invites confusion, and the stylesheet's argument
+(`data.css:1065-1068`) matches what the pixels show. Live probe: 8 rail rows at lap 33, legend
+present.
+
+**The filled chip (D2): right.** Before (`state-dead.png` header): GREEN and SAFETY CAR were
+both 18 px outline chips — the race's most decision-dense state differed from its calmest by
+nothing but the word. After (`sc-rail-pace.png`, `sc-filled-chip.png`, live): the chip fills
+with the wire's own colour (rgb(255,140,0), decoded from `palette.py` by the producer —
+`StatusStrip.tsx:90-98`), dark text, AA-checked per label (`data.css:97-107`). Weight now
+separates race state from annotation, which also quietly resolves most of D17: the comment at
+`data.css:872-880` now states the five ambers honestly instead of claiming one. Beside
+PROVISIONAL (outline amber) the filled chip clearly dominates — the hierarchy reads.
+
+**The band (D6 on the race trace): right idea, wrong alpha AND a live-edge defect.** Detail in
+findings N1/N2 and the disagreement section: 0.12 composites to rgb(51,38,45) over the
+rgb(24,22,51) panel — the red channel more than doubles and OVERTAKES blue, so the surface
+flips from cool navy to warm brown and reads as a solid block (the author is right); and a
+band whose revealed range is so far a single lap (live SC, lap 33) has **zero width** — it
+paints nothing while its label floats over the driver endLabels at the plot's right edge
+(executed evidence: live capture at lap 35, second SC).
+
+### V4 · D7 — `P.EXIT` — **BETTER, done, nothing to add**
+
+Wide: `P.EXIT` in WARNING amber (`racePace.ts:299`), coarse: `EXIT`; the in-lap keeps DANGER
+red. The tower's `OUT` = retirement vocabulary is no longer contradicted three rows away — and
+the comment documents the collision it kills. Verified on the served bundle (probe cell texts)
+and on `sc-rail-pace.png` (lap-5 full-field `P.EXIT` row under the SC pit-lane pass — the exact
+row that used to read as seventeen simultaneous retirements).
+
+### V5 · D10 — own trace painted last — **BETTER, done**
+
+`TraceChart.tsx` series order is now rival (dashed, first) then main (solid, last). Before
+(`traces-full-1485x833.png`): Speed read as one amber dashed line with slivers of blue under
+it. After (`iter1-traces.png`): the solid pit-wall-grade line defines every shape and the
+broadcast dashes peek from behind — the z-order now matches the tier hierarchy the dash
+semantics claim, and matches the race trace's own convention.
+
+### V6 · D9/D15/D16 — radio scroll, blind list, hit targets — **BETTER, all three verified live**
+
+- Radio (`data.css:830-834`): `overflow-y: auto`; probe: scrollHeight 1553 vs clientHeight 120,
+  scrollable. 36-events-below-an-unscrollable-fold is dead.
+- Blind list: live at lap 35 with FOUR `OUT` rows in the tower (ALO, SAI, DOO, HAD) the ring
+  shows **no** `NO POSITION:` caption — the telemetry alarm is no longer spent on retirements.
+  (At lap 1, `sc-filled-chip.png` still shows `NO POSITION: HAD` — correct, HAD is not yet
+  marked out on the wire at that instant; honest, not a regression.)
+- Targets: probe at both clients — TRACES/RACE PACE/RACE TRACE tabs and the race trace's
+  LEADER/FIELD/NOR strip all exactly 26 px tall. D16's 15-22 px targets are gone.
+
+### V7 · D1 — STOPS counts tyre-set transitions — **BETTER, and Melbourne is the proof**
+
+`session_data.py:215-229` (`_tyre_stops`): counted off the tyre-set evidence, not pit
+entries, with the docstring naming why Melbourne is the strongest case — the SC led the field
+through the pit lane on laps 2, 3 AND 4 with no tyre work. Before: every classified car showed
+STOPS 3 by lap 24 next to a TYRE cell reading `I 25` — the tower printed its own contradiction.
+After (lap 23 capture + live): 0 for the field, 1 for the cars that actually changed (ALB, STR,
+LAW, OCO, BEA), consistent with their TYRE ages. The column now answers the question a
+strategist asks of it.
+
+---
+
+## Part 2 — New findings
+
+### N1 · P2 — The neutralised band at 0.12 flips the plot surface from cool to warm and reads as a solid block; 0.08 keeps it a tint
+
+**Where:** `src/pitwall/ui/src/lib/chart.ts:55` (`NEUTRALISED_BAND = "rgba(245, 158, 11, 0.12)"`),
+consumed at `RaceTraceChart.tsx:152-168`.
+
+**Executed evidence.** Pixel-sampled `iter1-racetrace.png` (5 points inside the band, 5 outside):
+band composite **rgb(51,38,45)** over panel **rgb(24,22,51)**. The red channel goes 24 → 51
+(2.1x) and OVERTAKES blue (51 → 45): the surface's hue flips from navy to warm brown-pink, so a
+third of the plot reads as a different MATERIAL, not a tinted region of the same one. Rendered
+the alpha ladder over the real panel colour with the real WARNING amber: the red-over-blue
+crossover sits at alpha ≈ 0.105. Below it the band stays a cool surface with a warm cast; at
+0.12 it is past the flip. By the flag the effect covers ~34% of the axis permanently (bands
+1-7, 33-41, 46-51 — `neutralised.ts:46-47`).
+
+**What a strategist loses:** the twenty lines are the data and the band is an annotation, but at
+0.12 the band has more visual mass than any line inside it — the eye parses the brown block
+first on every glance at the panel.
+
+**Prescription:** `rgba(245, 158, 11, 0.08)` — composite rgb(42,33,48), blue still dominant,
+clearly visible as a band (verified on a rendered swatch over the real panel colour), and the
+`SAFETY CAR` label plus the pace grid's keyed rail carry the semantics, so the fill does not
+need to shout. 0.07 also works; do not go to 0.05 (barely distinguishable). One constant, no
+layout risk. This respects settled rule 2 — the treatment stays a translucent amber fill.
+
+### N2 · P1 — At 1265x593 the four telemetry x-axes render as an unbroken digit string: five labels of ~30 px on a ~120 px axis
+
+**Where:** `src/pitwall/ui/src/lib/chart.ts:129-155` (`valueAxis`, `axisLabel` fontSize 10, no
+formatter), used by all four charts in `features/data/TraceChart.tsx` with x locked to
+`[0, circuit_length]`.
+
+**Executed evidence.** Live probe at 1265x593, TRACES tab (the DEFAULT tab): each `.trace-plot`
+is **152 px wide**; after grid margins the axis span is ~120 px. Five labels `1,000`…`5,000`
+at 10 px mono are ~30 px each — 150 px of glyphs on 120 px of axis. `bests-final-1265x593.png`
+shows the result on all four charts: `1,0002,0003,0004,0005,000`, one unreadable run. The wide
+client (203 px plots, `traces-full-1485x833.png`) is tight but separated.
+
+**What a strategist loses:** the distance scale on every telemetry chart at the laptop client —
+and worse, the axis looks like a rendering fault, which taxes trust in the three panels above
+it that are correct. This is the loudest broken-looking thing at 1265 and it is on the tab the
+window opens on.
+
+**Prescription:** a formatter on the x `valueAxis` used by TraceChart:
+`axisLabel.formatter: (v) => \`${v / 1000}k\`` → `1k 2k 3k 4k 5k`, ~12 px per label at both
+clients, self-consistent with the axis name "Distance (m)" becoming "Distance" or "Distance
+(km)" if preferred. No measurement machinery needed; it also reads better at 1485. (An
+`interval` that drops to three labels is the fallback if the k-form is unwanted.)
+
+### N3 · P3 — The BESTS compact form is two lines, not the one line its comment claims, and its safety margin is spent
+
+**Where:** `BestsPanel.tsx:92-96` (comment: "puts the title on the same line as the values…
+One line has 24 px of air"), `data.css:353-363` (`flex-wrap: wrap`, `line-height: 17px`),
+`data.css:303` (`overflow-y: auto` on the card, scrollbars hidden globally).
+
+**Executed evidence.** Live probe at 1265x593: `.bests-leaders` height **40 px** — two flex
+lines (first leader top 509, THEO top 531); card 62 px in a 63 px slot. It FITS, and the
+right-aligned THEO happens to read as a deliberate footer — but the 24 px of air the comment
+budgets does not exist, and the failure mode behind D5 (content sliding under an unscrollable,
+unannounced fold) is one wrap away: any client a few px narrower than 1265, or a wider
+fallback font, wraps a second entry and pushes THEO below the fold in silence.
+
+**What a strategist loses today:** nothing — both settled client sizes render correctly.
+This is a margin-and-honesty finding, not a visible defect.
+
+**Prescription:** (a) correct the comment — it currently documents a mechanism the panel does
+not have, which is the defect class `feedback_errors_gates_caught_in_me` names; (b) cheap
+guard: at compact, if `.bests-leaders` scrollHeight exceeds the room, drop the `.bests-value`
+spans and keep `S1 VER · S2 PIA · S3 NOR · LAP NOR · THEO 1:27.234` — codes are the panel's
+glance answer and the third degrade step continues the existing ladder (ranked → leaders →
+codes). (b) can wait; (a) should not.
+
+### N4 · P2 — A LIVE safety car paints a zero-width band: the range from==to renders nothing while its label floats over the driver codes
+
+**Where:** `RaceTraceChart.tsx:163-166` (`data: neutral.map((band) => [{ name, xAxis:
+band.from }, { xAxis: band.to }])`), ranges from `neutralised.ts:49-58`.
+
+**Executed evidence.** Live capture at lap 35 (second SC, only lap 33 revealed as neutralised
+so far, `from == to == 33`): the 1-7 band is shaded, but at lap 33 there is NO shading — a
+zero-width markArea — while its `SAFETY CAR` label renders at the plot's right edge on top of
+the NOR/PIA endLabels (`~/.claude/plans/pitwall-sprint9/shots/iter1-live-trace-2bands.png`). The moment the
+band matters most — an SC out RIGHT NOW — is the moment it is invisible and its label is noise.
+A second, quieter cost of the same encoding: a lap is a POINT on this axis, so even a wide band
+leaves its boundary laps' data points ON the band edge rather than inside it.
+
+**What a strategist loses:** the annotation exactly during the live neutralisation it exists
+for; plus a label collision in the only identification zone the chart has.
+
+**Prescription:** pad the range to the lap's cell — `{ xAxis: band.from - 0.5 }, { xAxis:
+band.to + 0.5 }`. A one-lap band becomes one lap wide, boundary laps sit inside their band, and
+nothing else changes. Additionally set the markArea `label.position` to `"insideTopLeft"` so a
+band ending at the plot's right edge keeps its label at the band's left, away from the
+endLabels. Two lines, no new constants, respects settled rule 2.
+
+### N5 · P3 — Two columns with zero revealed laps (HAD, DOO) occupy grid width for the whole race — and dropping them would NOT buy the tenths back
+
+**Where:** `racePace.ts` `stableColumns` (grid columns are the full field), visible in every
+pace capture: HAD and DOO are empty for all 55 rows (`after-pace-1485x833.png`); SAI keeps
+early-lap rows so his column earns its place.
+
+**What a strategist loses:** ~2 columns × 27.75-38.75 px of the panel's scarcest axis, spent on
+cars that never set a revealed lap. Honest arithmetic before anyone oversells the fix: at 1265,
+dropping both gives 18 columns of ~30.8 px — still under the ~35 px the fine (`0:00.0`) form
+needs, so the coarse form STAYS; the gain is only decluttering. Rule if taken: drop a column
+only at zero revealed laps (a car that retires mid-race must keep its column and its history).
+Low value, low risk; fine to leave.
+
+### N6 · P3 — The safety car wears two different ambers: the chip fills with the wire's rgb(255,140,0), the band/rail/legend use WARNING #f59e0b
+
+**Where:** `StatusStrip.tsx:97-98` (background from `track_status_color`) vs `chart.ts:55` and
+`data.css:1070/1078` (WARNING). Both trace to `palette.py` names, so settled rule 7 is
+respected, and at a glance the hues are indistinguishable — this costs nothing today. It is
+noted so the pair cannot drift apart silently: if the producer's SC state colour ever changes,
+the chip moves and the band does not, and the window would then say "safety car" in two
+colours. A one-line comment at `NEUTRALISED_BAND` naming the pairing is enough.
+
+---
+
+## Part 3 — What to change next, in order
+
+1. **N1 — band alpha 0.12 → 0.08** (`chart.ts:55`). One constant; the biggest visual win at
+   1485 per character of diff.
+2. **N2 — x-axis `formatter: v => v/1000 + "k"`** on the four telemetry charts. Kills the
+   digit soup at 1265; improves 1485 too.
+3. **N4 — pad neutralised bands ±0.5 lap and move the markArea label to `insideTopLeft`**
+   (`RaceTraceChart.tsx:156-166`). Makes the live-SC band exist.
+4. **N3a — fix the false "one line / 24 px of air" comment** (`BestsPanel.tsx:92-96`).
+5. **Refresh the three stale captures** (`after-pace-1485x833.png`, `after-pace-1265x593.png`,
+   `after-pace-earlyrace.png`) so the next pass doesn't re-litigate D7/D11 from pre-fix pixels.
+6. **#982 dead-producer treatment** — the planned shape is right; see Part 4a notes.
+7. (Optional) N3b codes-only third degrade; N5 zero-revealed-lap column drop; N6 pairing
+   comment.
+
+All of 1-5 are safe under the no-rebuild constraint of this gate — they are prescriptions for
+the NEXT build, none was applied.
+
+---
+
+## Part 4 — Judgments on the untouched surfaces
+
+**4a · The planned #982 dead treatment (`PLAYBACK —` + stale filter on both columns +
+non-transient `DATA FROZEN · last tick L28`) — right shape.** `state-dead.png` shows why all
+three legs are needed: today a dead producer leaves GREEN chip + `PLAYBACK 2x` + a full board
+of confident numbers, and the only tell is one small `Disconnected` chip. Four additions to the
+plan, all in its spirit: (1) the bottom status line reads `lap 28 · live` — it must flip with
+the same signal, or the window contradicts its own banner; (2) the track-status chip must go
+hollow/neutral when frozen — a dead feed cannot assert GREEN (the track may be red-flagged
+for all it knows), and a frozen FILLED SAFETY CAR chip would be worse; (3) the stale filter
+should be desaturation (~0.5) plus a mild dim, never blur or opacity below ~0.55 — the last
+known state is still operationally useful and must stay readable; (4) `DATA FROZEN · last tick
+L28` belongs in the header strip where the chips already live, so the reader who only checks
+the top-left gets it.
+
+**4b · The track ring under a live SC (`state-safetycar-lap1.png`) — leave it.** Nineteen dots
+collapsing into a nose-to-tail caterpillar IS the safety-car message; the gestalt is the
+information, and identity was never the ring's job (settled rule 1 — ten colours, twenty cars;
+only NOR/PIA are labelled and they stay on top). Any de-overlap (jitter, radial fanning) would
+draw a field spread the race does not have — worse than the overlap it fixes.
+
+**4c · What is now the loudest WRONG thing on the window.** At 1485: the band's brown mass
+(N1). At 1265: the axis digit soup (N2). Both are in the next-list. After those two land, the
+loudest remaining wrong thing is not from this iteration at all — it is D12, the six
+sub-3:1-contrast driver codes (VER/LAW at 1.88:1), already tracked in #976; worth pulling
+forward, because identity is the tower's whole answer and every fix in this pass sharpened the
+panels AROUND it.
+
+---
+
+## Part 5 — What I tried to break and could not
+
+- **The coarse/fine flip-flop.** `fineFormFits` (`RacePaceGrid.tsx:66-76`) always measures the
+  FINE form in the cell's computed font regardless of what is rendered — the classic
+  measure-what-you-just-rendered oscillation is structurally absent. Code-read plus live
+  verification at both clients (fine at 1485, coarse at 1265); I did not drive a continuous
+  resize, so "no oscillation" is asserted for the two settled sizes, not for every width.
+- **The BESTS ranked/compact hysteresis.** The ranked height is latched once
+  (`BestsPanel.tsx:55-79`) and compact never re-measures itself — the 63<153→compact,
+  63>=54→ranked loop the comment describes cannot occur. Verified the compact form live at
+  1265 and the ranked form at 1485.
+- **Rail vs `is-t3` text confusion (author question A4).** Same hue, different channel; on the
+  real captures at 9 px I could not construct a glance that misreads one for the other — the
+  rail is a continuous gutter line, amber text is glyphs inside ranked cells.
+- **STOPS vs TYRE contradiction.** Searched every capture and the live tower for a car whose
+  STOPS disagrees with its TYRE age under the new definition; none found (the before-capture
+  shows the old contradiction on every classified row).
+- **The visible-range header (#949 fix).** Live at 1265: header `LAPS 1-33 of 57` with exactly
+  laps 1-33 rendered and all rows inside the scroller; at the 56-lap capture the header
+  windows to `19-55` and the newest row is bold and last. Could not make it lie.
+- **The filled chip's AA claim.** Re-derived SAFETY CAR: rgb(255,140,0) text `--qt-bg` #121127
+  → 7.92:1 against the claimed 7.93 (`data.css:101-103`). The one label I checked matches; the
+  other three were not re-derived.
+- **The neutralised twin.** The rail and the trace band read the same `neutralisedLaps` module
+  (`neutralised.ts:30`, `RaceTraceChart.tsx:92-95`, `RacePaceGrid` via `racePaceGrid`), so the
+  two panels cannot disagree about which laps were neutralised — the twin defect this repo pays
+  for most often is structurally closed here.
+
+---
+
+## Part 6 — Where I disagree with the author, plainly
+
+- **The band: you are right, and the number is 0.08.** The capture is not misleading you — the
+  measured composite flips warm at 0.12 (red overtakes blue at alpha ≈ 0.105). But alpha is
+  only half the finding: the LIVE band is zero-width (N4), and if you only dim the fill the
+  live-SC case gets worse, not better. Land N1 and N4 together.
+- **The bottom-anchored card: your worry is misplaced — keep it exactly as is.** The early-race
+  void is the honest cost of a fixed newest-lap eye line, and every alternative (including the
+  one you already tried and reverted) costs more. Do not spend another commit on it.
+- **BESTS "one line": it is two lines at 1265 and that is fine — but the comment says one, and
+  a comment that mis-describes its own mechanism is this repo's named defect class. Fix the
+  comment, not the panel.**
+
+---
+
+## Summary
+
+- V1 (D4/D11 pace degrade + anchor): **BETTER** · V1b (anchor early-race): **keep, don't touch**
+- V2 (D5 BESTS): **BETTER** (honestly two lines; comment wrong)
+- V3 (D6/D2/D17 SC): **MIXED** — rail right, chip right, band right idea / wrong alpha + zero-width live band
+- V4 (D7 P.EXIT): **BETTER** · V5 (D10 z-order): **BETTER** · V6 (D9/D15/D16): **BETTER** · V7 (D1 STOPS): **BETTER**
+
+**P1:** N2 (telemetry x-axis digit soup at 1265, default tab).
+**P2:** N1 (band alpha flips the surface warm; 0.08), N4 (zero-width live SC band + label collision).
+**P3:** N3 (BESTS two-line reality vs one-line comment; margin spent), N5 (two zero-lap columns), N6 (two ambers for one state).
+
+**Counts:** P0 0 · P1 1 · P2 2 · P3 3. Probe left at `src/pitwall/ui/scripts/_iter_probe.mjs`
+(untracked; delete before PR), alongside the author's `_probe_s9.mjs`.

--- a/src/arcade/overlays.py
+++ b/src/arcade/overlays.py
@@ -32,7 +32,6 @@ from src.arcade.config import (
     LEGEND_X,
     PROGRESS_BAR_BOTTOM,
     PROGRESS_BAR_HEIGHT,
-    SUCCESS,
     TEXT_PRIMARY,
     TEXT_SECONDARY,
     TEXT_TERTIARY,
@@ -40,6 +39,16 @@ from src.arcade.config import (
     WEATHER_ROW_GAP,
     WEATHER_TOP_OFFSET,
     WEATHER_WIDTH,
+)
+
+# Re-exported so every existing caller keeps its import path. The rule itself
+# moved to a module with no `arcade` import, because PITWALL's bulk reader
+# decodes the status of each LAP and must not drag the GUI library in to do it -
+# nor keep a second copy of the priority order.
+from src.arcade.track_status import (  # noqa: F401
+    neutralised_label,
+    track_status_banner,
+    track_status_label,
 )
 
 if TYPE_CHECKING:
@@ -616,53 +625,6 @@ class LeaderboardPanel:
             reverse=True,
         )
         return ranked + unknown
-
-
-def track_status_banner(code: str) -> tuple[str, tuple[int, int, int]] | None:
-    """Map a FastF1 multi-digit ``TrackStatus`` to (label, RGB), or None if clear.
-
-    Priority red > SC > VSC > yellow > clear, matching how race control
-    announces concurrent events: a red flag wins even if a yellow was
-    already out in another sector.
-
-    Module level rather than a method because two surfaces read it. It used
-    to be ``RaceEventsPanel._status_for``, and a second consumer arriving in
-    TypeScript would have forked the priority order and the four labels
-    across two languages - the defect ``driver_colors`` rides on the wire to
-    prevent.
-
-    --- WHERE TO CHANGE IF THE STATUS CODES CHANGE ---
-    ``src/arcade/app.py`` publishes the decoded form on the broadcast, so
-    PITWALL's status strip renders whatever this returns.
-    """
-    if not code:
-        return None
-    digits = set(code)
-    if "5" in digits:
-        return ("RED FLAG", (239, 68, 68))
-    if "4" in digits:
-        return ("SAFETY CAR", (255, 140, 0))
-    if "6" in digits or "7" in digits:
-        return ("VSC", (245, 158, 11))
-    if "2" in digits:
-        return ("YELLOW FLAG", (250, 204, 21))
-    return None
-
-
-def track_status_label(code: str) -> tuple[str, tuple[int, int, int]] | None:
-    """The banner, but with the clear case named instead of hidden.
-
-    The arcade's pill HIDES itself on a clear track, so it never had to tell
-    "clear" apart from "the loader has no entry for this lap" - both are the
-    absence of a pill. A timing strip always shows a track status, so the
-    two have to separate: ``""`` is unknown and returns None, ``"1"`` is
-    green and says so. Conflating them would put a confident GREEN on a lap
-    whose status nobody knows, which is the sentinel class this repo keeps
-    paying for.
-    """
-    if not code:
-        return None
-    return track_status_banner(code) or ("GREEN", SUCCESS)
 
 
 class RaceEventsPanel:

--- a/src/arcade/track_status.py
+++ b/src/arcade/track_status.py
@@ -1,0 +1,95 @@
+"""Decoding FastF1's ``TrackStatus`` digits, in the one place that owns the rule.
+
+**Moved out of ``overlays.py`` so a consumer can read it without importing the
+arcade GUI library.** The functions themselves are unchanged and ``overlays``
+re-exports them, so every existing caller is untouched; what changed is that
+``src/pitwall/session_data.py`` can now decode the status of each LAP while
+building the bulk payload. Before this, the only decoded form on the wire was
+the arcade-level one for the lap on screen, and the race-pace grid had no way to
+know a lap was neutralised without a second copy of the priority order and the
+four labels in TypeScript - which is the defect ``driver_colors`` rides on the
+wire to prevent.
+
+--- WHERE TO CHANGE IF THE STATUS CODES CHANGE ---
+``src/arcade/app.py`` publishes ``track_status_label`` for the lap on screen and
+``src/pitwall/session_data.py`` publishes ``neutralised`` per lap row. Both read
+this module; neither has its own table.
+"""
+
+from __future__ import annotations
+
+from src.arcade.config import SUCCESS
+
+__all__ = ["neutralised_label", "track_status_banner", "track_status_label"]
+
+# The statuses under which the field is NOT racing freely, so a per-lap pace
+# ranking over them ranks the queue rather than the pace. A single yellow is
+# deliberately absent: it is sector-local, and cars away from it are racing.
+_NOT_RACING = frozenset({"RED FLAG", "SAFETY CAR", "VSC"})
+
+
+def track_status_banner(code: str) -> tuple[str, tuple[int, int, int]] | None:
+    """Map a FastF1 multi-digit ``TrackStatus`` to (label, RGB), or None if clear.
+
+    Priority red > SC > VSC > yellow > clear, matching how race control
+    announces concurrent events: a red flag wins even if a yellow was
+    already out in another sector.
+
+    Module level rather than a method because several surfaces read it. It used
+    to be ``RaceEventsPanel._status_for``, and a second consumer arriving in
+    TypeScript would have forked the priority order and the four labels
+    across two languages - the defect ``driver_colors`` rides on the wire to
+    prevent.
+    """
+    if not code:
+        return None
+    digits = set(code)
+    if "5" in digits:
+        return ("RED FLAG", (239, 68, 68))
+    if "4" in digits:
+        return ("SAFETY CAR", (255, 140, 0))
+    if "6" in digits or "7" in digits:
+        return ("VSC", (245, 158, 11))
+    if "2" in digits:
+        return ("YELLOW FLAG", (250, 204, 21))
+    return None
+
+
+def track_status_label(code: str) -> tuple[str, tuple[int, int, int]] | None:
+    """The banner, but with the clear case named instead of hidden.
+
+    The arcade's pill HIDES itself on a clear track, so it never had to tell
+    "clear" apart from "the loader has no entry for this lap" - both are the
+    absence of a pill. A timing strip always shows a track status, so the
+    two have to separate: ``""`` is unknown and returns None, ``"1"`` is
+    green and says so. Conflating them would put a confident GREEN on a lap
+    whose status nobody knows, which is the sentinel class this repo keeps
+    paying for.
+    """
+    if not code:
+        return None
+    return track_status_banner(code) or ("GREEN", SUCCESS)
+
+
+def neutralised_label(code: str | None) -> str | None:
+    """The label when the field was NOT racing freely on this lap, else None.
+
+    This is what the race-pace grid needs and what no client should derive: it
+    ranks every timed lap into thirds and paints the thirds green / grey / amber,
+    and under a safety car those thirds are the accordion's queue order, not
+    pace. Measured on Melbourne 2025, 22 of 57 laps carry a safety-car digit and
+    **213 of the 776 cells the grid ranks (27.4 %)** sit on one, with lap times
+    running 86.4-148.2 s (median 131.6) against a green median of 91.9.
+
+    A single yellow returns None on purpose. It is sector-local: the cars that
+    are not in that sector are racing, and marking the whole lap would spend the
+    marker on 43 more rows of this one race without a claim behind it.
+
+    ``None`` is also the answer for an unknown status (``""`` or absent), because
+    "nobody recorded what the track was doing" is not "the track was clear" -
+    and it must not paint a marker either way.
+    """
+    decoded = track_status_banner(code or "")
+    if decoded is None:
+        return None
+    return decoded[0] if decoded[0] in _NOT_RACING else None

--- a/src/pitwall/session_data.py
+++ b/src/pitwall/session_data.py
@@ -43,6 +43,7 @@ from typing import Any
 
 import pandas as pd
 
+from src.arcade.track_status import neutralised_label
 from src.f1_strat_manager.tyre_stint_repair import is_real_compound, repair_tyre_stints
 
 logger = logging.getLogger(__name__)
@@ -131,6 +132,14 @@ def _lap_row(record: dict[str, Any]) -> dict[str, Any]:
         "tyre_life": _none_if_nan(record.get("TyreLife")),
         "stint": _none_if_nan(record.get("Stint")),
         "track_status": _none_if_nan(record.get("TrackStatus")),
+        # The digits DECODED, by the arcade's own rule, for the one question the
+        # grid needs answered: was the field racing freely on this lap. Decoded
+        # here for the same reason `track_status_label` is decoded for the tick -
+        # the priority order and the labels are a project rule, and a client that
+        # tested for a `4` would be the second copy of it in another language.
+        # Non-null means a per-lap pace ranking over this lap ranks the safety
+        # car's queue rather than pace; see `neutralised_label`.
+        "neutralised": neutralised_label(_none_if_nan(record.get("TrackStatus"))),
         "pit_in": pd.notna(record.get("PitInTime")),
         "pit_out": pd.notna(record.get("PitOutTime")),
         "deleted": bool(record.get("Deleted", False)),

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -266,21 +266,43 @@ for (const [index, [name, range]] of expected.entries()) {
 // The delta the interpolation produced. Three points, not five: the rival's
 // samples stop at 300 m and `lerpSorted` returns null past the end rather
 // than extrapolating a flat tail that would look like real data.
-const delta = await page.evaluate(() => {
-  const el = document.querySelectorAll(".trace-plot")[0];
-  return el.__pitwallChart.getOption().series[1].data;
-});
+// Looked up by NAME, not by index. These two used to read `series[1]` and
+// `series[0]`, and the declaration order is exactly what the z-order fix had to
+// change - an index-keyed probe turns that into two silently wrong assertions
+// about the wrong line.
+const seriesByName = (plot, name) =>
+  page.evaluate(
+    ([which, series]) => {
+      const el = document.querySelectorAll(".trace-plot")[which];
+      return el.__pitwallChart.getOption().series.find((s) => s.name === series) ?? null;
+    },
+    [plot, name],
+  );
+
+const delta = (await seriesByName(0, "rival")).data;
 check(
   delta.length === 3 && delta.every(([, value]) => Math.abs(value - 2) < 1e-9),
   `the delta is +2.0 s over the rival's three samples only (${JSON.stringify(delta)})`,
 );
 
 // The speed trace carries the whole main span.
-const speedPoints = await page.evaluate(() => {
-  const el = document.querySelectorAll(".trace-plot")[1];
-  return el.__pitwallChart.getOption().series[0].data.length;
-});
+const speedPoints = (await seriesByName(1, "main")).data.length;
 check(speedPoints === 5, `the speed trace holds all five samples (${speedPoints})`);
+
+// **The own car paints ON TOP, on every chart.** ECharts paints in declaration
+// order, and the rival's coarse broadcast dashes used to be last: wherever the
+// two cars run comparable numbers - which is when the comparison matters - the
+// solid pit-wall-grade line was underneath. The race trace one tab away builds
+// the opposite rule deliberately, so this is the twin that had it inverted.
+const paintOrder = await page.evaluate(() =>
+  [...document.querySelectorAll(".trace-plot")].map((el) =>
+    el.__pitwallChart.getOption().series.map((s) => s.name).join(">"),
+  ),
+);
+check(
+  paintOrder.length === 4 && paintOrder.every((order) => order === "rival>main"),
+  `the own car is declared last so it paints over the rival on all four charts (${paintOrder.join(" | ")})`,
+);
 
 // The cursor, in PIXELS. It must be at the column ECharts maps 500 m to, and
 // must not be at a column the car has not reached - which is also a column
@@ -363,10 +385,7 @@ check(
 // re-driven - nothing else would ever evict them.
 await page.evaluate((payload) => window.__ticks.push(payload), tick(2, { main: [], rivalSpan: [], rewound: true }));
 await page.waitForTimeout(400);
-const afterRewind = await page.evaluate(() => {
-  const el = document.querySelectorAll(".trace-plot")[1];
-  return el.__pitwallChart.getOption().series[0].data.length;
-});
+const afterRewind = (await seriesByName(1, "main")).data.length;
 check(afterRewind === 0, `a rewind empties the trace (${afterRewind} points left)`);
 
 // ...and the rewind must NOT look like single-driver mode. This is the twin
@@ -409,10 +428,7 @@ await page.evaluate(
   tick(3, { main: JUMPED, rivalSpan: [], dropped: 60 }),
 );
 await page.waitForTimeout(400);
-const afterJump = await page.evaluate(() => {
-  const el = document.querySelectorAll(".trace-plot")[1];
-  return el.__pitwallChart.getOption().series[0].data.map(([x]) => x);
-});
+const afterJump = (await seriesByName(1, "main")).data.map(([x]) => x);
 check(
   afterJump.length === 3 && afterJump[0] === 3100,
   `a forward jump keeps the span it arrived with (${JSON.stringify(afterJump)})`,
@@ -498,9 +514,14 @@ check(
 );
 // A null `rel_dist` is unknown, not zero. Drawing the cursor at 0 m would put
 // the blind car exactly on the start line, a place a real car can be.
+// Across EVERY series, not the one that happens to carry the marks: they hang
+// off whichever series is declared first, and that changed once already.
 const blindCursor = await soloPage.evaluate(() => {
   const el = document.querySelectorAll(".trace-plot")[0];
-  return (el.__pitwallChart.getOption().series[0].markLine?.data ?? []).some((m) => "xAxis" in m);
+  return el.__pitwallChart
+    .getOption()
+    .series.flatMap((s) => s.markLine?.data ?? [])
+    .some((m) => "xAxis" in m);
 });
 check(!blindCursor, "and draws no cursor for a car with no position");
 
@@ -517,7 +538,12 @@ const FIELD = {
   PIA: driver({ rel_dist: 0.25 }), //        running, rival, a quarter round
   VER: driver({ active: false, has_finished: true, rel_dist: 0.5 }), // finished
   HUL: driver({ active: false, has_finished: false, rel_dist: 0.75 }), // out
-  HAD: driver({ rel_dist: null, has_position: false }), // never placed
+  HAD: driver({ rel_dist: null, has_position: false }), // never placed, still RUNNING
+  // Never placed AND retired, which is what HAD really is on Melbourne 2025 and
+  // what no fixture carried: the blind list used to collect him for all 57 laps,
+  // so the ring's only telemetry alarm was lit from the first capture to the
+  // last. A retired car cannot be a car the telemetry lost.
+  SAI: driver({ rel_dist: null, has_position: false, active: false, has_finished: false }),
 };
 
 const ring = await browser.newContext({ viewport: { width: 1500, height: 950 } });
@@ -528,7 +554,7 @@ await ringPage.addInitScript((payload) => {
   window.pywebview = {
     api: { get_tick: async (sinceSeq) => (sinceSeq === payload.seq ? null : payload) },
   };
-}, tick(1, { drivers: FIELD, order: ["NOR", "PIA", "VER", "HUL", "HAD"] }));
+}, tick(1, { drivers: FIELD, order: ["NOR", "PIA", "VER", "HUL", "HAD", "SAI"] }));
 
 await ringPage.goto(url, { waitUntil: "domcontentloaded" });
 await ringPage.waitForSelector(".ring-dot", { timeout: 5000 });
@@ -571,14 +597,21 @@ check(
 // A car the telemetry never placed is NAMED, never drawn at fraction 0 -
 // which is the start line, a position a real car can hold.
 check(!of("HAD"), "the unplaced car has no dot");
+const blindLine = await ringPage.locator(".ring-blind").innerText();
+check(blindLine.includes("HAD"), "and the ring says which car it is");
+// **The alarm names only the cars it is ABOUT.** It exists to flag a live car the
+// telemetry lost; a retirement has no telemetry by definition and lighting it for
+// one turns the alarm into furniture - on the real race it was lit from lap 1 to
+// lap 57 by a car that crashed on the first lap.
 check(
-  (await ringPage.locator(".ring-blind").innerText()).includes("HAD"),
-  "and the ring says which car it is",
+  !blindLine.includes("SAI"),
+  `and not the retired one, which has no telemetry by definition ("${blindLine}")`,
 );
 check(
   (await ringPage.locator(".ring-code").count()) === 2,
   "only the two featured cars are labelled",
 );
+
 
 // The two labels go on OPPOSITE sides of their dots. The main driver and the
 // car chosen to compare against are routinely seconds apart - on the real
@@ -788,6 +821,7 @@ function towerBulk() {
           tyre_life: 12,
           stint: 2,
           track_status: "1",
+          neutralised: null,
           pit_in: false,
           pit_out: false,
           deleted: false,
@@ -1104,6 +1138,62 @@ check(
 check((await rowText(1)).startsWith("L23 VER"), "the newest event is the top row");
 check((await rowText(6)).startsWith("L2 RCM"), "and the oldest is the last one");
 
+// --- The history a reader could not reach ---------------------------------
+//
+// `.radio-list` and `.radio-feed` were BOTH `overflow: hidden`, which made this
+// the one panel in the window whose content was genuinely gone rather than merely
+// unadorned: measured on the live page, 10 of 46 events visible and no user input
+// that could reach the other 36 - `scrollTop` from the console worked, so the rows
+// were there and only the reader had no path in. The window's own rule is the
+// opposite: `qt-base.css` hides the scrollBAR and keeps bodies scrollable.
+//
+// Six events fit, so this needs its own fixture: a fold has to EXIST before
+// "can it be reached" is a question, and a guard whose probe sits where the
+// content fits cannot see the defect it names.
+//
+// **`overflowY` is not the mechanism half of this check, it IS the effect.**
+// Driving the mutation proved it: with `overflow: hidden` a scripted
+// `scrollTop = scrollHeight` still moves the list to 1615 and the oldest row is
+// still in view, so the scroll-and-look half passes ON the defect. What
+// `overflow: hidden` blocks is the WHEEL, the trackpad and the keyboard - the
+// reader's only paths - and the computed value is what says whether they work.
+{
+  const many = Array.from({ length: 60 }, (_, index) => ({
+    kind: index % 3 === 0 ? "rcm" : "radio",
+    lap: 40 - Math.floor(index / 2),
+    driver: index % 3 === 0 ? null : "NOR",
+    text: `event ${index} - long enough to occupy a row of its own on the panel`,
+  }));
+  const [longCtx, longPage] = await radioPage({ available: true, events: many });
+  const reach = await longPage.evaluate(async () => {
+    const list = document.querySelector(".radio-list");
+    const rows = [...list.querySelectorAll(".radio-row")];
+    const folded = list.scrollHeight - list.clientHeight;
+    const before = list.scrollTop;
+    list.scrollTop = list.scrollHeight;
+    await new Promise((done) => setTimeout(done, 60));
+    const box = list.getBoundingClientRect();
+    const oldest = rows[rows.length - 1]?.getBoundingClientRect();
+    return {
+      rows: rows.length,
+      folded,
+      before,
+      after: list.scrollTop,
+      overflowY: getComputedStyle(list).overflowY,
+      oldestReached: !!oldest && oldest.bottom <= box.bottom + 1 && oldest.top >= box.top - 1,
+    };
+  });
+  check(
+    reach.folded > 100 && reach.rows === many.length,
+    `the long feed really has a fold (${reach.folded} px hidden over ${reach.rows} rows)`,
+  );
+  check(
+    reach.overflowY === "auto" && reach.after > reach.before && reach.oldestReached,
+    `and the oldest event can be reached (${reach.overflowY}, scrollTop ${reach.before} -> ${reach.after}, oldest in view: ${reach.oldestReached})`,
+  );
+  await longCtx.close();
+}
+
 // The tier claim, on screen rather than in a PDF. NOR is `driver_main`.
 const tiers = await feedPage.evaluate(() =>
   [...document.querySelectorAll(".radio-row")].map((row) => ({
@@ -1214,8 +1304,8 @@ function paceBulk() {
         number, laps_revealed: 0, stops: 0, crossings: {},
         laps: [{ lap: 1, t: null, lap_time: null, s1: null, s2: null, s3: null,
           v1: null, v2: null, vfl: null, vst: null, position: null, compound: null,
-          tyre_life: null, stint: null, track_status: "1", pit_in: false, pit_out: false,
-          deleted: false, generated: true, pb: false }],
+          tyre_life: null, stint: null, track_status: "1", neutralised: null,
+          pit_in: false, pit_out: false, deleted: false, generated: true, pb: false }],
         best: { lap: null, lap_time: null, s1: null, s2: null, s3: null,
           v1: null, v2: null, vfl: null, vst: null, compound: null },
         theoretical: null,
@@ -1267,10 +1357,16 @@ function paceBulk() {
       // been twenty flat lines at zero and every check would have passed.
       elapsed += lapTime;
       crossings[lap] = elapsed;
+      // **The fixture used to say `track_status: "1"` on the very laps it calls
+      // the safety car.** It knew they were neutralised - `neutralised` above
+      // makes their times 2.4x - and told the wire they were green, so the rail
+      // and the trace's shaded band had no fixture that could exercise them.
       laps.push({ lap, t: elapsed, lap_time: lapTime,
         s1: 29, s2: 30, s3: 26, v1: 301, v2: 289, vfl: 280, vst: 321,
         position: index + 1, compound: "MEDIUM", tyre_life: lap, stint: 1,
-        track_status: "1", pit_in: pitIn, pit_out: pitOut, deleted,
+        track_status: neutralised ? "4" : "1",
+        neutralised: neutralised ? "SAFETY CAR" : null,
+        pit_in: pitIn, pit_out: pitOut, deleted,
         generated: false, pb: false });
     }
     drivers[code] = { number, laps_revealed: revealed, stops: 1, crossings, laps,
@@ -1401,8 +1497,25 @@ const paceCells = await pacePage.evaluate(() => {
 // which is how a 0.27 px "fit" measured as a pass right up to the screenshot.
 check(paceCells.clipped === 0, `no lap time is cut (${paceCells.clipped}/${paceCells.total} clipped)`);
 check(paceCells.rows === PACE_LAPS, `one row per lap of the race (${paceCells.rows})`);
-check(paceCells.pitText === "IN PIT" && paceCells.outText === "OUT",
+check(paceCells.pitText === "IN PIT" && paceCells.outText === "P.EXIT",
   "the in-lap and the out-lap replace the time, as a timing screen shows them");
+// **And neither of them says what the tower says about a RETIRED car.** The
+// tower's own docstring refuses to reuse that word for a car that is still
+// racing; this grid used it for the out-lap, in the same window, on the same
+// screen. Asserted over the whole enumeration of cell texts rather than on the
+// one sampled above, so a single tone reverting is still caught.
+const paceWords = await pacePage.evaluate(() => {
+  const cells = [...document.querySelectorAll(".pace-table td")];
+  const tower = [...document.querySelectorAll(".tower-row .col-last")].map((c) => c.textContent);
+  return {
+    collisions: cells.filter((c) => c.textContent.trim() === "OUT").length,
+    towerUsesIt: tower.includes("OUT"),
+  };
+});
+check(
+  paceWords.collisions === 0,
+  `no pace cell says OUT, which the tower reserves for a retirement (${paceWords.collisions} do)`,
+);
 check(paceCells.best === 1, `exactly one purple cell - the session's fastest lap (${paceCells.best})`);
 
 // **The range says what is ON SCREEN, and the only way to check that is to
@@ -1539,6 +1652,50 @@ const scSpread = ["is-t1", "is-t2", "is-t3"].map((k) => scLaps[k] ?? 0);
 check(
   scSpread.every((count) => count > 0),
   `under the safety car the grid still ranks the field instead of painting it one colour (${scSpread.join(" / ")})`,
+);
+
+// **And it SAYS the thirds are the queue on those laps.** The ranking is left
+// alone deliberately - excluding the laps would leave holes in a history panel
+// and re-ranking them would invent a scale - so the rail is what stops a green
+// cell on lap 4 reading as "quick" when it means "at the compressing end of the
+// accordion". Measured on the real race: 22 of 57 laps, 213 of the 776 cells the
+// grid ranks.
+//
+// Over the WHOLE enumeration, both directions: every lap the payload marks has a
+// rail and no other lap does. A count would pass on a rail drawn on the wrong
+// laps.
+const rails = await pacePage.evaluate(() => {
+  const rows = [...document.querySelectorAll(".pace-table tbody tr")];
+  const railed = [];
+  const plain = [];
+  for (const row of rows) {
+    const cell = row.querySelector("th.pace-lapcol");
+    const lap = Number(cell.textContent);
+    (cell.classList.contains("is-neutralised") ? railed : plain).push(lap);
+  }
+  return {
+    railed,
+    plain,
+    // The rail is a border, so a text-colour assertion could not see it.
+    width: railed.length
+      ? getComputedStyle(rows[railed[0] - 1].querySelector("th")).borderLeftWidth
+      : "0px",
+    legend: document.querySelectorAll(".pace-legend-rail").length,
+    title: rows[railed[0] - 1]?.querySelector("th")?.getAttribute("title") ?? "",
+  };
+});
+
+check(
+  JSON.stringify(rails.railed) === JSON.stringify([2, 3, 4, 5, 6]),
+  `the neutralised laps carry a rail and only those (${rails.railed.join(",")})`,
+);
+check(
+  rails.plain.length === PACE_LAPS - 5 && !rails.plain.includes(4),
+  `and the other ${rails.plain.length} laps carry none`,
+);
+check(
+  rails.width === "2px" && rails.legend === 1 && rails.title === "SAFETY CAR",
+  `the rail is drawn, keyed in the header and named on hover (${rails.width}, ${rails.legend} legend, "${rails.title}")`,
 );
 
 // --- The WIDTH axis, which the check above cannot see ---------------------
@@ -1712,6 +1869,20 @@ check(
 check(
   (traceLeader?.x?.[1] ?? 0) > 1,
   "a lap-1 retirement does not collapse the trace to nothing",
+);
+
+// The two control strips, whose targets were 15 px and 22 against the ~28 a mouse
+// wants - and these three buttons decide what the whole panel is measured against.
+const targets = await pacePage.evaluate(() => {
+  const height = (sel) => {
+    const el = document.querySelector(sel);
+    return el ? +el.getBoundingClientRect().height.toFixed(1) : 0;
+  };
+  return { tab: height(".tab"), ref: height(".ref") };
+});
+check(
+  targets.tab >= 26 && targets.ref >= 26,
+  `the tab and reference targets are big enough to hit (${targets.tab} px tab, ${targets.ref} px ref)`,
 );
 
 // A retired car keeps the laps he drove and gets NO point for the ones he did

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -1334,7 +1334,11 @@ function paceBulk() {
       // past +10 % of the session best, so a heat scale anchored on that best
       // paints four fifths of the grid one colour. A tidy fixture cannot tell
       // the two scales apart - this one can.
-      const neutralised = lap >= 2 && lap <= 6;
+      // Laps 2-6 are one range; lap 30 is a SECOND, ONE lap long. A live safety
+      // car looks like that - only the lap just revealed is marked - and an
+      // unpadded one-lap range is `from == to`, which paints a zero-width band.
+      // No fixture had one, so the case could not be seen.
+      const neutralised = (lap >= 2 && lap <= 6) || lap === 30;
       const green = 85 + (index % 9) * 0.4 + ((lap * 3) % 11) * 0.2;
       const time = onBoundary
         ? 119.96
@@ -1686,11 +1690,11 @@ const rails = await pacePage.evaluate(() => {
 });
 
 check(
-  JSON.stringify(rails.railed) === JSON.stringify([2, 3, 4, 5, 6]),
+  JSON.stringify(rails.railed) === JSON.stringify([2, 3, 4, 5, 6, 30]),
   `the neutralised laps carry a rail and only those (${rails.railed.join(",")})`,
 );
 check(
-  rails.plain.length === PACE_LAPS - 5 && !rails.plain.includes(4),
+  rails.plain.length === PACE_LAPS - 6 && !rails.plain.includes(4) && !rails.plain.includes(30),
   `and the other ${rails.plain.length} laps carry none`,
 );
 check(
@@ -1884,6 +1888,91 @@ check(
   targets.tab >= 26 && targets.ref >= 26,
   `the tab and reference targets are big enough to hit (${targets.tab} px tab, ${targets.ref} px ref)`,
 );
+
+// **The neutralised bands, and the one-lap case a live safety car produces.** A
+// lap is a POINT on this axis, so an unpadded one-lap range is `from == to` and
+// ECharts paints a zero-width area: measured live at lap 35 with only lap 33
+// revealed, the band was invisible exactly while the safety car was out, and its
+// label floated over the NOR/PIA end labels - the chart's only identification.
+const bands = await pacePage.evaluate(() => {
+  const el = document.querySelector(".trace-band-plot");
+  const series = el.__pitwallChart.getOption().series;
+  const area = series.map((s) => s.markArea).find(Boolean);
+  if (!area) return null;
+  return {
+    label: area.label?.position ?? "",
+    ranges: area.data.map(([from, to]) => [from.xAxis, to.xAxis, from.name ?? ""]),
+  };
+});
+if (bands === null) {
+  check(false, "the race trace carries the neutralised bands");
+} else {
+  const widths = bands.ranges.map(([from, to]) => +(to - from).toFixed(2));
+  check(
+    bands.ranges.length === 2 && widths.every((width) => width >= 1),
+    `both bands have real width, the one-lap one included (${JSON.stringify(widths)})`,
+  );
+  check(
+    bands.ranges.every(([, , name]) => name === "SAFETY CAR") &&
+      bands.label === "insideTopLeft",
+    `each band is named and labelled at its left edge (${bands.label}, ${JSON.stringify(bands.ranges.map((r) => r[2]))})`,
+  );
+}
+
+// The distance axis' ticks, which the four telemetry charts share. At 1265x593 a
+// plot is 152 px and the `1,000`-style labels are ~150 px of glyphs on ~120 px of
+// axis: they rendered as one unbroken digit string on the tab the window OPENS on.
+// Measured as WIDTH against the axis, in the axis' own font, not as a string
+// comparison - a formatter that shortened the labels and still did not fit would
+// pass a string test.
+{
+  const narrowCtx = await browser.newContext({ viewport: { width: 1265, height: 593 } });
+  const narrow = await narrowCtx.newPage();
+  narrow.on("pageerror", (error) => failures.push(`pageerror(axis): ${error.message}`));
+  await narrow.addInitScript(
+    ([payload, bulk, live]) => {
+      window.pywebview = { api: {
+        get_tick: async (s) => (s === payload.seq ? null : payload),
+        get_bulk: async (r) => (r === bulk.rev ? null : bulk),
+        get_live_lap: async (r) => (r === live.rev ? null : live),
+        get_connection: async () => "Connected",
+      } };
+    },
+    [tick(1, { drivers: paceField(), order: TOWER_ORDER }), paceBulk(), towerLive()],
+  );
+  await narrow.goto(`http://127.0.0.1:${server.address().port}/data.html`, {
+    waitUntil: "domcontentloaded",
+  });
+  await narrow.waitForSelector(".trace-plot canvas", { timeout: 5000 });
+  await narrow.waitForTimeout(500);
+
+  const axis = await narrow.evaluate(() => {
+    const el = document.querySelector(".trace-plot");
+    const chart = el.__pitwallChart;
+    const option = chart.getOption();
+    const x = option.xAxis[0];
+    const ticks = chart
+      .getModel()
+      .getComponent("xAxis", 0)
+      .axis.scale.getTicks()
+      .map((entry) => (typeof entry === "object" ? entry.value : entry));
+    const format = x.axisLabel.formatter;
+    // The bounds are not labelled on a locked axis (`valueAxis`), so they are not
+    // glyphs on the axis and must not be counted as if they were.
+    const shown = x.axisLabel.showMinLabel === false ? ticks.slice(1, -1) : ticks;
+    const labels = shown.map((value) => (format ? format(value) : String(value)));
+    const ruler = document.createElement("canvas").getContext("2d");
+    ruler.font = `${x.axisLabel.fontSize}px ${getComputedStyle(document.body).fontFamily}`;
+    const glyphs = labels.reduce((total, text) => total + ruler.measureText(text).width, 0);
+    const span = el.clientWidth - (option.grid[0].left + option.grid[0].right);
+    return { labels, glyphs: +glyphs.toFixed(1), span, plot: el.clientWidth };
+  });
+  check(
+    axis.glyphs < axis.span,
+    `the distance ticks fit their axis at the narrow client (${axis.labels.join(" ")} = ${axis.glyphs} px on ${axis.span} px of a ${axis.plot} px plot)`,
+  );
+  await narrowCtx.close();
+}
 
 // A retired car keeps the laps he drove and gets NO point for the ones he did
 // not. These three have no crossings at all, so their series must be EMPTY -

--- a/src/pitwall/ui/src/features/data/BestsPanel.tsx
+++ b/src/pitwall/ui/src/features/data/BestsPanel.tsx
@@ -90,10 +90,19 @@ export function BestsPanel({ bulk }: { bulk: Bulk | null }) {
   return (
     <section className="bests card" ref={setCard}>
       {/* The compact form drops the header ROW too, not just the ranks: it puts
-       * the title on the same line as the values. Keeping a separate 16 px header
-       * plus its 8 px gap left the card 65 px tall in a 63 px slot - fighting for
-       * two pixels, which a font fallback would take straight back. One line has
-       * 24 px of air. */}
+       * the title into the same flex run as the values. Keeping a separate 16 px
+       * header plus its 8 px gap left the card 65 px tall in a 63 px slot -
+       * fighting for two pixels, which a font fallback would take straight back.
+       *
+       * **It is not literally one line, and the version of this comment that said
+       * "one line has 24 px of air" was wrong.** Measured at the 1265 x 593 client:
+       * `.bests-leaders` is 40 px, two wrapped flex lines, with THEO on the second
+       * one - where its `margin-left: auto` happens to read as a deliberate footer.
+       * The card comes to 62 px in a 63 px slot, so it FITS, but the margin is one
+       * wrap: a slightly narrower client or a wider fallback font puts a second
+       * entry on line two and pushes THEO under an unannounced fold, which is the
+       * failure this whole degradation exists to remove. The next step down the
+       * ladder, if that ever bites, is to drop the VALUES and keep the codes. */}
       {ranked ? (
         <>
           <header className="bests-header">

--- a/src/pitwall/ui/src/features/data/RacePaceGrid.tsx
+++ b/src/pitwall/ui/src/features/data/RacePaceGrid.tsx
@@ -160,6 +160,14 @@ export function RacePaceGrid({ bulk, order }: { bulk: Bulk | null; order: string
           {/* Said out loud, because a coarser number that nobody was told about
               is the same silence the truncation was. */}
           {coarse ? " · times to the second at this width" : ""}
+          {/* And the rail needs a key, or it is a decoration. Only shown when
+              there is a marked lap on the panel at all. */}
+          {grid.neutralised.some(Boolean) ? (
+            <>
+              {" · "}
+              <span className="pace-legend-rail" /> neutralised
+            </>
+          ) : null}
         </span>
         <span className="pace-range">
           {grid.laps.length ? `LAPS ${first}-${last} of ${total}` : "no laps revealed"}
@@ -178,7 +186,20 @@ export function RacePaceGrid({ bulk, order }: { bulk: Bulk | null; order: string
           <tbody>
             {grid.rows.map((row, index) => (
               <tr key={grid.laps[index]}>
-                <th className="pace-lapcol">{grid.laps[index]}</th>
+                {/* The rail on the lap number is the whole marker: on a
+                 * neutralised lap the colour thirds rank the safety car's queue,
+                 * not pace, and 213 of the 776 cells this grid ranks on the real
+                 * race sit on one. It is a BORDER rather than a text colour
+                 * because amber text one column right already means "slowest
+                 * third" - one hue, but a different channel, so the two cannot be
+                 * confused. The label rides in the title for the reader who
+                 * wonders which neutralisation it was. */}
+                <th
+                  className={`pace-lapcol${grid.neutralised[index] ? " is-neutralised" : ""}`}
+                  title={grid.neutralised[index] ?? undefined}
+                >
+                  {grid.laps[index]}
+                </th>
                 {row.map((cell, column) => (
                   <td key={grid.columns[column]} className={`is-${cell.tone}`}>
                     {cell.text}

--- a/src/pitwall/ui/src/features/data/RaceTraceChart.tsx
+++ b/src/pitwall/ui/src/features/data/RaceTraceChart.tsx
@@ -39,8 +39,9 @@
 import { useMemo, useState } from "react";
 import type { EChartsOption } from "echarts";
 
-import { AXIS_TEXT, CURSOR_LINE, useEChart, valueAxis } from "../../lib/chart";
+import { AXIS_TEXT, CURSOR_LINE, NEUTRALISED_BAND, useEChart, valueAxis } from "../../lib/chart";
 import { driverStatus } from "../../lib/driverStatus";
+import { neutralisedLaps, neutralisedRanges } from "../../lib/neutralised";
 import { raceTrace } from "../../lib/raceTrace";
 import type { TraceReference } from "../../lib/raceTrace";
 import type { ArcadeState, Bulk } from "../../lib/bridge";
@@ -88,6 +89,11 @@ export function RaceTraceChart({ bulk, arcade }: { bulk: Bulk | null; arcade: Ar
     [signature],
   );
 
+  // Same source as the pace grid's rail, one tab away, so the two panels cannot
+  // disagree about which laps were neutralised. Memoised on the reveal, not on
+  // `arcade`, for the reason the trace itself is.
+  const neutral = useMemo(() => neutralisedRanges(neutralisedLaps(bulk)), [bulk?.rev]);
+
   const option = useMemo<EChartsOption>(() => {
     const first = trace.laps[0] ?? 1;
     const last = trace.laps[trace.laps.length - 1] ?? 1;
@@ -131,6 +137,33 @@ export function RaceTraceChart({ bulk, arcade }: { bulk: Bulk | null; arcade: Ar
                 symbol: "none" as const,
                 label: { show: false },
                 data: [{ yAxis: 0, lineStyle: { color: CURSOR_LINE, width: 1, type: "solid" } }],
+              }
+            : undefined,
+          // **The neutralised lap ranges, shaded, and they explain the shape the
+          // panel already draws.** Melbourne's trace has a V across laps 5-8 and
+          // a long convergence from 33 that are the field bunching behind a
+          // safety car, not anybody's pace; unlabelled they read as racing. Hung
+          // off the same first series as the zero line, for the same reason.
+          //
+          // A translucent fill, never a stroke: a dashed line means
+          // BROADCAST-TIER one tab away and a solid thin vertical is the current
+          // lap. The band is a fifth channel rather than a second meaning for a
+          // taken one.
+          markArea: line.code === trace.lines[0]?.code && neutral.length
+            ? {
+                silent: true,
+                itemStyle: { color: NEUTRALISED_BAND },
+                label: {
+                  show: true,
+                  position: "insideTop" as const,
+                  color: AXIS_TEXT,
+                  fontSize: 8,
+                  formatter: (params: { name?: string }) => params.name ?? "",
+                },
+                data: neutral.map((band) => [
+                  { name: band.label, xAxis: band.from },
+                  { xAxis: band.to },
+                ]),
               }
             : undefined,
           endLabel: {

--- a/src/pitwall/ui/src/features/data/RaceTraceChart.tsx
+++ b/src/pitwall/ui/src/features/data/RaceTraceChart.tsx
@@ -155,14 +155,25 @@ export function RaceTraceChart({ bulk, arcade }: { bulk: Bulk | null; arcade: Ar
                 itemStyle: { color: NEUTRALISED_BAND },
                 label: {
                   show: true,
-                  position: "insideTop" as const,
+                  // At the band's LEFT edge, not its top centre: a band that ends
+                  // at the plot's right - which is what a LIVE neutralisation looks
+                  // like - put its label straight on top of the NOR/PIA end labels,
+                  // and those labels are the chart's only identification.
+                  position: "insideTopLeft" as const,
                   color: AXIS_TEXT,
                   fontSize: 8,
                   formatter: (params: { name?: string }) => params.name ?? "",
                 },
+                // **Padded to the lap's own cell, because a lap is a POINT on this
+                // axis.** Unpadded, a one-lap range is `from == to` and ECharts
+                // paints a zero-width area: a safety car that has just come out -
+                // the moment the band exists for - rendered NOTHING while its label
+                // floated over the driver codes. Measured live at lap 35 with only
+                // lap 33 revealed as neutralised. The half-lap also puts a boundary
+                // lap's data point INSIDE its band rather than on the edge.
                 data: neutral.map((band) => [
-                  { name: band.label, xAxis: band.from },
-                  { xAxis: band.to },
+                  { name: band.label, xAxis: band.from - 0.5 },
+                  { xAxis: band.to + 0.5 },
                 ]),
               }
             : undefined,

--- a/src/pitwall/ui/src/features/data/StatusStrip.tsx
+++ b/src/pitwall/ui/src/features/data/StatusStrip.tsx
@@ -79,8 +79,24 @@ function TrackStatusChip({
 }) {
   if (!label || !colour) return <span className="strip-chip is-unknown">NO STATUS</span>;
   const rgb = `rgb(${colour[0]}, ${colour[1]}, ${colour[2]})`;
+  // **A non-green status is FILLED, and that is the whole of the window's
+  // reaction to a safety car.** Before this it was an outline chip swapping its
+  // text - `GREEN` measured 54.3 x 18 px, `SAFETY CAR` about 86 x 18 - inside a
+  // 1465 x 28 strip, and nothing else on the window changed at all. Two captures
+  // of the same window, one green and one under the safety car, differed in no
+  // element but that one; glanced at from the arcade beside it, the race's most
+  // decision-dense state and its calmest looked the same.
+  //
+  // The colour is the wire's own (`track_status_color`, decoded by the producer
+  // out of `palette.py`), so this spends no new constant, and it degrades
+  // honestly: `NO STATUS` above stays the dim unknown chip rather than borrowing
+  // the weight, because an absence is not an alarm.
+  const green = label === "GREEN";
   return (
-    <span className="strip-chip" style={{ color: rgb, borderColor: rgb }}>
+    <span
+      className={green ? "strip-chip" : "strip-chip is-filled"}
+      style={green ? { color: rgb, borderColor: rgb } : { background: rgb, borderColor: rgb }}
+    >
       {label}
     </span>
   );

--- a/src/pitwall/ui/src/features/data/StatusStrip.tsx
+++ b/src/pitwall/ui/src/features/data/StatusStrip.tsx
@@ -91,6 +91,14 @@ function TrackStatusChip({
   // out of `palette.py`), so this spends no new constant, and it degrades
   // honestly: `NO STATUS` above stays the dim unknown chip rather than borrowing
   // the weight, because an absence is not an alarm.
+  //
+  // It is a DIFFERENT amber from the one the pace grid's rail and the race trace's
+  // band use for the same state - the wire sends `SAFETY CAR` as rgb(255,140,0)
+  // while those two use `palette.WARNING` #f59e0b. Both names live in `palette.py`
+  // so neither is a stray literal, and at a glance the two are indistinguishable;
+  // it is recorded here so the next reader finds a decision rather than a bug. The
+  // wire's colour is the right one to fill with, because it is the one the arcade
+  // paints its own banner in on the screen beside this window.
   const green = label === "GREEN";
   return (
     <span

--- a/src/pitwall/ui/src/features/data/TraceChart.tsx
+++ b/src/pitwall/ui/src/features/data/TraceChart.tsx
@@ -97,13 +97,28 @@ export function TraceChart(props: TraceChartProps) {
       grid: { left: 44, right: 12, top: 8, bottom: 36, containLabel: false },
       xAxis: valueAxis({ name: "Distance (m)", nameGap: 20, min: 0, max: xMax }),
       yAxis: valueAxis({ min: yRange[0], max: yRange[1] }),
+      // **The RIVAL is declared first, so the own car paints on top of it.**
+      // ECharts paints in declaration order and this was the other way round,
+      // which put the coarse broadcast-tier dashes over the pit-wall-grade trace
+      // on all four charts - and it is the exact inverse of the rule the race
+      // trace builds deliberately one tab away ("our own car moved LAST so it
+      // draws on top of the nineteen it has to be picked out from"). It shows
+      // wherever the two cars run comparable numbers, which is precisely when the
+      // comparison is worth making: measured on a full lap of the real payload,
+      // the Speed and Throttle plots read as one amber dashed line with slivers
+      // of blue under it.
+      //
+      // The reference marks move with the first series, because that is where
+      // they hang. They are `silent` and geometric - a `yAxis: 0` baseline and an
+      // `xAxis` cursor - so they do not care which series carries them, and the
+      // rival series exists on every chart even when it holds no data.
       series: [
         {
           type: "line",
-          name: "main",
-          data: mainAsZeroLine ? [] : main,
-          lineStyle: { color: mainColour, width: 2 },
-          itemStyle: { color: mainColour },
+          name: "rival",
+          data: rivalCode ? rival : [],
+          lineStyle: { color: rivalColour, width: 2, type: "dashed" },
+          itemStyle: { color: rivalColour },
           symbol: "none",
           markLine: marks.length
             ? { silent: true, symbol: "none", label: { show: false }, data: marks }
@@ -111,10 +126,10 @@ export function TraceChart(props: TraceChartProps) {
         },
         {
           type: "line",
-          name: "rival",
-          data: rivalCode ? rival : [],
-          lineStyle: { color: rivalColour, width: 2, type: "dashed" },
-          itemStyle: { color: rivalColour },
+          name: "main",
+          data: mainAsZeroLine ? [] : main,
+          lineStyle: { color: mainColour, width: 2 },
+          itemStyle: { color: mainColour },
           symbol: "none",
         },
       ],

--- a/src/pitwall/ui/src/features/data/TraceChart.tsx
+++ b/src/pitwall/ui/src/features/data/TraceChart.tsx
@@ -95,7 +95,20 @@ export function TraceChart(props: TraceChartProps) {
       animation: false,
       animationDurationUpdate: 0,
       grid: { left: 44, right: 12, top: 8, bottom: 36, containLabel: false },
-      xAxis: valueAxis({ name: "Distance (m)", nameGap: 20, min: 0, max: xMax }),
+      // `1k`-style ticks, because five `1,000`-style labels do not fit. Measured at
+      // the 1265 x 593 client: the plot is 152 px, the axis about 120, and the five
+      // labels are ~150 px of glyphs - they rendered as one unbroken digit string
+      // on all four charts, on the tab this window opens on. The axis name already
+      // says the unit, so `1k` is not ambiguous, and the same form is used at both
+      // clients: two tick vocabularies for one axis depending on the screen is its
+      // own small wrongness.
+      xAxis: valueAxis({
+        name: "Distance (m)",
+        nameGap: 20,
+        min: 0,
+        max: xMax,
+        label: (value) => `${value / 1000}k`,
+      }),
       yAxis: valueAxis({ min: yRange[0], max: yRange[1] }),
       // **The RIVAL is declared first, so the own car paints on top of it.**
       // ECharts paints in declaration order and this was the other way round,

--- a/src/pitwall/ui/src/features/data/TrackRing.tsx
+++ b/src/pitwall/ui/src/features/data/TrackRing.tsx
@@ -90,7 +90,17 @@ export function TrackRing({ arcade }: { arcade: ArcadeState }) {
     // line - a position a real car can hold, which is the sentinel collision
     // this repo has already paid for once.
     if (car.rel_dist === null) {
-      blind.push(code);
+      // **Only a car that is still RUNNING goes on the blind list.** The line
+      // exists to flag a live car the telemetry lost, which is a real alarm; it
+      // used to collect retirements too, and HAD - who has no telemetry rows at
+      // all on this race - lit it from lap 1 to lap 57. It was in every one of
+      // the nine captures, in every state. A permanently lit alarm is furniture,
+      // and the day a live car goes blind the alarm has already been trained
+      // away - which is the failure `isProvisional` names in as many words one
+      // panel over ("a permanent PROVISIONAL says nothing, which is worse than
+      // not having it"). A retired car is already carried by the tower's OUT and
+      // by the legend's hollow dot.
+      if (driverStatus(car) !== "out") blind.push(code);
       continue;
     }
     dots.push({

--- a/src/pitwall/ui/src/lib/bridge.ts
+++ b/src/pitwall/ui/src/lib/bridge.ts
@@ -109,6 +109,21 @@ export interface LapRow {
   tyre_life: number | null;
   stint: number | null;
   track_status: string | null;
+  /**
+   * The digits decoded to the label for "the field was NOT racing freely on this
+   * lap" - SAFETY CAR, VSC or RED FLAG - and `null` for green, for a lone yellow
+   * (sector-local: the cars away from it are racing) and for an unknown status.
+   *
+   * Decoded by the producer, from `src/arcade/track_status.py`, for the same
+   * reason `driver_colors` and the tick's own `track_status_label` are: the
+   * priority order and the four labels are a project rule, and a client testing
+   * for a `4` would be the second copy of it in another language.
+   *
+   * Non-null means a per-lap pace ranking over this lap ranks the safety car's
+   * queue and not pace. Measured on Melbourne 2025: 22 of 57 laps, and 213 of
+   * the 776 cells the grid ranks.
+   */
+  neutralised: string | null;
   pit_in: boolean;
   pit_out: boolean;
   /** A deleted time. Render struck; it never counts towards a best. */

--- a/src/pitwall/ui/src/lib/chart.ts
+++ b/src/pitwall/ui/src/lib/chart.ts
@@ -48,11 +48,21 @@ export const CURSOR_LINE = "#9ca3af";
  * A translucent FILL rather than a stroke, and that is the constraint rather
  * than a preference: on this window a dashed line already means broadcast-tier
  * data and a solid thin vertical is the current-lap cursor, so a band needed a
- * channel of its own. 12 % reads behind twenty lines without competing with any
- * of them - the alpha is the only number here chosen by eye, and it is a
- * background rather than a value, which is the one place that is allowed.
+ * channel of its own.
+ *
+ * **8 %, and 12 % was measurably too much.** The alpha is the one number in this
+ * file chosen for how it looks, so it is the one that needed arithmetic rather
+ * than an eye. Composited over the panel - rgb(24,22,51) under rgb(245,158,11) -
+ * the red channel overtakes the blue at alpha 0.1034: past that the surface stops
+ * being a tinted navy and becomes a warm brown, so a third of the plot reads as a
+ * different MATERIAL and the band ends up with more visual mass than any of the
+ * twenty lines it is annotating. 0.12 composited to rgb(51,38,46), the wrong side.
+ * 0.08 gives rgb(42,33,48): still plainly a band, still blue.
+ *
+ * The `SAFETY CAR` label and the pace grid's keyed rail carry the meaning, so the
+ * fill does not have to shout to be understood.
  */
-export const NEUTRALISED_BAND = "rgba(245, 158, 11, 0.12)";
+export const NEUTRALISED_BAND = "rgba(245, 158, 11, 0.08)";
 
 /**
  * Mount an ECharts instance on a div and push options into it imperatively.
@@ -114,6 +124,17 @@ export interface AxisSpec {
    * visually noisy and hides where on the lap the car actually is.
    */
   scale?: boolean;
+  /**
+   * Shorten the tick labels. Optional because only the distance axis needs it:
+   * at the 1265 x 593 client a telemetry plot is 152 px wide, its axis about 120,
+   * and five labels of `1,000`-style text at 10 px mono are ~150 px of glyphs -
+   * measured, they rendered as `1,0002,0003,0004,0005,000`, one unreadable run on
+   * all four charts, on the tab the window OPENS on.
+   *
+   * Per call rather than inside `valueAxis`, because the race trace's x axis is
+   * LAPS and a `k` suffix there would be nonsense.
+   */
+  label?: (value: number) => string;
   min?: number;
   max?: number;
 }
@@ -150,6 +171,7 @@ export function valueAxis(spec: AxisSpec = {}) {
       fontSize: 10,
       showMinLabel: locked ? false : undefined,
       showMaxLabel: locked ? false : undefined,
+      formatter: spec.label,
     },
     splitLine: { lineStyle: { color: SPLIT_LINE } },
   };

--- a/src/pitwall/ui/src/lib/chart.ts
+++ b/src/pitwall/ui/src/lib/chart.ts
@@ -42,6 +42,17 @@ export const SPLIT_LINE = "rgba(255,255,255,0.06)";
  * competes with the four traces it is supposed to be annotating.
  */
 export const CURSOR_LINE = "#9ca3af";
+/**
+ * `palette.WARNING` at 12 % - the shaded lap range the field was neutralised on.
+ *
+ * A translucent FILL rather than a stroke, and that is the constraint rather
+ * than a preference: on this window a dashed line already means broadcast-tier
+ * data and a solid thin vertical is the current-lap cursor, so a band needed a
+ * channel of its own. 12 % reads behind twenty lines without competing with any
+ * of them - the alpha is the only number here chosen by eye, and it is a
+ * background rather than a value, which is the one place that is allowed.
+ */
+export const NEUTRALISED_BAND = "rgba(245, 158, 11, 0.12)";
 
 /**
  * Mount an ECharts instance on a div and push options into it imperatively.

--- a/src/pitwall/ui/src/lib/neutralised.ts
+++ b/src/pitwall/ui/src/lib/neutralised.ts
@@ -1,0 +1,58 @@
+/**
+ * Which laps the field was NOT racing freely on, from the label the wire carries.
+ *
+ * **One module because TWO panels need it**, and a second reduction over
+ * `bulk.drivers` is the twin this repo pays for more than any other defect: the
+ * race-pace grid marks the lap in its own column and the race trace shades the
+ * same lap range on its x axis, and two panels disagreeing about which laps were
+ * neutralised would be worse than neither marking them.
+ *
+ * The rule itself is not here. `LapRow.neutralised` arrives decoded by
+ * `src/arcade/track_status.py`, so nothing in TypeScript knows that a `4` means
+ * a safety car.
+ */
+
+import type { Bulk } from "./bridge";
+
+/**
+ * `lap -> label`, for every revealed lap any car was neutralised on.
+ *
+ * **ANY row, not a majority of them**, and the conservative direction is the
+ * point: the label is a warning that this lap's ranking is not about pace, and a
+ * lap where the safety car was out for part of the field is exactly as unsafe to
+ * read as one where it was out for all of it. On the real race the difference is
+ * three laps - 33, 34 and 47 carry mixed statuses - and on those the SC digit is
+ * on the majority of rows anyway.
+ *
+ * Generated rows are skipped: FastF1 synthesised them for a car that never
+ * finished the lap, and they count towards nothing anywhere else either.
+ */
+export function neutralisedLaps(bulk: Bulk | null): Map<number, string> {
+  const laps = new Map<number, string>();
+  if (!bulk?.available) return laps;
+  for (const driver of Object.values(bulk.drivers)) {
+    for (const row of driver.laps) {
+      if (row.generated || row.neutralised === null) continue;
+      if (!laps.has(row.lap)) laps.set(row.lap, row.neutralised);
+    }
+  }
+  return laps;
+}
+
+/**
+ * The neutralised laps as CONTIGUOUS ranges, which is what a chart shades.
+ *
+ * Twenty-two separate one-lap bands over a 57-lap axis is visual noise; the same
+ * laps as three bands is a caption. Melbourne 2025 collapses to exactly three:
+ * 1-7, 33-41 and 46-51.
+ */
+export function neutralisedRanges(laps: Map<number, string>): { from: number; to: number; label: string }[] {
+  const sorted = [...laps.keys()].sort((left, right) => left - right);
+  const ranges: { from: number; to: number; label: string }[] = [];
+  for (const lap of sorted) {
+    const last = ranges[ranges.length - 1];
+    if (last && lap === last.to + 1) last.to = lap;
+    else ranges.push({ from: lap, to: lap, label: laps.get(lap) as string });
+  }
+  return ranges;
+}

--- a/src/pitwall/ui/src/lib/racePace.ts
+++ b/src/pitwall/ui/src/lib/racePace.ts
@@ -33,6 +33,7 @@
  */
 
 import type { Bulk, LapRow } from "./bridge";
+import { neutralisedLaps } from "./neutralised";
 import { sessionBests } from "./sessionBests";
 
 /**
@@ -51,6 +52,13 @@ export interface PaceCell {
 export interface PaceGrid {
   /** Lap numbers, ascending. Empty until something is revealed. */
   laps: number[];
+  /**
+   * `laps[i]`'s neutralisation label, or null when the field was racing.
+   *
+   * Parallel to `laps` rather than folded into the cells: the claim is about the
+   * LAP, and putting it on each of twenty cells would invite twenty answers.
+   */
+  neutralised: (string | null)[];
   /** Driver codes in WIRE order, which is the only order that holds mid-lap. */
   columns: string[];
   /** `rows[i][j]` is lap `laps[i]` for driver `columns[j]`. */
@@ -243,7 +251,7 @@ function tone(times: number[], value: number): PaceTone {
  * and at most instants the field spans two or three different laps.
  */
 export function racePaceGrid(bulk: Bulk | null, order: string[], coarse = false): PaceGrid {
-  if (!bulk?.available) return { laps: [], columns: [...order], rows: [] };
+  if (!bulk?.available) return { laps: [], neutralised: [], columns: [...order], rows: [] };
   const columns = stableColumns(bulk, order);
 
   const byDriver = new Map<string, Map<number, LapRow>>();
@@ -258,6 +266,11 @@ export function racePaceGrid(bulk: Bulk | null, order: string[], coarse = false)
   }
 
   const laps = Array.from({ length: lastLap }, (_, index) => index + 1);
+  // **The ranking is unchanged on these laps, and the marker is why that is
+  // honest.** Excluding them would leave holes in a history panel; re-ranking
+  // them against something else would invent a scale. What was wrong was
+  // rendering the thirds with nothing saying the thirds are the queue.
+  const neutral = neutralisedLaps(bulk);
   const ranked = rankedByLap(byDriver, laps);
   const fastest = sessionBests(bulk).lap_time[0] ?? null;
 
@@ -270,7 +283,20 @@ export function racePaceGrid(bulk: Bulk | null, order: string[], coarse = false)
       // the P0 alive in the one place the reader most needs the whole word -
       // `IN PI` ran straight into its neighbour as `IN PIIN PI`.
       if (row.pit_in) return { text: coarse ? "PIT" : "IN PIT", tone: "pit" as PaceTone };
-      if (row.pit_out) return { text: "OUT", tone: "out" as PaceTone };
+      // **`P.EXIT`, not `OUT`, and the tower is why.** `TimingTower`'s `lastCell`
+      // renders a RETIRED car as `OUT` and says in as many words that an out-lap
+      // gets `PIT EXIT` "rather than borrowing the same word for a car that is
+      // very much still racing". This grid borrowed it anyway, in the same
+      // window: on the real race BEA's lap-1 cell read `OUT` three rows above the
+      // tower printing `OUT` for SAI, DOO and HAD, and lap 5 was a full-field red
+      // `OUT` row - the safety car's pit-lane pass, which in tower vocabulary is
+      // seventeen simultaneous retirements. The tower fixed this collision; this
+      // was the copy that never got the fix.
+      //
+      // Abbreviated because the column cannot hold the tower's eight glyphs:
+      // `PIT EXIT` measures 43 px against 38.75 at the wide client, so it would
+      // have arrived clipped. `P.EXIT` is 34, and `EXIT` fits the coarse column.
+      if (row.pit_out) return { text: coarse ? "EXIT" : "P.EXIT", tone: "out" as PaceTone };
       if (row.lap_time === null) return EMPTY;
       const text = paceLabel(row.lap_time, coarse);
       // A deleted time is shown and struck through, as the tower already shows
@@ -290,5 +316,5 @@ export function racePaceGrid(bulk: Bulk | null, order: string[], coarse = false)
       return { text, tone: tone(ranked.get(lap) ?? [], row.lap_time) };
     }),
   );
-  return { laps, columns, rows };
+  return { laps, neutralised: laps.map((lap) => neutral.get(lap) ?? null), columns, rows };
 }

--- a/src/pitwall/ui/src/styles/data.css
+++ b/src/pitwall/ui/src/styles/data.css
@@ -94,6 +94,18 @@
   color: #f59e0b;
 }
 
+/* A non-green track status is FILLED, not outlined. The background is the wire's
+ * own `track_status_color` and the text is the window's ground, so the chip reads
+ * as a state rather than as a label - the difference between "there is a safety
+ * car" being 18 px of outlined text and being the one loud thing on the strip.
+ * `--qt-bg` rather than black: measured against every label the producer can
+ * emit, the ground clears AA on all of them - YELLOW FLAG 12.08:1, VSC 8.61,
+ * SAFETY CAR 7.93, RED FLAG 4.92, the dimmest of the four and still over 4.5. */
+.strip-chip.is-filled {
+  color: var(--qt-bg);
+  font-weight: 800;
+}
+
 .strip-spacer {
   flex: 1 1 auto;
 }
@@ -759,11 +771,18 @@
   gap: 6px;
   padding: 10px;
   min-height: 0;
-  /* Scrollbars are hidden globally (`qt-base.css`), so an overflow here has no
-   * affordance at all. The list is newest-first for that reason: what falls
-   * off the bottom is the OLDEST, which is what a ticker is expected to lose,
-   * and the header's count says how many there are so the cut is never
-   * silent. */
+  /* The CARD clips; the LIST below scrolls. Both used to be `overflow: hidden`,
+   * which made this the one panel in the window whose content was genuinely
+   * unreachable: measured on the live page, 10 of 46 events visible, 344 px of
+   * clientHeight against 1379 of scrollHeight, and no user input that could
+   * reach the other 36 - setting `scrollTop` from the console worked, so the
+   * content was there and only the reader had no path to it.
+   *
+   * That is not the window's hidden-scrollbar rule. `qt-base.css` hides the
+   * CHROME and keeps bodies scrollable, in as many words: "a wheel, a trackpad,
+   * a touch drag and the keyboard all still reach the content". This panel was
+   * the exception, and the header's count said how many events EXIST, not that
+   * most of them could not be read. */
   overflow: hidden;
 }
 
@@ -806,8 +825,12 @@
   list-style: none;
   margin: 0;
   padding: 0;
+  flex: 1 1 auto;
   min-height: 0;
-  overflow: hidden;
+  /* The one declaration that gives the reader the other 36 events back. Newest
+   * first already puts the fold where it belongs, and the scrollbar stays
+   * invisible, so nothing about the panel's pixels changes. */
+  overflow-y: auto;
 }
 
 .radio-row {
@@ -844,8 +867,16 @@
 }
 
 /* The public feed, tagged exactly as band 4 tags a pinned rival's trace: the
- * same WARNING the rival chip uses, so one colour means one tier across the
- * whole window. */
+ * same WARNING the rival chip uses.
+ *
+ * **This used to end "so one colour means one tier across the whole window",
+ * and that clause was false.** `#f59e0b` is five things here: broadcast tier on
+ * this tag and on the rival's chip, the PROVISIONAL warning, the tower's
+ * slower-than-own-best sector, the pace grid's slowest third, and now the
+ * neutralised-lap rail. Each surface disambiguates locally, which is why it costs
+ * little in practice - what it cost was the safety car, which had no loud amber
+ * left to reach for and got a FILLED chip instead (`.strip-chip.is-filled`), so
+ * weight rather than hue separates the state of the race from an annotation. */
 .radio-tier {
   color: #f59e0b;
   font-family: var(--qt-mono);
@@ -882,6 +913,10 @@
   gap: 4px;
 }
 
+/* 5/12 rather than 3/10: these were 22 px tall and the reference strip's buttons
+ * 15, against the ~28-32 px a mouse target wants - and the three reference
+ * buttons change what the whole race trace MEANS, since they move the zero line.
+ * Pure whitespace; both headers have slack at both client sizes. */
 .tab {
   background: none;
   border: 1px solid var(--qt-border);
@@ -892,7 +927,7 @@
   font-size: 10px;
   font-weight: 700;
   letter-spacing: 1px;
-  padding: 3px 10px;
+  padding: 5px 12px;
 }
 
 .tab.is-active {
@@ -1027,6 +1062,24 @@
   width: 26px;
 }
 
+/* The lap the field was NOT racing on. A 2 px rail rather than a text colour:
+ * amber TEXT one column right already means "slowest third", and the same hue in
+ * a different channel cannot be mistaken for it. It costs 2 px of a 26 px column
+ * that holds two digits at 9 px, so nothing moves. */
+.pace-table th.pace-lapcol.is-neutralised {
+  border-left: 2px solid #f59e0b;
+}
+
+/* The rail's key, in the subtitle. Without it the rail is a decoration. */
+.pace-legend-rail {
+  display: inline-block;
+  width: 2px;
+  height: 8px;
+  background: #f59e0b;
+  vertical-align: baseline;
+  margin-right: 3px;
+}
+
 /* Purple is the session's outright fastest lap, the same rule and the same
  * colour the tower's sector cells use. */
 .pace-table td.is-best {
@@ -1058,11 +1111,22 @@
   text-decoration: line-through;
 }
 
-/* The in-lap and the out-lap, red in place of the time, as a timing screen
- * shows them. */
-.pace-table td.is-pit,
-.pace-table td.is-out {
+/* The in-lap in place of the time, as a timing screen shows it. DANGER red is
+ * kept for the lap you cannot unwind - the car is in the pit lane - and NOT for
+ * the out-lap, which is a car rejoining a race. Both were red, so laps 2-4 of
+ * Melbourne rendered as three full-field red rows and read as a crisis; and this
+ * red is the same one band 1's Disconnected chip uses. Measured, it is also
+ * 4.25:1 on the banded columns at 9 px, under the 4.5 floor for this size. */
+.pace-table td.is-pit {
   color: #ef4444;
+}
+
+/* The out-lap: WARNING, the same amber the slowest third uses. The hue does not
+ * have to separate them because the TEXT does - `P.EXIT` against `1:33.5` - and
+ * spending a sixth meaning on amber is cheaper than telling a reader that a car
+ * rejoining the race is the same kind of event as one sitting in the box. */
+.pace-table td.is-out {
+  color: #f59e0b;
 }
 
 .pace-table td.is-none {
@@ -1112,7 +1176,12 @@
   font-size: 9px;
   font-weight: 700;
   letter-spacing: 0.5px;
-  padding: 1px 6px;
+  /* See `.tab`: 15 px was the smallest target on the window and it sits on the
+   * control that decides what the race trace is measured against. 6/9 rather than
+   * 4/8 so the three land on the same 26 px as the tab strip above them - two
+   * control rows of different heights on one panel is its own small wrongness. */
+  padding: 6px 9px;
+  line-height: 12px;
 }
 
 .ref.is-active {

--- a/src/pitwall/ui/src/styles/data.css
+++ b/src/pitwall/ui/src/styles/data.css
@@ -347,9 +347,11 @@
   min-width: 0;
 }
 
-/* The compact form: one line of purple holders plus the theoretical, for the
- * client where the ranked panel does not fit at all. Spends width, which this
- * column has 630 px of, instead of the height it has 63 of. */
+/* The compact form: the purple holders plus the theoretical, for the client where
+ * the ranked panel does not fit at all. Spends width, which this column has 630 px
+ * of, instead of the height it has 63 of. Measured, it wraps to TWO 17 px lines at
+ * 1265 and the card comes to 62 px in a 63 px slot - it fits, with about one wrap
+ * of margin. See `BestsPanel`'s note. */
 .bests-leaders {
   display: flex;
   align-items: baseline;

--- a/src/pitwall/ui/src/styles/data.css
+++ b/src/pitwall/ui/src/styles/data.css
@@ -915,10 +915,17 @@
   gap: 4px;
 }
 
-/* 5/12 rather than 3/10: these were 22 px tall and the reference strip's buttons
+/* 6/12 rather than 3/10: these were 22 px tall and the reference strip's buttons
  * 15, against the ~28-32 px a mouse target wants - and the three reference
  * buttons change what the whole race trace MEANS, since they move the zero line.
- * Pure whitespace; both headers have slack at both client sizes. */
+ * Pure whitespace; both headers have slack at both client sizes.
+ *
+ * **`line-height` is pinned because the padding alone is not the height.** With
+ * the line-height left to the font this measured 26 px on the machine it was
+ * written on and 23 in CI, where JetBrains Mono is not installed - the guard
+ * caught it there, which is the guard working, and it is the same
+ * a-fallback-font-eats-the-pixel class the left column's 630 px note worries
+ * about. Both strips now compute to 26 from the stylesheet alone. */
 .tab {
   background: none;
   border: 1px solid var(--qt-border);
@@ -929,7 +936,8 @@
   font-size: 10px;
   font-weight: 700;
   letter-spacing: 1px;
-  padding: 5px 12px;
+  line-height: 12px;
+  padding: 6px 12px;
 }
 
 .tab.is-active {

--- a/tests/surfaces/test_pitwall_tokens.py
+++ b/tests/surfaces/test_pitwall_tokens.py
@@ -310,6 +310,17 @@ def test_the_chart_axis_palette_has_not_drifted_either():
     # It is value-paired with pyqtgraph's grid alpha.
     assert source.count("rgba(255,255,255,0.06)") == 1, "the grid alpha moved"
 
+    # Same blind spot, second occupant: the neutralised-lap band the race trace
+    # shades. Its RGB is WARNING and only the alpha is chosen here, so the guard
+    # pins the triplet to the palette and lets the alpha be what it is.
+    bands = re.findall(r"rgba\((\d+),\s*(\d+),\s*(\d+),\s*([\d.]+)\)", source)
+    neutralised = [triplet for triplet in bands if triplet[:3] != ("255", "255", "255")]
+    assert len(neutralised) == 1, f"expected one neutralised band colour, found {neutralised}"
+    assert tuple(int(value) for value in neutralised[0][:3]) == palette.WARNING, (
+        "the neutralised-lap band copies palette.WARNING; the pace grid's rail uses the same "
+        "hue in a different channel and the two must not drift apart"
+    )
+
 
 def test_the_trace_colours_are_in_the_right_slots():
     """Copy number six: band 4's four traces, one palette name each.


### PR DESCRIPTION
Five findings from the DATA design gate. **Together because they share three files** — `data.css`,
`racePace.ts` and `smoke-data.mjs` are touched by all of them — and splitting by hunk would produce
three branches that each fail their own smoke.

## 1 · The safety car, twice (#980)

The pace grid ranks every timed lap into thirds and paints them green / grey / amber. On a neutralised
lap those thirds are the accordion's queue order, not pace. Measured on
`data/raw/2025/Melbourne/laps.parquet`:

- **22 of 57 laps carry a safety-car digit**; 25 are non-green.
- **213 of the 776 cells the grid ranks (27.4 %) sit on one**, with lap times 86.4-148.2 s
  (median 131.6) against a green median of 91.9.
- `LapRow.track_status` rode the bridge and was read by **nothing**.

**The ranking is left alone.** Excluding those laps would leave holes in a history panel and
re-ranking them would invent a scale; what was wrong was painting the thirds with nothing saying
what the thirds are. So the lap number carries a **2 px amber rail**, keyed in the header and
labelled on hover, and the race trace **shades the same lap ranges** — which is also what explains
the V its own plot draws across laps 5-8.

**The decode is a producer change, not a client one.** `track_status_banner` moved out of
`overlays.py` into `src/arcade/track_status.py` so a consumer can read it without importing the
arcade GUI library, and `session_data` publishes `neutralised` per lap row. Nothing in TypeScript
knows that a `4` means a safety car. Both panels read one shared `lib/neutralised.ts`, because two
panels disagreeing about which laps were neutralised would be worse than neither marking them.

**And band 1 reacts.** A non-green status is a **filled** chip in the wire's own colour with the
window's ground as text. Before, the entire difference between green running and a safety car was
one outline chip swapping its text inside a 1465 x 28 strip — about 0.4 % of the window — with no
other element changing at all. Measured against every label the producer can emit, the ground clears
AA on all four: YELLOW FLAG 12.08:1, VSC 8.61, SAFETY CAR 7.93, RED FLAG 4.92.

The `.radio-tier` comment claiming "one colour means one tier across the whole window" is corrected;
it was false in five places (D17).

## 2 · `OUT` meant two opposite things (#983)

`TimingTower`'s docstring: an out-lap gets `PIT EXIT` *"rather than borrowing the same word for a car
that is very much still racing"*. The pace grid borrowed it anyway — on `pace-1485x833.png` BEA's
lap-1 cell said `OUT` three rows above the tower printing `OUT` for three crashed cars, and lap 5 was
a full-field red `OUT` row, which in tower vocabulary is seventeen simultaneous retirements.

Now `P.EXIT` — abbreviated because the tower's eight glyphs measure 43 px against a 38.75 px column —
in WARNING rather than DANGER, so red is spent on the lap you cannot unwind.

## 3 · The broadcast rival painted over the own car (#983)

`TraceChart` declared `[main, rival]` and ECharts paints in declaration order, so the coarse
broadcast-tier dashes were on top on all four charts — the exact inverse of the rule `raceTrace`
builds one tab away. On a full lap of the real payload the Speed and Throttle plots read as one amber
dashed line with slivers of blue under it. The rival is declared first now.

## 4 · The radio history was unreachable (#984)

`.radio-feed` and `.radio-list` were both `overflow: hidden`: **10 of 46 events visible and no wheel,
trackpad or key could reach the other 36**, while `qt-base.css` hides the scroll**bar** and keeps
bodies scrollable in as many words. One declaration gives them back.

## 5 · Two small ones (#984)

The ring's blind list collected retirements, so a lap-1 crash lit the panel's only telemetry alarm for
all 57 laps — it is in every one of the nine captures. And the tab and reference strips were 22 px and
15 px targets against the ~28 a mouse wants; both are 26 now.

## Guards

**Every new guard was driven RED against a MUTATED build that still compiles** — a build that does not
compile is not a red check — and all twelve failed. Notably:

> With `overflow: hidden` a scripted `scrollTop = scrollHeight` **still** moves the list to 1615 px and
> the oldest row is still in view, so the scroll-and-look half of that check **passes on the defect**.
> What `hidden` blocks is the wheel, the trackpad and the keyboard. The computed value is what says so,
> which makes it the effect and not the mechanism.

The smoke's trace probes also stopped being keyed by `series[0]` / `series[1]`: the declaration order
is exactly what the z-order fix changes, so four index-keyed assertions would have quietly started
measuring the wrong line. They look up by name now, and a new check asserts the paint order itself.

Two fixtures were migrated rather than worked around: the pace fixture said `track_status: "1"` on the
very laps it calls the safety car, and the ring fixture had no retired-and-blind car.

## Checks

- `smoke-data` **163 checks** (was 154) · `smoke-agents` 19 · `tests/surfaces/` 225 · `typecheck`
  clean · `uvx ruff@0.15.22 check` clean on the four Python files.
- The new band colour is registered in `test_pitwall_tokens.py`, pinned to `palette.WARNING` — the
  rgba form is invisible to the existing hex regex, which is the blind spot that test exists for.
- **Verified by opening the real window:** the filled chip at lap 1 under the safety car; the rail on
  laps 1-6 with `P.EXIT` beside it; the shaded band across laps 1-7 of the race trace with the V
  inside it; the own car's solid line over the rival's dashes on Speed and Throttle.

Closes #980
Closes #983
Closes #984
