### PR TITLE
fix(pitwall): a dead feed stops looking like a live one

### DIFF
--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -1974,6 +1974,97 @@ if (bands === null) {
   await narrowCtx.close();
 }
 
+// --- The producer dies, and the window has to stop looking live -------------
+//
+// `state-dead.png` is why: the board held a full set of confident numbers, the lap
+// counter still said L 28/57, the track chip still asserted GREEN and PLAYBACK
+// still said 2x, with one 77 x 18 chip and a status bar that had quietly gone
+// BLANK as the only tells. The socket label is the only thing that still moves
+// once the ticks stop, so the state is known client-side.
+//
+// Asserted as the EFFECT on the four surfaces that used to lie, and the fixture
+// feeds real ticks first so the board is populated before the feed goes quiet -
+// a window that never had data cannot demonstrate a window whose data went stale.
+{
+  const deadCtx = await browser.newContext({ viewport: { width: 1485, height: 833 } });
+  const dead = await deadCtx.newPage();
+  dead.on("pageerror", (error) => failures.push(`pageerror(dead): ${error.message}`));
+  await dead.addInitScript(
+    ([payload, bulk, live]) => {
+      window.__alive = true;
+      window.pywebview = { api: {
+        get_tick: async (s) => (s === payload.seq ? null : payload),
+        get_bulk: async (r) => (r === bulk.rev ? null : bulk),
+        get_live_lap: async (r) => (r === live.rev ? null : live),
+        get_connection: async () => (window.__alive ? "Connected" : "Disconnected"),
+      } };
+    },
+    [tick(1, { drivers: paceField(), order: TOWER_ORDER }), paceBulk(), towerLive()],
+  );
+  await dead.goto(`http://127.0.0.1:${server.address().port}/data.html`, {
+    waitUntil: "domcontentloaded",
+  });
+  await dead.waitForSelector(".tower-row", { timeout: 5000 });
+  await dead.waitForTimeout(600);
+
+  const alive = await dead.evaluate(() => ({
+    playback: [...document.querySelectorAll(".strip-field")]
+      .find((f) => f.textContent.startsWith("PLAYBACK"))
+      ?.querySelector(".strip-field-value")?.textContent,
+    bar: document.querySelector(".status-bar")?.textContent ?? "",
+    frozenChip: document.querySelectorAll(".strip-chip.is-frozen").length,
+    filter: getComputedStyle(document.querySelector(".data-main")).filter,
+    rows: document.querySelectorAll(".tower-row").length,
+  }));
+  check(
+    alive.rows === 20 && /^\d+x$/.test(alive.playback ?? "") && alive.bar.includes("live"),
+    `the board is live and says so before the producer dies (${alive.rows} rows, ${alive.playback}, "${alive.bar}")`,
+  );
+
+  // The producer goes quiet. The connection poll is 1 Hz, so this waits for it.
+  await dead.evaluate(() => {
+    window.__alive = false;
+  });
+  await dead.waitForTimeout(2200);
+
+  const frozen = await dead.evaluate(() => ({
+    playback: [...document.querySelectorAll(".strip-field")]
+      .find((f) => f.textContent.startsWith("PLAYBACK"))
+      ?.querySelector(".strip-field-value")?.textContent,
+    bar: document.querySelector(".status-bar")?.textContent ?? "",
+    frozenChip: document.querySelectorAll(".strip-chip.is-frozen").length,
+    trackFilled: document.querySelectorAll(".strip-chip.is-filled").length,
+    filter: getComputedStyle(document.querySelector(".data-main")).filter,
+    rows: document.querySelectorAll(".tower-row").length,
+    lost: document.querySelectorAll(".strip-chip.is-lost").length,
+  }));
+
+  check(
+    frozen.playback === "—" && !frozen.bar.includes("live") && frozen.bar.includes("FROZEN"),
+    `nothing on the strip claims the replay is advancing (${frozen.playback}, "${frozen.bar}")`,
+  );
+  check(
+    frozen.frozenChip === 1 && frozen.lost === 1 && frozen.trackFilled === 0,
+    `the frozen state is named in the header and the track status gives up its weight (${frozen.frozenChip} frozen, ${frozen.lost} lost, ${frozen.trackFilled} filled)`,
+  );
+  // The board is treated, and STILL THERE. The last known state is the best
+  // information a strategist has; a treatment that hid it would be worse than
+  // the lie it replaces.
+  check(
+    frozen.filter !== "none" && frozen.rows === 20,
+    `the board reads as history without becoming unreadable (${frozen.filter}, ${frozen.rows} rows)`,
+  );
+  // And the bar does not go blank. Its 1.5 s auto-clear is what left the window
+  // with no message at all, which is how a dead feed looked like a quiet one.
+  await dead.waitForTimeout(2000);
+  const later = await dead.evaluate(() => document.querySelector(".status-bar")?.textContent ?? "");
+  check(
+    later.includes("FROZEN"),
+    `and it is still saying so four seconds later, not auto-cleared ("${later}")`,
+  );
+  await deadCtx.close();
+}
+
 // A retired car keeps the laps he drove and gets NO point for the ones he did
 // not. These three have no crossings at all, so their series must be EMPTY -
 // never a flat line at zero, which is what a missing crossing read as a

