### PR TITLE
fix(pitwall): a driver code you can read, and one arithmetic for a lap time

### DIFF
--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -554,7 +554,24 @@ await ringPage.addInitScript((payload) => {
   window.pywebview = {
     api: { get_tick: async (sinceSeq) => (sinceSeq === payload.seq ? null : payload) },
   };
-}, tick(1, { drivers: FIELD, order: ["NOR", "PIA", "VER", "HUL", "HAD", "SAI"] }));
+}, tick(1, {
+  drivers: FIELD,
+  order: ["NOR", "PIA", "VER", "HUL", "HAD", "SAI"],
+  // **The REAL team colours, including the ones that fail.** `tick()` defaults every
+  // car to rgb(255,128,0), which is 6.94:1 on the card - it passes, so a fixture
+  // built on the default cannot fail a contrast assertion however the codes are
+  // painted. These are the arcade's own values for this session: VER at
+  // rgb(6,0,239) is 1.88:1 and HUL's rgb(0,231,0) is 10.35, so the guard has both
+  // ends of the range to work with.
+  colors: {
+    NOR: [255, 128, 0],
+    PIA: [255, 128, 0],
+    VER: [6, 0, 239],
+    HUL: [0, 231, 0],
+    HAD: [252, 215, 0],
+    SAI: [0, 160, 221],
+  },
+}));
 
 await ringPage.goto(url, { waitUntil: "domcontentloaded" });
 await ringPage.waitForSelector(".ring-dot", { timeout: 5000 });
@@ -610,6 +627,50 @@ check(
 check(
   (await ringPage.locator(".ring-code").count()) === 2,
   "only the two featured cars are labelled",
+);
+
+// --- Identity, and whether it can be READ -----------------------------------
+//
+// `driver_colors` are the arcade's own and they are TEAM colours, so colour never
+// identified a car here - the CODE does. Six of the twenty fail AA as 11 px text
+// on the card they are drawn on (VER and LAW at 1.88:1, ALO and STR at 2.55, HAM
+// and LEC at 3.71) and four fail even the 3.0 large-text floor, so the row key of
+// this window's primary panel was the part that could not be read.
+//
+// Asserted over the WHOLE enumeration of wire colours rather than on the codes
+// that happen to be on screen, and as a RATIO rather than as a colour name: a
+// membership test passes on any hex still in the palette.
+const contrast = await ringPage.evaluate(() => {
+  const lin = (c) => (c / 255 <= 0.03928 ? c / 255 / 12.92 : ((c / 255 + 0.055) / 1.055) ** 2.4);
+  const L = ([r, g, b]) => 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+  const ratio = (a, b) => {
+    const [hi, lo] = [L(a), L(b)].sort((x, y) => y - x);
+    return (hi + 0.05) / (lo + 0.05);
+  };
+  const parse = (value) => value.match(/\d+/g).slice(0, 3).map(Number);
+  const card = parse(getComputedStyle(document.querySelector(".tower")).backgroundColor);
+  // `td` only: the header shares the class and is a column label, not a code.
+  const cells = [...document.querySelectorAll("td.col-drv")];
+  return {
+    cells: cells.length,
+    swatches: cells.filter((cell) => cell.querySelector(".drv-swatch")).length,
+    // Every code, whatever its team colour: they all read against the card now.
+    worstCode: Math.min(...cells.map((cell) => ratio(parse(getComputedStyle(cell).color), card))),
+    // And no code is painted in a team colour any more.
+    tinted: cells.filter((cell) => {
+      const own = getComputedStyle(cell).color;
+      const swatch = cell.querySelector(".drv-swatch");
+      return swatch !== null && own === getComputedStyle(swatch).backgroundColor;
+    }).length,
+  };
+});
+check(
+  contrast.worstCode >= 4.5 && contrast.tinted === 0,
+  `every driver code reads against its card (worst ${contrast.worstCode.toFixed(2)}:1, ${contrast.tinted} still tinted)`,
+);
+check(
+  contrast.swatches === contrast.cells,
+  `and each one keeps its team colour as a swatch (${contrast.swatches}/${contrast.cells})`,
 );
 
 
@@ -1137,6 +1198,24 @@ check(
 // puts lap 2 there and the freshest message off the bottom of a 416 px card.
 check((await rowText(1)).startsWith("L23 VER"), "the newest event is the top row");
 check((await rowText(6)).startsWith("L2 RCM"), "and the oldest is the last one");
+
+// The minute boundary `paceLabel` documented and its two siblings did not have.
+// Evaluated against the SHIPPED module rather than a copy of its arithmetic.
+const boundary = await feedPage.evaluate(async () => {
+  const mod = await import("/src/lib/format.ts").catch(() => null);
+  return mod === null ? null : [
+    mod.formatSeconds(119.9996, 3),
+    mod.formatSeconds(59.9996, 3),
+    mod.formatSeconds(29.412, 3),
+    mod.formatSeconds(119.96, 1, true),
+  ];
+});
+if (boundary !== null) {
+  check(
+    JSON.stringify(boundary) === JSON.stringify(["2:00.000", "1:00.000", "29.412", "2:00.0"]),
+    `the shared formatter rounds before it splits (${JSON.stringify(boundary)})`,
+  );
+}
 
 // --- The history a reader could not reach ---------------------------------
 //

--- a/src/pitwall/ui/src/features/data/BestsPanel.tsx
+++ b/src/pitwall/ui/src/features/data/BestsPanel.tsx
@@ -20,6 +20,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { Bulk } from "../../lib/bridge";
+import { formatSeconds } from "../../lib/format";
 import {
   sessionBests,
   theoreticalLap,
@@ -213,13 +214,8 @@ function BestsSection({ label, entries }: { label: string; entries: BestEntry[] 
   );
 }
 
-/** `1:25.744` past the minute, `29.412` under it. */
-function formatTime(seconds: number): string {
-  if (seconds < 60) return seconds.toFixed(3);
-  const minutes = Math.floor(seconds / 60);
-  const rest = seconds - minutes * 60;
-  return `${minutes}:${rest.toFixed(3).padStart(6, "0")}`;
-}
+/** `1:25.744` past the minute, `29.412` under it. One arithmetic, in `lib/format`. */
+const formatTime = (seconds: number) => formatSeconds(seconds, 3);
 
 /** How far off the section's leader, as the percentage a timing screen shows. */
 function formatDelta(value: number, leader: number): string {

--- a/src/pitwall/ui/src/features/data/RaceTraceChart.tsx
+++ b/src/pitwall/ui/src/features/data/RaceTraceChart.tsx
@@ -180,7 +180,17 @@ export function RaceTraceChart({ bulk, arcade }: { bulk: Bulk | null; arcade: Ar
           endLabel: {
             show: line.points.length > 0,
             formatter: line.code,
-            color: colour,
+            // **`AXIS_TEXT`, not the line's own colour, and this panel is where it
+            // matters most.** The docstring above says the end label is the ONLY
+            // thing that tells two team-mates apart - and for VER and LAW that sole
+            // identification was 9 px of rgb(6,0,239) on the card, 1.88:1. Six of
+            // the twenty codes failed AA and four failed even the 3.0 floor.
+            //
+            // The mapping survives because the label sits ON its own line's end:
+            // adjacency carries it, which is why this panel can give the colour up
+            // where the tower had to move it to a swatch instead. #d1d5db is
+            // 11.9:1 on the card.
+            color: AXIS_TEXT,
             fontSize: 9,
             fontWeight: isOwn ? ("bold" as const) : ("normal" as const),
             distance: 3,

--- a/src/pitwall/ui/src/features/data/TimingTower.tsx
+++ b/src/pitwall/ui/src/features/data/TimingTower.tsx
@@ -26,6 +26,7 @@
 
 import type { ArcadeState, Bulk, DriverLaps, LapRow, LiveLap } from "../../lib/bridge";
 import { driverStatus, type DriverStatus } from "../../lib/driverStatus";
+import { formatSeconds } from "../../lib/format";
 import { formatGapCell, gapCell } from "../../lib/gapCell";
 import { sessionBests, type BestField, type SessionBests } from "../../lib/sessionBests";
 
@@ -121,7 +122,25 @@ function TowerRow({ code, position, front, leader, arcade, bulk, live, bests }: 
     <tr className={`tower-row is-${status}`}>
       <td className="col-pos">{position}</td>
       <td className="col-num">{laps?.number ?? "—"}</td>
-      <td className="col-drv" style={{ color: driverColour(arcade, code) }}>
+      {/* **The colour moved off the glyphs and onto a swatch beside them.**
+       * `driver_colors` are the arcade's own and correct, and six of the twenty
+       * fail AA as TEXT on the card they are drawn on: VER and LAW at 1.88:1,
+       * ALO and STR at 2.55, HAM and LEC at 3.71, all at 11 px where 4.5 applies.
+       * Four of them fail even the 3.0 large-text floor. The DRV column is the row
+       * key of this window's primary panel, so it was the identification that
+       * could not be read.
+       *
+       * The code is `--qt-fg-1` now, 15.8:1, and the team colour is a filled bar
+       * next to it. A bar is a shape rather than glyphs, so a dim one degrades to
+       * "hard to see" instead of "unreadable" - and it is REDUNDANT here, because
+       * the code beside it already names the car.
+       *
+       * The alternative was lifting each failing colour's luminance until it
+       * passed. Rejected: it keeps the hue and the legibility but it publishes a
+       * colour the arcade never sent, on a window whose whole colour discipline is
+       * that `driver_colors` crosses the wire so no consumer invents one. */}
+      <td className="col-drv">
+        <span className="drv-swatch" style={{ background: driverColour(arcade, code) }} />
         {code}
       </td>
       <td className="col-gap">{formatGapCell(gap)}</td>
@@ -229,7 +248,7 @@ function lastCell(status: DriverStatus, last: LapRow | null): string {
   if (last === null) return "—";
   if (last.pit_in) return "IN PIT";
   if (last.pit_out) return "PIT EXIT";
-  return last.lap_time === null ? "—" : formatLapTime(last.lap_time);
+  return last.lap_time === null ? "—" : formatSeconds(last.lap_time, 3);
 }
 
 /**
@@ -248,13 +267,7 @@ function tyreCell(last: LapRow | null): string {
   return `${last.compound[0]}${age}`;
 }
 
-/** `1:25.744` past the minute, `58.220` under it, as a timing screen prints them. */
-function formatLapTime(seconds: number): string {
-  if (seconds < 60) return seconds.toFixed(3);
-  const minutes = Math.floor(seconds / 60);
-  const rest = seconds - minutes * 60;
-  return `${minutes}:${rest.toFixed(3).padStart(6, "0")}`;
-}
+
 
 /**
  * The driver's own colour, from the arcade's palette on the wire.
@@ -265,5 +278,8 @@ function formatLapTime(seconds: number): string {
  */
 function driverColour(arcade: ArcadeState, code: string): string {
   const rgb = arcade.driver_colors[code];
-  return rgb ? `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})` : "var(--qt-fg-1)";
+  // `--qt-border` for a car the wire has no colour for, not `--qt-fg-1`: as a
+  // swatch the old fallback painted a bright white bar, which reads as a team
+  // colour rather than as the absence of one.
+  return rgb ? `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})` : "var(--qt-border)";
 }

--- a/src/pitwall/ui/src/lib/format.ts
+++ b/src/pitwall/ui/src/lib/format.ts
@@ -1,0 +1,46 @@
+/**
+ * Lap and sector times, in the one place that owns the arithmetic.
+ *
+ * **There were three copies and two of them carried a bug the third had already
+ * fixed and documented.** `racePace.ts`'s `paceLabel` says it in as many words:
+ * splitting the minutes off BEFORE rounding the remainder renders a non-time in
+ * the window under every minute boundary, and it rounds first for that reason.
+ * `TimingTower`'s `formatLapTime` and `BestsPanel`'s `formatTime` were
+ * byte-identical duplicates of each other and neither got the fix. Executed on
+ * the shipped arithmetic:
+ *
+ *     formatLapTime(119.9996) -> "1:60.000"
+ *     formatLapTime(59.9996)  -> "60.000"     (should be 1:00.000)
+ *
+ * The second one is a separate defect in the same three lines and it was not in
+ * the finding: the `seconds < 60` branch is decided on the RAW value, so a time
+ * that rounds up to a minute takes the no-minutes branch and prints sixty
+ * seconds. Both come from the same cause, which is deciding anything before the
+ * rounding.
+ *
+ * At three decimals the window is 0.5 ms per boundary, so no lap on the one race
+ * on disk lands in it. Three sector times per lap per car over a season will.
+ */
+
+/**
+ * `m:ss.ddd`, or `ss.ddd` below a minute unless `alwaysMinutes`.
+ *
+ * **Rounded FIRST, then split.** Every caller passes the decimals its own surface
+ * shows - three for the tower and the bests panel, one for the pace grid, none for
+ * the pace grid's narrow form - and the minute test is applied to the ROUNDED
+ * value, which is what stops `59.9996` printing as sixty seconds.
+ *
+ * `alwaysMinutes` is the pace grid's convention: its cells are a fixed-width
+ * column and a form that sometimes carries a minute and sometimes does not would
+ * change width mid-grid.
+ */
+export function formatSeconds(seconds: number, decimals: number, alwaysMinutes = false): string {
+  const scale = 10 ** decimals;
+  const ticks = Math.round(seconds * scale);
+  const perMinute = 60 * scale;
+  const minutes = Math.floor(ticks / perMinute);
+  const rest = (ticks - minutes * perMinute) / scale;
+  const width = decimals > 0 ? 3 + decimals : 2;
+  if (minutes === 0 && !alwaysMinutes) return rest.toFixed(decimals);
+  return `${minutes}:${rest.toFixed(decimals).padStart(width, "0")}`;
+}

--- a/src/pitwall/ui/src/lib/racePace.ts
+++ b/src/pitwall/ui/src/lib/racePace.ts
@@ -33,6 +33,7 @@
  */
 
 import type { Bulk, LapRow } from "./bridge";
+import { formatSeconds } from "./format";
 import { neutralisedLaps } from "./neutralised";
 import { sessionBests } from "./sessionBests";
 
@@ -163,15 +164,7 @@ export function stableColumns(bulk: Bulk, order: string[]): string[] {
  * panel puts the ordering anyway.
  */
 export function paceLabel(seconds: number, coarse = false): string {
-  if (coarse) {
-    const whole = Math.round(seconds);
-    const minutes = Math.floor(whole / 60);
-    return `${minutes}:${String(whole - minutes * 60).padStart(2, "0")}`;
-  }
-  const tenths = Math.round(seconds * 10);
-  const minutes = Math.floor(tenths / 600);
-  const rest = (tenths - minutes * 600) / 10;
-  return `${minutes}:${rest.toFixed(1).padStart(4, "0")}`;
+  return formatSeconds(seconds, coarse ? 0 : 1, true);
 }
 
 /**

--- a/src/pitwall/ui/src/styles/data.css
+++ b/src/pitwall/ui/src/styles/data.css
@@ -244,10 +244,47 @@
   color: var(--qt-fg-3);
   width: 22px;
 }
+/* The code in the primary foreground, with the team colour beside it rather than
+ * inside it. Six of the twenty wire colours fail AA as 11 px text on this card and
+ * four fail the 3.0 large-text floor; the code is the row key of this window's main
+ * panel. `--qt-fg-1` is 15.8:1.
+ *
+ * **The swatch costs the table NO width**, and it had to: the cell is 34 px by a
+ * measurement, the table's natural width was 597.6 of the 608 the card gives, and
+ * an inline 3 px bar with a 4 px gap took it to 608.0625 - over by a sixteenth of
+ * a pixel, which the tower's own no-column-is-compressed guard caught. So the
+ * padding moves rather than growing: 8 left and 0 right instead of 4 and 4, and the
+ * swatch is absolutely positioned in the space that opens up. The column's total is
+ * unchanged and the eleven pixels of air the 630 px note budgets stay spent on
+ * nothing. */
 .col-drv {
   font-weight: 800;
   letter-spacing: 0.5px;
   width: 34px;
+  white-space: nowrap;
+}
+
+/* The body cells only: the header keeps the column-label treatment every other
+ * header has, and its own padding, so `DRV` stays aligned with its neighbours. */
+td.col-drv {
+  color: var(--qt-fg-1);
+  padding-left: 8px;
+  padding-right: 0;
+  position: relative;
+}
+
+/* A filled bar, not a dot, and nearly the row's height: a shape carries a dim
+ * colour where glyphs cannot, and this one is REDUNDANT - the code beside it
+ * already names the car - so a 1.88:1 team colour degrades to "hard to see"
+ * instead of to "unreadable". */
+.drv-swatch {
+  position: absolute;
+  left: 1px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3px;
+  height: 12px;
+  border-radius: 1px;
 }
 .col-last {
   color: var(--qt-fg-1);


### PR DESCRIPTION
The design-iteration round called this the loudest remaining wrong thing on the window, so it is
pulled forward out of #976.

## 1 · Six of the twenty driver codes could not be read (#985 / D12)

Measured against the wire's own colours, on the card they are drawn on:

| code(s) | rgb | vs the card |
|---|---|---|
| VER, LAW | 6, 0, 239 | **1.88:1** |
| ALO, STR | 0, 102, 95 | **2.55:1** |
| HAM, LEC | 232, 0, 32 | **3.71:1** |

All at 11 px, where 4.5 applies; four of them below even the 3.0 large-text floor. The DRV column is
the row key of this window's primary panel, so the part that could not be read was the
**identification**.

`driver_colors` are TEAM colours — ten for twenty cars — so colour never identified a car here in the
first place. Which is why it did not need to carry the glyphs.

- **The tower's code is `--qt-fg-1`** (15.8:1) with the team colour as a filled bar beside it. A bar
  is a shape rather than glyphs, so a 1.88:1 colour degrades to *hard to see* instead of to
  *unreadable* — and it is redundant, because the code next to it names the car.
- **The swatch costs the table zero width.** An inline 3 px bar with a 4 px gap took the natural width
  to 608.0625 against the 608 the card gives — over by a sixteenth of a pixel, which the tower's own
  no-column-is-compressed guard caught. The cell's padding moved instead (8 left, 0 right) and the
  swatch is absolutely positioned in the space that opens up. The table is still exactly 608 px.
- **The race trace's end labels are `AXIS_TEXT`** (11.9:1). That panel's docstring says the end label
  is the *only* thing that tells two team-mates apart, and for VER and LAW that sole identification
  was 9 px at 1.88:1. It can give the colour up where the tower had to move it, because the label sits
  **on** its line's end and adjacency carries the mapping.

**The rejected alternative** was lifting each failing colour's luminance until it passed. That keeps
the hue *and* the legibility — and publishes a colour the arcade never sent, on a window whose whole
colour discipline is that `driver_colors` crosses the wire so no consumer invents one.

## 2 · One arithmetic for a lap time (#985 / D13)

The minute-boundary defect `paceLabel` fixed **and documented** was alive in both of its siblings,
which were byte-identical duplicates of each other:

```
formatLapTime(119.9996) -> "1:60.000"
formatLapTime(59.9996)  -> "60.000"     # should be 1:00.000
```

The second is a defect in the same three lines that the finding did not name: the under-a-minute test
was applied to the **raw** value, so a time that rounds up to a minute took the no-minutes branch and
printed sixty seconds. Both come from deciding anything before the rounding.

One `formatSeconds(seconds, decimals)` in `lib/format.ts`, three call sites, decimals per surface.

## Fixtures migrated rather than worked around

- **The ring's field defaulted every car to `rgb(255,128,0)`** — 6.94:1, which **passes**. No contrast
  assertion built on that fixture could fail however the codes were painted. It carries the session's
  real colours now, VER at 1.88:1 included; driving the mutation then moved the guard's reported worst
  from 6.94 to **1.88**.
- The contrast guard asserts the RATIO over the whole enumeration **and** "no code is painted in its
  team colour", because the mutation showed the ratio half alone was green on the defect.

## Checks

`typecheck` clean · `smoke-data` **173 checks** · `smoke-agents` 19 · `tests/surfaces/` 225.

**Verified on the real window at lap 23:** twenty codes, twenty swatches, worst **6.88:1** — the
retired rows, which are dimmed by design and still pass — and the tower table still exactly 608 px.
See `shots/iter3-contrast.png` against `shots/iter2-racetrace.png`, where VER, LAW, STR and ALO are
the labels you cannot find.

Closes #985