--- a/src/pitwall/ui/src/features/data/DataWindow.tsx
+++ b/src/pitwall/ui/src/features/data/DataWindow.tsx
@@ -60,16 +60,40 @@ export function DataWindow() {
   // Qt re-arms `showMessage(f"lap {lap} · live", 1500)` on every broadcast,
   // so the line stays up while streaming and clears 1.5 s after the producer
   // stops. `useStatusText` is keyed on the sequence for that reason.
-  const status = tick ? { text: `lap ${tick.arcade.lap} · live`, transient: true } : WAITING;
+  /**
+   * The producer is gone, and every panel below is holding numbers from before.
+   *
+   * The socket's own label is the only thing that still moves once the ticks
+   * stop - `useConnection` polls it at 1 Hz for exactly this - so the state is
+   * known client-side and needs no wire change. Before this, a dead producer left
+   * a full board of confident values, the lap counter still saying `L 28/57`, the
+   * track chip still asserting GREEN and `PLAYBACK 2x` still claiming the replay
+   * was advancing, with a 77 x 18 chip and a blank status bar as the only tells.
+   * A frozen tower that looks live is the one state a pit wall must not mistake,
+   * and this window sits beside a moving arcade.
+   */
+  const frozen = connection === "Disconnected" && tick !== null;
+  // Not transient when frozen: the 1.5 s auto-clear is what a LIVE bar wants, and
+  // it is why the only remaining signal used to be an EMPTY bar. It also has to
+  // stop saying `live`, or the window contradicts its own banner one line down.
+  const status = !tick
+    ? WAITING
+    : frozen
+      ? { text: `DATA FROZEN · last tick lap ${tick.arcade.lap}`, transient: false }
+      : { text: `lap ${tick.arcade.lap} · live`, transient: true };
   const statusText = useStatusText(status, tick?.seq ?? null);
   const [tab, setTab] = useState<"traces" | "pace" | "trace">("traces");
 
   return (
     <main className="data-window">
       <div className="data-body">
-        <StatusStrip tick={live ? tick : null} connection={connection} />
+        <StatusStrip tick={live ? tick : null} connection={connection} frozen={frozen} />
         {live && tick ? (
-          <div className="data-main">
+          // Desaturated and mildly dimmed, never blurred and never faded much:
+          // the last known state is still operationally useful and has to stay
+          // readable. What the treatment says is "this is history", not "this is
+          // unavailable".
+          <div className={frozen ? "data-main is-frozen" : "data-main"}>
             <div className="left-column">
               <TimingTower arcade={tick.arcade} bulk={bulk} live={liveLap} />
               <BestsPanel bulk={bulk} />

--- a/src/pitwall/ui/src/features/data/StatusStrip.tsx
+++ b/src/pitwall/ui/src/features/data/StatusStrip.tsx
@@ -21,9 +21,11 @@ import { driverStatus } from "../../lib/driverStatus";
 interface StatusStripProps {
   tick: Tick | null;
   connection: string | null;
+  /** The producer is gone and every value on this strip is from before. */
+  frozen?: boolean;
 }
 
-export function StatusStrip({ tick, connection }: StatusStripProps) {
+export function StatusStrip({ tick, connection, frozen = false }: StatusStripProps) {
   const arcade = tick?.arcade;
   const playback = tick?.playback;
 
@@ -37,7 +39,16 @@ export function StatusStrip({ tick, connection }: StatusStripProps) {
       <TrackStatusChip
         label={arcade?.track_status_label ?? null}
         colour={arcade?.track_status_color ?? null}
+        frozen={frozen}
       />
+
+      {/* Where the chips already live, so the reader who only checks the top-left
+       * corner gets it too. The status bar says the same thing at the bottom. */}
+      {frozen ? (
+        <span className="strip-chip is-frozen" title="The arcade broadcast stopped">
+          DATA FROZEN
+        </span>
+      ) : null}
 
       {arcade && isProvisional(arcade.drivers) ? (
         <span className="strip-chip is-provisional" title="No classification exists until every car has completed a lap">
@@ -48,7 +59,9 @@ export function StatusStrip({ tick, connection }: StatusStripProps) {
       <span className="strip-spacer" />
 
       <StripField label="SESSION" value={sessionClock(arcade)} />
-      <StripField label="PLAYBACK" value={playbackLabel(playback)} />
+      {/* The last tick's speed is not the replay's speed once the ticks stop, and
+       * `2x` is an assertion that it is still advancing. */}
+      <StripField label="PLAYBACK" value={frozen ? "—" : playbackLabel(playback)} />
       <span className={`strip-chip ${connectionClass(connection)}`}>{connection ?? "—"}</span>
     </header>
   );
@@ -73,11 +86,19 @@ function StripField({ label, value }: { label: string; value: string }) {
 function TrackStatusChip({
   label,
   colour,
+  frozen,
 }: {
   label: string | null;
   colour: [number, number, number] | null;
+  frozen: boolean;
 }) {
   if (!label || !colour) return <span className="strip-chip is-unknown">NO STATUS</span>;
+  // **A dead feed cannot assert a track status.** The track may have gone red in
+  // the seconds since the last tick, and a frozen FILLED `SAFETY CAR` chip would
+  // be worse than a frozen green one: it would look like a live alarm. So the chip
+  // keeps its LABEL - the last thing that was true - and gives up its weight,
+  // rendering as the same dim unknown treatment `NO STATUS` uses.
+  if (frozen) return <span className="strip-chip is-unknown">{label}</span>;
   const rgb = `rgb(${colour[0]}, ${colour[1]}, ${colour[2]})`;
   // **A non-green status is FILLED, and that is the whole of the window's
   // reaction to a safety car.** Before this it was an outline chip swapping its

--- a/src/pitwall/ui/src/styles/data.css
+++ b/src/pitwall/ui/src/styles/data.css
@@ -106,6 +106,25 @@
   font-weight: 800;
 }
 
+/* The producer is gone. DANGER, the same red the Disconnected chip carries, and
+ * filled for the same reason the track status is: this is a state, not a label. */
+.strip-chip.is-frozen {
+  background: #ef4444;
+  border-color: #ef4444;
+  color: var(--qt-bg);
+  font-weight: 800;
+}
+
+/* The board while the feed is dead: desaturated and mildly dimmed, NEVER blurred
+ * and never faded far. The last known state is the best information a strategist
+ * has - the treatment has to say "this is history" while leaving every number
+ * readable, so 0.45 saturation and 0.82 brightness rather than an opacity that
+ * would make the tower a guess. Band 1 and the status bar stay at full strength:
+ * they are the two surfaces that say WHY it looks like this. */
+.data-main.is-frozen {
+  filter: saturate(0.45) brightness(0.82);
+}
+
 .strip-spacer {
   flex: 1 1 auto;
 }


### PR DESCRIPTION
## What

When the producer died the DATA window kept a full board of confident numbers. The lap counter still
said `L 28/57`, the track chip still asserted `GREEN`, `PLAYBACK` still said `2x`, and the tower,
bests, traces, ring and radio all held their last values.

**The only two tells were a 77 x 18 red chip and a status bar that had quietly gone BLANK** — so the
one signal the window gave was an *absence*, which is what a quiet moment looks like too. A frozen
tower that reads as live is the one state a pit wall must not mistake, and this surface sits beside a
moving arcade window.

See `shots/state-dead.png` (before) and `shots/after-dead-real.png` (after).

## How

The socket's own label is the only thing that still moves once the ticks stop — `useConnection` polls
it at 1 Hz for exactly this — so nothing here needs a wire change. On `Disconnected`, with a tick
already in hand:

- **`PLAYBACK` reads a dash.** The last tick's speed is not the replay's speed once the ticks have
  stopped; `2x` was an assertion that it is still advancing.
- **The status bar reads `DATA FROZEN · last tick lap N`, and is NOT transient.** Its 1.5 s
  auto-clear is what emptied it in the first place, and it has to stop saying `live` or the window
  contradicts its own banner one line up.
- **A `DATA FROZEN` chip goes in the header strip**, where the chips already live, so a reader who
  only checks the top-left corner gets it.
- **The track-status chip keeps its LABEL and gives up its WEIGHT**, rendering as the same dim
  treatment `NO STATUS` uses. A dead feed cannot assert a track status — the track may have gone red
  in the seconds since the last tick — and a frozen **filled** `SAFETY CAR` chip would be worse than a
  stale green one, because it would look like a live alarm. Measured: `rgb(16,185,129)` live,
  `rgb(156,163,175)` frozen.
- **The board is desaturated to 0.45 and dimmed to 0.82**, never blurred and never faded far. The last
  known state is the best information a strategist has, so the treatment says "this is history" while
  leaving every number readable. Band 1 and the status bar stay at full strength: they are the two
  surfaces that say WHY it looks like this.

The four additions over the original plan are the design-iteration round's, and its reasoning is in
`documents/audits/GATE_PITWALL_DATA_ITERATION_1.md` part 4a.

## Guard

Feeds real ticks **first** and then goes quiet, because a window that never had data cannot
demonstrate one whose data went stale — and it re-reads the bar four seconds later, since the defect
it replaces was a message that cleared itself.

**All four assertions driven RED** against a build where the window never learns the feed died:
`PLAYBACK 1x`, an empty bar, no chip, no filter.

## Checks

`typecheck` clean · `smoke-data` **171 checks** · `smoke-agents` 19 · `tests/surfaces/` 225.

**Verified by killing the REAL producer under the REAL window** rather than routing a stub: the board
greys, the header reads `DATA FROZEN` beside a neutral `GREEN`, `PLAYBACK` is a dash, and the bar says
`DATA FROZEN · last tick lap 30` and keeps saying it.

Closes #982
