### PR TITLE
fix(pitwall): the windows load over one transport, and what two gates found in this sprint's own work

### DIFF
--- a/documents/audits/GATE_PITWALL_SPRINT9_EXIT.md
+++ b/documents/audits/GATE_PITWALL_SPRINT9_EXIT.md
@@ -1,0 +1,613 @@
+# ADVERSARIAL EXIT GATE — PITWALL Sprint 9 (DATA window)
+
+**Date:** 2026-08-18 · **Auditor:** adversarial exit gate (Fable 5)
+**Tree measured:** branch `dev` @ `239babd` (Merge PR #994). Sprint bounded by `d07a10a` (#989, stops)
+through `239babd`; diff base for the UI work `3492934..dev` (20 files, +1999/−162).
+**Live host:** the handed-over host at `127.0.0.1:57594` had exited by the time I reached it, so I
+started my own headless host + loopback server against the SAME already-running producer
+(`PitwallHost` + `BrowserServer(ui_dist(), host)`, no pywebview) at **http://127.0.0.1:58476/** —
+serving the same `dist/` the sprint built, snapshotted at that host's startup. **No rebuild was
+performed at any point; the served bundle is the measured bundle.** The producer was the real
+`scripts/dev_pitwall_producer.py` broadcasting Melbourne 2025 from frame 60000 (mid-race, laps 23-51
+observed across the session).
+**Session data:** `data/raw/2025/Melbourne` parquet set (the same the producer serves).
+**Ran:** `pytest tests/surfaces/ -q` · `node scripts/smoke-data.mjs` · `node scripts/smoke-agents.mjs`
+· six purpose-built Playwright probes, `src/pitwall/ui/scripts/_exit_probe{,2,3,4,5,6}.mjs`
+(they exist, untracked; inventory at the end of this report)
+· read-only Python censuses against the parquet.
+
+**Contract:** no repository file modified except this report. No `git` state change, no build.
+Earlier gates' findings (GATE_PITWALL_DATA_DESIGN.md, GATE_PITWALL_DATA_ITERATION_1.md) are NOT
+re-reported; this gate hunts what SURVIVED and what the sprint's own fixes BROKE.
+
+---
+
+## Checklist — the lettered claims
+
+| # | Claim | Verdict |
+|---|-------|---------|
+| A | `_tyre_stops`: 36 vs true 31, residual = {ALB,BEA,LAW,OCO,STR} = #988 artefact | **VERIFIED** — 36 / 82 / 31 and the residual five all reproduce |
+| B | `fineFormFits` cannot oscillate across a continuous resize | **VERIFIED** — one boundary each way, stable when held |
+| C | `useFitsRanked` cannot oscillate; BESTS fits at both settled sizes + between + after resize | **MIXED** — no oscillation, fits both settled sizes, **clips in between (X1)** |
+| D | `neutralisedLaps` & pace rail agree with parquet, both directions; two panels cannot disagree | **VERIFIED** — set-equal both ways; the two panels share one reducer |
+| E | Band `from − 0.5` outside the axis (lap 0.5) cannot break the chart | **VERIFIED** — and `to + 0.5` overruns too; both clipped, no error |
+| F | TraceChart series-order swap broke nothing index-keyed | **VERIFIED** — nothing index-keyed anywhere |
+| G | `formatSeconds` byte-equivalent to the three old formatters except the two boundary bugs | **VERIFIED** — 0 diffs over 2,080 served values; both bugs fixed |
+| H | Frozen treatment cannot latch after producer returns; `frozen` false before first tick | **VERIFIED** — against a real kill AND a real restart |
+| I | Swatch costs the tower no width, both sizes, colourless car | **VERIFIED** — 4 px, both sizes, colourless car included |
+| J | `track_status.py` move broke no importer | **VERIFIED** — every importer, 225 tests + 192 smoke checks |
+| K | `session_data` → `src.arcade.track_status` drags no pyglet into host/tests | **VERIFIED BY IMPORT** — no arcade/pyglet in `sys.modules` |
+| L | `neutralised` on the wire: `allow_nan=False`, bulk revisions, hand-written fixtures all fine | **VERIFIED** — serialisation, revisions, fixtures |
+
+---
+
+## Findings
+
+
+## A — `_tyre_stops`: VERIFIED (arithmetic, population, and residual all reproduce)
+
+Executed: `SessionLaps.load(data, 2025, "Melbourne")` + full-reveal `masked_view`, plus an
+independent transition census on the repaired frame.
+
+- Served total **36**; old in-lap rule **82**; compound-change-only census **31** — all three match
+  the claim exactly.
+- Residual five = ALB L2→3, STR L2→3, LAW L3→4, BEA L4→5, OCO L4→5, all `AGE n→1` with compound
+  unchanged (INTERMEDIATE), all on safety-car pit-lane transit laps. Matches #988's list by name.
+- **Artefact, not real stops, proven two ways:** (1) pit-lane transit durations for those passes are
+  13.0–22.3 s across ALL 17 runners (queue speed; STR's real lap-33 stop reads 18.8 s in #988's own
+  measurement — durations do not separate, but positions do); (2) **none of the five changed
+  position** across laps 1–7 (ALB P7, STR P11, LAW P16, BEA P17, OCO P15, constant). A real stop
+  while the field queues through the pit lane loses places to every car behind; none were lost.
+- True 31 confirmed independently: every real Melbourne stop was a compound change
+  (I→slick→I); the 31 compound-change transitions are the 31 stops. The rule's deliberate blind spot
+  (same-compound refit with a HIGHER used age) has no instance in this race.
+- Edge attacks that did NOT break it: ALO retires with a generated final row (lap 33) → 0 stops
+  beside a 32-lap tyre ✓; all 6 `FastF1Generated` rows sit at sequence ENDS or are the only row
+  (SAI/HAD/DOO lap 1), so drop-before-pairing has no mid-sequence case to corrupt; a final-lap
+  pit-in pairs with no successor and counts nothing; `is_real_compound` rejects
+  `""/nan/none/unknown` and Melbourne's only unknown compounds are on generated rows, already
+  dropped.
+- Nuance, not a finding: for ALB/STR/BEA/OCO the age restart PERSISTS (ALB reads `I 31` at lap 33
+  where truth is 33), so the TYRE column under-reads age for those cars all race. That is #988's
+  data defect, already filed with the correct five-car list, and cannot be fixed in `_tyre_stops`
+  without inventing stops.
+
+
+## B — `fineFormFits` cannot oscillate: VERIFIED
+
+Executed with `scripts/_exit_probe.mjs` on the live bundle: a continuous width sweep 1485 -> 1265 -> 1485
+in 10 px steps, then a hold at the boundary with 10 samples 150 ms apart.
+
+- Trail: fine down to 1445, coarse from 1435 down; on the way back coarse to 1435, fine from 1445.
+  Same boundary in both directions, so no hysteresis and no flip-flop.
+- Held at 1434 / 1435 / 1436 px: the state is a single value at each (`[true]`), never alternating.
+- The mechanism is sound for the reason claimed: the ruler measures the FINE form regardless of what
+  the cell currently renders, so the decision does not depend on its own output.
+
+## C — `useFitsRanked` cannot oscillate: VERIFIED. BESTS fits at both settled sizes: VERIFIED.
+## C — but it does NOT fit at intermediate client heights → **REFUTED for the third size** (finding X1)
+
+- Continuous resize 1485x833 -> 1265x593 -> back: one transition each way at the SAME boundary
+  (ranked at 1359x696, leaders at 1344x679, identically on the return). No oscillation.
+- Both settled sizes are deterministic over 6 fresh mounts each: 1485x833 always ranked and unclipped,
+  1265x593 always leaders and unclipped.
+- **A fresh mount at an intermediate height silently clips.** See X1.
+
+## D — `neutralisedLaps` and the pace rail agree with the parquet, both directions: VERIFIED
+
+Measured on the live page against `/api/bulk` fetched inside the same document:
+- Bulk rows say neutralised: laps 1-7, 33, 34, 35, 36 (11 laps at that reveal, all `SAFETY CAR`).
+- Rendered rails: laps 1-7, 33, 34, 35, 36 — set-equal, and every `title` is `SAFETY CAR`.
+  No railed lap the bulk does not mark, no marked lap without a rail.
+- The two panels cannot disagree: both call `neutralisedLaps(bulk)` from `lib/neutralised.ts`, and the
+  trace's bands on the same document resolved to the same laps (1-7 and 33-36 as two ranges).
+
+## E — the band's `from − 0.5` cannot break the chart: VERIFIED (and `to + 0.5` overruns too, harmlessly)
+
+- Live at a 36-lap reveal: axis extent `[1, 36]`, band 1 is `0.5 → 7.5` and band 2 `32.5 → 36.5`. So BOTH
+  ends fall outside the locked axis, not just the low one — the claim under-states its own case.
+- The axis is unaffected — `min`/`max` are locked to the data, extent stayed `[1, 36]` — and the canvas
+  renders with **zero page errors** across every probe run.
+- Sampled the canvas' own pixels: inside the band the pixel carries the amber (`[242,153,13]` before
+  alpha), 8 px and 40 px past the axis end it is `[0,0,0]`/transparent, and likewise before the axis
+  start. ECharts clips the `markArea` to the grid, so the overrun paints nothing outside the plot.
+
+## F — the `TraceChart` series-order swap broke nothing index-keyed: VERIFIED
+
+Every consumer, checked:
+- Repo-wide grep for `series[` in `src/pitwall/ui/scripts`, `src/pitwall/ui/src` and `tests/surfaces`:
+  **no index-keyed series access anywhere.**
+- `smoke-data.mjs` reads series BY NAME (`seriesByName`, `.find((s) => s.name === …)`) and asserts the
+  order as a string (`"rival>main"` on all four charts) — an intentional order assertion, not an
+  accidental index dependency. `settle.mjs` only collects `__pitwallChart` handles.
+  `shot-data.mjs` touches no series. `test_pitwall_tokens.py` parses source text, not indices.
+- `useEChart` is order-agnostic (`setOption` with `notMerge: true`).
+- The two reference marks (`yAxis: 0`, the cursor) hang off the FIRST series, which the swap changed from
+  main to rival; both are `silent` and geometric, and the rival series is declared on every chart even
+  when it holds no data, so they still render — confirmed on the live capture, where the delta chart's
+  zero baseline and the cursor are both present.
+
+## G — `formatSeconds` is byte-equivalent except the two boundary bugs: VERIFIED
+
+Harness ran the retired implementations (lifted verbatim from `f580922`) against the new one over
+**2,080 distinct values pulled from the live `/api/bulk`** — every `lap_time`, `s1`, `s2`, `s3`,
+per-driver best and theoretical the window renders:
+
+    diffs on the served distribution: tower 0 · paceFine 0 · paceCoarse 0
+
+Boundaries, old -> new: `59.9996` old `60.000` / new `1:00.000` (the sub-minute bug, fixed);
+`119.9996` old `1:60.000` / new `2:00.000` (the documented bug, fixed); `60`, `60.0004`, `0.5`,
+`0.0004`, `9.9996`, `599.95`, `600`, `600.04`, `149.413`, `89.96` all identical between old and new.
+`600 -> "10:00.0"` reproduces the docstring's seven-glyph case exactly.
+
+Degenerate inputs are NOT equivalent and are ugly in the new one (`NaN -> "NaN:000NaN"`,
+`-5 -> "-1:55.000"`, `-0.04 -> "-1:59.960"` at 3 dp but `"0:00.0"` at 1 dp). No caller can reach them —
+every call site is guarded by an explicit `null` check and the wire emits `None`, never NaN
+(`allow_nan=False`) — so this is recorded as X4 (P3), not as a live defect.
+
+## H — the frozen treatment cannot latch, and cannot precede the first tick: VERIFIED
+
+Driven on the live page by intercepting `/api/tick` and `/api/connection` to kill the producer and then
+BRING IT BACK:
+
+| state | frozen chip | `.data-main.is-frozen` | PLAYBACK | status bar | connection |
+|---|---|---|---|---|---|
+| live | no | no | `2x` | `lap 37 · live` | Connected |
+| dead | **yes** | **yes** | `—` | `DATA FROZEN · last tick lap 37` | Disconnected |
+| revived | no | no | `2x` | `lap 37 · live` | Connected |
+
+The treatment came off completely on reconnect (all five tells reverted; 20 tower rows throughout).
+With the tick held at `null` from the start and the connection reporting `Disconnected`, the window shows
+the WAITING state, no frozen chip, and `Waiting for arcade stream…` — `frozen` is false before the first
+tick, as `tick !== null` requires.
+
+## I — the swatch costs the tower no width: VERIFIED, colourless car included
+
+- 1485x833: 20 rows, 20 swatches, all 20 with an inline `rgb()`; the swatch's right edge is at **4 px**
+  inside an 8 px cell padding; `tower-table` and `.tower` clip 0 px; 0 of 20 `td.col-drv` clipped.
+- 1265x593: identical numbers (maxRight 4, 0 clipped, 0 table clip).
+- A car the wire has no colour for: intercepted the tick and deleted `driver_colors.RUS`. The swatch fell
+  back to `var(--qt-border)` → painted `rgb(45,45,58)`, still 4 px wide, still 0 clipped. The bright-white
+  fallback the comment says it avoids is genuinely avoided.
+
+## J — the `track_status.py` move broke no importer: VERIFIED
+
+Every caller in the repo, tests included:
+- `src/arcade/app.py:56-63` imports `track_status_label` from `src.arcade.overlays` — still resolves via
+  the `# noqa: F401` re-export at `src/arcade/overlays.py:49-52`.
+- `src/arcade/overlays.py:685` uses `track_status_banner` — same re-export.
+- `tests/surfaces/test_arcade_wire_contract.py:841,862` import from `src.arcade.overlays` — pass.
+- `src/pitwall/session_data.py:46` imports from the new module directly.
+- `src/arcade/__init__.py` re-exports nothing; `overlays.py` declares no `__all__` at all, so no
+  star-import surface was narrowed.
+- `tests/surfaces/` **225 passed**, `node scripts/smoke-data.mjs` **173 checks OK**,
+  `smoke-agents.mjs` **19 checks OK**.
+
+## K — `session_data` drags no GUI library in: VERIFIED BY IMPORT
+
+    $ .venv/Scripts/python.exe -c "import src.pitwall.session_data; …"
+    GUI modules loaded: NONE
+    heavy modules loaded: NONE
+
+`src.arcade.track_status` imports only `src.arcade.config` (json / logging / os / pathlib / typing plus
+`src.f1_strat_manager.data_cache`) — no `arcade`, no `pyglet`, no fastf1 / torch / lightgbm.
+
+## L — the `neutralised` field breaks nothing on the wire: VERIFIED
+
+- Serialisation: the value is `str | None` by construction (`neutralised_label` returns a label from a
+  fixed set or `None`), so it cannot be a NaN and `allow_nan=False` is untouched. The live `/api/bulk`
+  serves it on every row.
+- Bulk revisions: the signature is `(year, location, reveal_map)` (`src/pitwall/host.py:216`) and is
+  unchanged by a new row field, so the field cannot make the revision move or stall. Live `rev` advanced
+  normally.
+- Fixtures: every hand-written lap row in `smoke-data.mjs` carries `neutralised` (3 of 3 object literals
+  containing `pit_in` include it — lines 885, 1386, 1451). The Python fixtures build rows through
+  `_lap_row`, so they inherit it.
+
+---
+
+# Findings
+
+## X1 · P1 — BESTS silently clips at every intermediate client height, THEORETICAL included; the fix removed the defect at the two measured sizes and left the band between them
+
+**Where:** `src/pitwall/ui/src/features/data/BestsPanel.tsx:60-82` (`useFitsRanked`) ·
+`src/pitwall/ui/src/styles/data.css:376-390` (`.bests { max-height: 100%; overflow-y: auto }`).
+
+**What a strategist loses:** the THEORETICAL lap — by the panel's own docstring "the one value a wall
+reads off this panel that no other panel carries" — plus the rank-3 rows, cut off with **no tell of any
+kind**: the card is capped by `max-height: 100%`, the overflow becomes a scroll inside the card, and
+scrollbars are hidden globally. This is the same pixel-level failure as design-gate finding D5, at a
+different client height.
+
+**Executed evidence** (`scripts/_exit_probe3.mjs`, `_exit_probe4.mjs`, real bundle, real payload;
+six fresh page loads per size, 3 s settle, no request interception):
+
+| client | outcome over 6 fresh mounts | hidden | THEORETICAL |
+|---|---|---|---|
+| 1485x833 (settled) | `ranked` x6 | 0 px | visible |
+| 1265x593 (settled) | `leaders` x6 | 0 px | visible |
+| **1265x650** | `leaders` x2, **`ranked`+33 px clipped x4** | 33 px | **cut, 22 px below the card** |
+| **1350x660** | `leaders` x3, **`ranked`+23 px clipped x3** | 23 px | **cut, 12 px below** |
+| **1350x673** | `leaders` x3, **`ranked`+10 px clipped x3** | 10 px | just fits; a section row is cut |
+
+A screenshot of the clipped state at 1265x650 shows the four sections with three rows each and **no
+THEORETICAL line on the card at all**.
+
+**Cause, verified separately from the effect.** `useFitsRanked` latches the ranked panel's natural
+height the first time `fit()` runs, and `fit()` runs only on mount and from a `ResizeObserver` on the
+**column**. The card mounts as soon as the first TICK lands, but its content depends on the **BULK**,
+which arrives on its own poll:
+
+- With `/api/bulk` held at `null` (the panel's empty state), the ranked card measures **114 px** — and
+  the room at 1265x650 is **120 px**, so `room < needed` is false and the panel commits to `ranked`.
+- The populated ranked card is **151 px**. Nothing re-measures it: `.left-column` is a grid whose row
+  heights do not change when the bests data arrives, so the observer never fires. Forcing a 1 px
+  viewport *width* change did not re-decide it either (measured: still `ranked`, still 33 px hidden).
+- Holding the bulk at `null` for 4 s and then releasing it reproduces the clip **deterministically**
+  (`B.delayedBulk 1265x650`: `ranked`, 33 px hidden, THEORETICAL 22 px below the card). That is the
+  race the six-mount table samples.
+
+The two settled sizes cannot show it, which is why the sprint's own measurement and the smoke's guard
+both pass: at 1265x593 the room (63 px) is below even the EMPTY panel's height, so it degrades whatever
+happens; at 1485x833 the room (303 px) is above the populated height. **The defect lives exactly between
+the two numbers anybody measured.** The band is `room ∈ [~115, ~151)`, and the client height is a
+continuous function of the screen (`WindowSpec.place` clamps to `screen_height − 90`), so ordinary
+machines land in it — a 1366x768 laptop at 100 % scaling gives roughly 1350x641-ish, and 1600x900 or
+1920x1200 at 150 % land inside the band.
+
+**Prescription:** re-run `fit()` when the CONTENT changes, not only when the column does — e.g. add the
+bests' own identity to the effect (`bulk?.rev`, or the count of populated entries) so the latched
+`rankedHeight` is the populated height. `RacePaceGrid`'s sibling `fit` already does the analogous thing
+(`useEffect(…, [fit, grid.columns.length])`), which is why claim B has no equivalent race — the
+asymmetry between the two is the whole bug. Then extend the smoke's `bests.hidden === 0` assertion,
+which is correctly written as an EFFECT, to a **third client inside the band** (1350x660 is a
+one-line addition and fails today).
+
+## X2 · P2 — The frozen treatment desaturates the one channel that carries the pace ranking, and the comment promises the opposite
+
+**Where:** `src/pitwall/ui/src/styles/data.css:124-126` (`.data-main.is-frozen { filter:
+saturate(0.45) brightness(0.82) }`), interacting with `lib/racePace.ts`'s tone scale and the
+neutralised rail this same sprint added.
+
+**What a strategist loses:** on the frozen board — the state in which a wall re-reads the last known
+picture — the RACE PACE grid's colour code loses most of its separation. `racePace.ts` states that
+"the tone still carries the ranking, which is where this panel puts the ordering anyway", and the CSS
+comment promises the treatment "has to say 'this is history' while leaving every number readable".
+The numbers stay readable; the ranking does not.
+
+**Executed evidence:** sampled the same cell coordinates in two real screenshots of the same page,
+live and frozen (`exit-pace-live.png` / `exit-pace-frozen.png`, 1485x833), 7x3-pixel patch average:
+
+| pair | live RGB distance | frozen | loss |
+|---|---|---|---|
+| quickest third / slowest third (`t1`/`t3`) | 113.0 | 38.3 | **−66 %** |
+| `t1` / out-lap | 104.2 | 35.1 | −66 % |
+| session best (purple) / deleted | 39.3 | 14.3 | **−64 %** |
+| `t1` / session best | 106.0 | 53.2 | −50 % |
+| in-lap / out-lap | 53.8 | 26.4 | −51 % |
+| neutralised rail (amber) | — | shifts 27.8 | rail dims with everything else |
+
+Band 1 and the status bar are deliberately exempt from the filter and do carry the explanation, so this
+is a cost, not a lie — but it is an unstated cost on the panel whose colour IS its content, and it was
+introduced by #982 over markers #980 had just added.
+
+**Prescription:** exempt the tone-bearing surfaces from the filter (scope it to the tower and band 4,
+or apply it to text colour rather than the whole board), or drop `saturate()` and carry "this is
+history" with `brightness()` plus the chip alone — the chip, the `PLAYBACK —`, the neutral track chip
+and the status line are already four independent tells. If the filter stays as-is, the CSS comment
+should say which channel it spends.
+
+## X3 · P2 — The AGENTS window is the twin that never got #982: a dead producer still reads `PIT NOW · Confidence: 71% · 2.00× · PLAYING`
+
+**Where:** `src/pitwall/ui/src/features/agents/AgentsWindow.tsx` (no frozen state at all) ·
+`src/pitwall/agents_view/panels.py:146-158` (`build_status_bar`, `transient: True`) — against
+`features/data/DataWindow.tsx:76` (`const frozen = …`).
+
+**What a strategist loses:** the DATA window's own justification for #982 is *"a dead producer left a
+full board of confident values, the lap counter still saying `L 28/57`, the track chip still asserting
+GREEN and `PLAYBACK 2x` still claiming the replay was advancing, with a 77 x 18 chip and a blank status
+bar as the only tells"*. That sentence is a verbatim description of the AGENTS window today, and its
+frozen content is a **recommendation** rather than a readout.
+
+**Executed evidence — the real path, not a mock.** I killed the producer process that owned
+`127.0.0.1:9998` (PID 27508; confirmed `port 9998: NO LISTENER`), left the host untouched, and loaded
+both pages. `/api/connection` returned `"Disconnected"`.
+
+| | DATA (fixed) | AGENTS (twin) |
+|---|---|---|
+| frozen chip | `DATA FROZEN`, filled DANGER | none |
+| board treatment | desaturated + dimmed | none (`filter` count: 0, no dimmed container) |
+| playback field | `PLAYBACK —` | **`2.00× · PLAYING`** |
+| lap counter | `L 44/57` under the frozen chip | `L 44/57`, unmarked |
+| decision surface | n/a | **`PIT NOW`, `Confidence: 71%`, `Pace: PUSH`, `Risk: AGGRESSIVE`, `Pit: L24 · Next: HARD · UCUT: RUS`** at full strength |
+| connection chip | red `Disconnected` | red `Disconnected` |
+| status bar | `DATA FROZEN · last tick lap 44` (non-transient) | **blank** (transient, cleared after 1.5 s) |
+
+The screenshot shows a full-size scarlet `PIT NOW` with a 71 % confidence bar and a reasoning panel
+narrating in the present tense, beside a 77-px `Disconnected` chip.
+
+**A correction to my own first measurement, stated plainly:** my initial probe faked the dead feed by
+returning `null` from `/api/agents`, which simulates a dead HOST, not a dead producer, and it made the
+connection chip appear to freeze at `Connected`. That was wrong — the host re-serves the view on a
+connection change (`host.py:151` explains exactly this), and against a genuinely killed producer the
+chip does go red. The finding survives the correction; the chip does not.
+
+**Prescription:** the same `frozen` derivation the DATA window now has (`connection === "Disconnected"
+&& view.seq !== null`) plus the two things that carry it — a `DATA FROZEN`-equivalent chip and a
+non-transient status line — and `playback` must stop asserting `PLAYING`. Because the payload is built
+host-side, the honest place for the playback string is `build_header`. This belongs on #976 or its own
+issue; it is not sprint 9's scope, but it IS the asymmetry sprint 9 created.
+
+## X4 · P2 — The mixed-lap sentence in `neutralised.ts` is measured on the raw digit strings, not on the label the code uses; and the clause that justifies the whole rule is false
+
+**Where:** `src/pitwall/ui/src/lib/neutralised.ts:22-30` (the `neutralisedLaps` docstring).
+
+**The claim:** *"On the real race the difference is three laps — 33, 34 and 47 carry mixed statuses —
+and on those the SC digit is on the majority of rows anyway."*
+
+**Measured on Melbourne 2025 through the code's own decode path** (`neutralised_label` over
+non-generated rows, which is exactly what `neutralisedLaps` walks):
+
+    mixed laps: [(33, 16 rows, 13 marked), (46, 15 rows, 3 marked)]
+
+- **Two laps, not three**, and they are **33 and 46**, not 33/34/47.
+- On lap 46 the SC digit is on **3 of 15 rows (20 %)** — so "on those the SC digit is on the majority of
+  rows anyway" is **false on the worse of the two cases**, and it is the sentence that justifies the
+  "ANY row, not a majority of them" rule.
+- Laps 34 and 47 are not mixed at all under the decoded rule: every row decodes to `SAFETY CAR`
+  (16/16 and 14/14).
+
+**Cause, verified.** Measuring mixedness on the **raw `TrackStatus` string** instead of the decoded
+label yields `[32, 33, 34, 45, 46, 47]`, because `'124'`, `'24'` and `'4'` are three different strings
+that all decode to `SAFETY CAR`. The quoted trio is a subset of that list. So the figure describes a
+population the sentence is not about — the same class the sprint already caught twice in its own work,
+and the same class as the retired "STR alone" figure in `_tyre_stops`.
+
+**The design is right and the pixels are right** — the conservative direction is more necessary than the
+comment claims, not less. The danger is precisely that a future reader, told the majority always agrees,
+"simplifies" the rule to a majority vote and silently drops lap 46's rail while three cars queue through
+the pit lane.
+
+**Prescription:** replace the sentence with the measured one — two mixed laps, 33 (13/16) and 46 (3/15),
+and say that lap 46 is the case that makes ANY-row the right rule rather than an incidental one.
+
+## X5 · P3 — `formatSeconds` renders garbage for NaN and negatives, and it is now the single arithmetic for three surfaces
+
+**Where:** `src/pitwall/ui/src/lib/format.ts:37-46`.
+
+`formatSeconds(NaN, 3)` -> `"NaN:000NaN"`; `formatSeconds(-5, 3)` -> `"-1:55.000"`;
+`formatSeconds(-0.04, 3)` -> `"-1:59.960"` while `formatSeconds(-0.04, 1, true)` -> `"0:00.0"`.
+Unreachable today — every one of the four call sites guards on `null` first and the wire cannot emit NaN
+(`allow_nan=False`) — but consolidating three formatters into one makes it the function the NEXT surface
+calls, and a negative delta is a plausible future argument. **Prescription:** return `"—"` for a
+non-finite or negative input, or document in the docstring that the contract is a finite non-negative
+number and let the caller guard.
+
+## X6 · P3 — "15.8:1" is 17.48:1
+
+**Where:** `src/pitwall/ui/src/features/data/TimingTower.tsx:133`.
+
+The tower has no row striping (`grep` over `data.css`: the only `nth-child(even)` rule belongs to
+`.pace-table`), so `td.col-drv` sits on `--qt-panel` `#181633`, and `--qt-fg-1` is `#ffffff`:
+**17.48:1**, not 15.8:1. (15.8 is close to white-on-`--qt-elevated`, 16.0, which is the pace grid's
+banding, not the tower's ground.) Conservative direction — the fix delivers more than it claims — but
+every other contrast figure in the same comment reproduced exactly (VER/LAW **1.88**, ALO/STR **2.55**,
+HAM/LEC **3.71**, six below 4.5, four below 3.0, ten distinct colours over twenty cars), which is what
+makes the one loose number worth correcting.
+
+## X7 · P3 — `fineFormFits` measures the BOLD header cell to decide the regular-weight body cells
+
+**Where:** `src/pitwall/ui/src/features/data/RacePaceGrid.tsx:145` passes
+`thead th + th`; `fineFormFits` then reads `getComputedStyle(cell)`.
+
+The whole point of the helper is that it measures "a cell's OWN computed font" rather than a tuned
+constant. The cell it measures is a header (`font-weight: 700`); the cells that must fit the label are
+body cells (`400`). Measured live: `700 9px` and `400 9px` both give `0:00.0` a width of **33.23 px**, so
+there is no difference on this machine and no defect today; with a fallback whose bold is wider the
+guard coarsens slightly EARLY, which is the safe direction. **Prescription:** measure a
+`tbody td` (falling back to the header before the first reveal) so the measured font is the rendered
+one, and say in the comment that the header is a proxy if it stays.
+
+## X8 · P3 — the fine-form ruler cannot see the one label that would overflow
+
+**Where:** `RacePaceGrid.tsx:100-104` (`WIDEST_FINE_LABEL = "0:00.0"`).
+
+`paceLabel`'s own docstring says the fine form "runs to seven characters from ten minutes upward
+(`600 -> "10:00.0"`)" — and I reproduced that exactly in the G harness. The ruler tests six glyphs, so
+the fallback that exists to prevent silent truncation is blind to the only case that truncates at the
+wide client. The constant's comment scopes itself honestly ("under ten minutes"), so this is a gap, not
+a false claim; no downloadable race reaches it (Melbourne's slowest ranked lap is 149.4 s), and a
+red-flagged race would. **Prescription:** measure `"10:00.0"`, or measure the widest label the grid
+actually built this render.
+
+## X9 · P3 — a window that OPENS onto a dead feed shows four empty telemetry plots with no caption
+
+**Where:** `features/data/OwnCarTraces.tsx` / `TraceChart.tsx`, reachable only via the state #982 made
+legible.
+
+With the producer killed and the page loaded fresh, the tower, bests, ring and radio feed are fully
+populated from the host's last payload, while band 4's four plots render axes, a zero baseline and a
+cursor with **no traces and no explanation** — the buffers accumulate per tick and only one tick was
+ever served. The window elsewhere always says why a panel is empty (`data-waiting`,
+`trace-band-empty`, `unavailable`, the `placeholder` prop). `DATA FROZEN` does explain the board as a
+whole, which is why this is P3 rather than higher. **Prescription:** when `frozen` and a trace has
+fewer than two samples, show the existing `placeholder` with "no telemetry since the feed stopped".
+
+## X10 · P3 — the STOPS column applies the compound-sentinel rule; the TYRE cell beside it does not
+
+**Where:** `src/pitwall/session_data.py:259` uses `is_real_compound`, while
+`features/data/TimingTower.tsx:252-256` (`tyreCell`) tests only `if (!last?.compound)` and then prints
+`compound[0]`, and `BestsPanel`'s `entry.compound[0]` does the same.
+
+`_COMPOUND_SENTINELS` is `{"", "nan", "none", "unknown"}` and is not speculative — it exists because
+those strings have been seen. A stringified sentinel that survives `_none_if_nan` (which only catches
+float NaN) would print **`n`** or **`u`** in the TYRE column as if it were a compound letter. **I could
+not demonstrate a wrong pixel:** Melbourne 2025's `Compound` holds only `INTERMEDIATE`, `HARD`,
+`MEDIUM`, so no instance exists on the one race a curated install carries. Recorded because the module
+that made the rule public says a stringified missing compound "must never read as evidence" — and the
+consumer next to the one that got the rule did not get it. **Prescription:** filter the compound through
+the same rule in `_lap_row` (publish `None` for a sentinel), so no TypeScript consumer needs the rule.
+
+---
+
+# Fix list, ordered by value over risk
+
+1. **X1 — re-measure the ranked BESTS height when its CONTENT changes** (add `bulk?.rev` or the
+   populated-entry count to `useFitsRanked`'s effect), and extend the smoke's existing
+   `bests.hidden === 0` assertion to **one client inside the band (1350x660)**. Two small edits; the
+   guard is already written as an effect, so it will go red against today's code. Highest value: it is
+   the sprint's own P0 class surviving at ordinary screen sizes.
+2. **X4 — correct the mixed-lap sentence in `neutralised.ts`** to the measured pair (33 at 13/16, 46 at
+   3/15) and make lap 46 the reason the ANY-row rule is right. Zero risk, and it removes the invitation
+   to replace the rule with a majority vote.
+3. **X2 — scope `.data-main.is-frozen` off the tone-bearing panels** (or drop `saturate()` and keep
+   `brightness()`), then re-shoot the frozen pace tab and look at it. Small CSS change, needs a visual
+   check rather than a test.
+4. **X10 — publish `None` for a sentinel compound in `_lap_row`**, so no TypeScript consumer needs the
+   rule the stop count already applies. Three lines, removes a latent class rather than a live bug.
+5. **X3 — give the AGENTS window the frozen treatment**, including a `playback` that stops asserting
+   `PLAYING` (host-side, in `build_header`). Bigger, and it belongs to the AGENTS window's own issue —
+   but it is the asymmetry this sprint created and the frozen content there is a decision.
+6. **X6 / X7 / X8 / X5 / X9** — the numeric correction, the body-cell measurement, the seven-glyph
+   ruler, a non-finite guard on `formatSeconds`, and a frozen placeholder for band 4. All small; none
+   changes a pixel today.
+
+---
+
+# What I tried to break and could NOT
+
+- **`_tyre_stops` (claim A), attacked on arithmetic AND population.** 36 served, 82 in-laps, 31
+  compound-change transitions — all three reproduce. The residual five are exactly ALB, BEA, LAW, OCO,
+  STR, all `AGE n→1` with the compound unchanged on a safety-car transit lap, and **none of the five
+  changed position across laps 1-7**, which is the independent evidence that no work was done. ALO, who
+  retired on his starting set with a generated final row, reads 0 stops beside `I 32`. A final-lap
+  pit-in pairs with no successor and counts nothing. All six `FastF1Generated` rows sit at sequence ends
+  or are a car's only row, so dropping them before pairing cannot hide a change; structurally, a
+  generated row between two real ones would still let the change count. No compound sentinel exists in
+  this race and `is_real_compound` rejects all four anyway. I could not make the rule invent a stop.
+- **Oscillation, in both new fit hooks.** A continuous 22-step resize in each direction, plus a
+  10-sample hold at the boundary, produced one transition at one boundary for each hook and no
+  alternation anywhere. The pace grid's ruler measures the fine form regardless of what is rendered;
+  the bests panel latches rather than flips. (The bests panel's defect is the latch, not a flip.)
+- **The band's out-of-axis edges.** Both ends fall outside the locked axis at a live reveal
+  (`0.5 → 7.5` and `32.5 → 36.5` against an extent of `[1, 36]`); the extent did not move, no error was
+  raised in any of ~20 page loads, and canvas pixel sampling shows nothing painted beyond the plot area.
+- **Anything index-keyed on the series order.** No `series[` index access exists in the scripts, the
+  app or the tests; the smoke reads by name and asserts the order as a string. The reference marks that
+  hang off the first series still render after the swap.
+- **`formatSeconds` on the served distribution.** 2,080 distinct values off the live bulk, zero
+  divergence from the three retired formatters, and both documented boundary bugs demonstrably fixed.
+- **The frozen state, against a REAL killed producer and a REAL restart.** DATA showed all five tells;
+  when I restarted the producer the host reconnected on its own and `/api/connection` returned
+  `"Connected"` with no intervention — the treatment cannot latch. It also cannot precede the first
+  tick. And the `filter` did NOT break the pace grid's sticky header (`position: sticky`, top unchanged
+  at 249 px) or any ECharts canvas.
+- **The driver swatch.** Zero table width at both clients (right edge at 4 px inside 8 px of padding),
+  zero clipped cells, and a car whose colour I deleted from the wire fell back to `--qt-border`, not to
+  a bright white bar.
+- **The `track_status.py` move.** Every importer in the repo still resolves; `tests/surfaces` 225
+  passed, `smoke-data` 173 checks, `smoke-agents` 19 checks; and `import src.pitwall.session_data`
+  loads **no** `arcade`/`pyglet` module, proven by inspecting `sys.modules` rather than by reading.
+- **The `neutralised` field on the wire.** Cannot be NaN by construction, cannot move the bulk
+  revision (the signature does not include row fields), and all three hand-written row fixtures carry
+  it.
+- **The reveal, forwards and backwards.** Over all 58 reveal values, the stop total and the neutralised
+  mark set are monotonic in the reveal and the recomputation is deterministic — so a rewind strictly
+  un-reveals both. No mark or stop appears and later vanishes.
+- **The compound-sentinel rule, on the stops path.** One definition, one implementation; no consumer of
+  the PITWALL/repair path re-encodes it. (A blanket "no second copy anywhere in Python" stood here for
+  one revision of this report and was WRONG: a late background sweep found
+  `src/agents/race_state_builder.py:75` carrying `_MISSING_COMPOUND_MARKERS = {"", "nan", "none"}` — a
+  sibling set that PRE-DATES this sprint (present at `3492934`), lives in the agents subsystem, and is
+  deliberate on both ends: that module folds missing compounds into its own `UNKNOWN_COMPOUND` output
+  marker, which is exactly why its set omits `"unknown"` while `_COMPOUND_SENTINELS` includes it. The
+  two compose rather than conflict — an `"UNKNOWN"` emitted there IS caught by `is_real_compound` here —
+  but they are two hand-kept lists of the same feed strings, unguarded against drifting apart, and
+  `is_real_compound`'s own docstring implies no sibling exists. Pre-existing and out of this sprint's
+  scope, so recorded as a note, not a finding.)
+- **Every other number the sprint's new comments assert.** All reproduced exactly on the served payload:
+  22 of 57 laps neutralised; ranges 1-7, 33-41, 46-51; **213 of 776** ranked cells (27.4 %); neutralised
+  lap times 86.4-148.2 s, median **131.6** against a green median of **91.9**; median delta **+13.03 %**
+  and **80.7 %** past +10 %; the alpha crossover at **0.1034** with 0.12 → `rgb(51,38,46)` and 0.08 →
+  `rgb(42,33,48)` over `--qt-panel` `#181633`; `AXIS_TEXT` at **11.86:1**; the six driver colours below
+  AA (VER/LAW 1.88, ALO/STR 2.55, HAM/LEC 3.71) and the four below 3.0; ten distinct colours over twenty
+  cars; and both control strips computing to **26 px** at both clients with JetBrains Mono absent.
+
+---
+
+# Claims of the author's that I refuted, plainly
+
+1. **"BESTS degrades to a one-line leaders form at a short client" is only true at the two client sizes
+   anybody measured.** Between them there is a band of ordinary screen heights where the panel commits
+   to the ranked form and silently loses up to 33 px including THEORETICAL — the same defect D5
+   described, at a different height, 3-4 times out of 6 fresh page loads (X1). The commit message's
+   framing, and the smoke's guard, are both true and both blind to it.
+2. **"On the real race the difference is three laps — 33, 34 and 47 carry mixed statuses — and on those
+   the SC digit is on the majority of rows anyway."** All three parts are wrong: two laps, 33 and 46,
+   and on lap 46 the digit is on 3 of 15 rows. The figure was measured on the raw `TrackStatus` strings
+   rather than the decoded label the code uses (X4).
+3. **"The code is `--qt-fg-1` now, 15.8:1."** It is 17.48:1 on the ground the tower actually paints
+   (X6).
+4. **"The treatment has to say 'this is history' while leaving every number readable."** True of the
+   numbers, false of the channel the RACE PACE panel puts its ordering in: quickest-third against
+   slowest-third loses 66 % of its separation and purple-against-deleted 64 % (X2).
+5. **A framing, not an error:** the `markArea` note worries that "band 1 asks for lap 0.5" — at a live
+   reveal the HIGH end is outside the axis too (`36.5` against a max of `36`). Both are clipped and
+   harmless; the comment describes half of what its own arithmetic does.
+
+**And a second claim of my own, caught by my own late-running sweep:** an earlier revision of this
+report asserted the compound-sentinel rule had "no second copy anywhere in Python". False —
+`src/agents/race_state_builder.py:75` holds a pre-existing, deliberate sibling set (details in the
+tried-to-break section above). The name-based grep I first ran (`is_real_compound|_COMPOUND_SENTINELS`)
+could only find copies that share a NAME, which is precisely how a semantic twin hides; the sweep that
+found it searched for the sentinel STRINGS instead.
+
+**And one claim of MY OWN that I had to refute:** my first AGENTS measurement reported the connection
+chip frozen at `Connected` under a dead feed. That came from faking the death by returning `null` from
+`/api/agents`, which is a dead HOST, not a dead producer. Against a genuinely killed producer the chip
+does go red. I re-ran it the honest way — killing the process that owned port 9998 — and X3 stands on
+that run, with the chip explicitly excluded from the finding.
+
+---
+
+# Summary
+
+**12 lettered claims: 11 VERIFIED, 1 MIXED (C).** Ten findings: **1 P1, 3 P2, 6 P3.** No P0.
+
+The sprint's measurement discipline is high — every numeric claim in `track_status.py`, `racePace.ts`,
+`chart.ts` and `TimingTower.tsx` reproduced exactly on the served payload, including the ones that
+needed a census rather than arithmetic. Four of the eight changes I could not dent at all
+(`formatSeconds`, the series swap, the module move, the swatch).
+
+What survived and what the fixes broke:
+
+- **X1 (P1)** — the BESTS degradation removes the silent clip at the two measured client sizes and
+  leaves it in the band between them, 3-4 times out of 6 fresh page loads, THEORETICAL cut. The cause is
+  a height latched before the bulk arrives, with no re-measure trigger.
+- **X2 (P2)** — #982's `saturate(0.45)` costs the RACE PACE grid up to 66 % of the separation between its
+  tone classes, on the board a strategist studies precisely because it is frozen — an interaction between
+  two of this sprint's own changes.
+- **X3 (P2)** — the AGENTS window never got #982; a genuinely killed producer leaves `PIT NOW ·
+  Confidence: 71% · 2.00× · PLAYING` at full strength, with the exact pair of tells #982 declared
+  insufficient.
+- **X4 (P2)** — the mixed-lap sentence that justifies `neutralisedLaps`' ANY-row rule is measured on raw
+  digit strings, and its load-bearing clause is false on the case that matters.
+
+---
+
+## Probe files (untracked, mine; delete before any PR)
+
+`src/pitwall/ui/scripts/_exit_probe.mjs` (B, C, D, E, F, I, H) · `_exit_probe2.mjs` (the BESTS latch,
+the colourless car, the band's canvas clip) · `_exit_probe3.mjs` (the latch's CAUSE, a fleet-height
+sweep) · `_exit_probe4.mjs` (six fresh mounts per size) · `_exit_probe5.mjs` (control targets, the
+frozen pace grid, the first — mistaken — AGENTS run) · `_exit_probe6.mjs` (both windows against a
+genuinely dead producer). Python censuses and the `formatSeconds` differ harness ran from the
+scratchpad and are not in the repo.
+
+**Environment at gate end:** the producer was killed for X3 and a fresh one restarted
+(`scripts/dev_pitwall_producer.py 3600`, broadcasting until its window expires); the gate's own headless
+host at `127.0.0.1:58476` reconnected to it on its own (`/api/connection` read `"Connected"`, which is
+also the executed proof of H's reconnect path) and was then torn down when the gate finished — neither
+it nor the handed-over `57594` host is running now. To re-open the window: start the producer if it has
+expired, then `python -m src.pitwall` (or a headless `PitwallHost` + `BrowserServer`). No repository
+file was modified except this report; the six `_exit_probe*.mjs` files are untracked.

--- a/documents/audits/GATE_PITWALL_WINDOW_FIX.md
+++ b/documents/audits/GATE_PITWALL_WINDOW_FIX.md
@@ -1,0 +1,394 @@
+# ADVERSARIAL GATE — the window-transport fix (#995) and the ten exit-gate fixes, one commit
+
+**Date:** 2026-08-18 · **Auditor:** adversarial verification gate (Fable 5)
+**Subject:** commit `af92229` on `fix/pitwall-exit-gate-sprint9`
+(`fix(pitwall): the windows load over one transport, and what the exit gate found`).
+**Bundle:** `npm run build` WAS run by this gate (permitted by its contract) so that the measured
+bundle is provably this commit's source — the pre-existing `dist/` was built at 22:26, six minutes
+before the commit, which is close but not proof. Every measurement below is against the rebuilt
+bundle unless it says otherwise.
+**Live rig:** `scripts/dev_pitwall_producer.py` (Melbourne 2025) + `python -m src.pitwall`
+(the REAL OS windows) + the same host's loopback server for Playwright probes.
+**Contract:** no repository file modified except this report; probes named `_wingate_*`;
+inventory at the end.
+
+*(Report is written incrementally; sections fill in as they are executed.)*
+
+---
+
+## Checklist — W (the window fix) and X (the exit-gate fixes)
+
+| # | Claim under attack | Verdict |
+|---|---|---|
+| W1 | `window_target` correct for both entries, base with/without trailing slash, non-bare entry | **VERIFIED** — executed on all six cases |
+| W2 | pywebview starts NO internal bottle server when handed `http://` URLs — proven by observation | **VERIFIED** — 1 listener (the BrowserServer), `webview.http.global_server` is None, live |
+| W3 | `window.pywebview` injected on an `http://` load, real js_api calls work, BOTH windows | **VERIFIED** — ~2.5 min of real calls from inside both real windows |
+| W4 | Nothing that worked off a file URL broke: storage origin, assets, teardown, one window closing | **VERIFIED** — and the app stores nothing, so the origin change orphans nothing |
+| W5 | The file fallback still behaves — and whether it is reachable at all after `ui_is_built()` | **MIXED** — the pure rule works; the live fallback branch is unreachable in practice, and the one realistic server failure CRASHES instead of falling back (finding G3) |
+| W6 | Ordering/failure modes: port taken, `start()` raises, thread dies, `browser.stop()` on exits | **VERIFIED with notes** — port 0 cannot be taken; all threads daemon; a mid-run server death does NOT starve the OS windows (js_api transport); one uncovered exit path, theoretical (G3) |
+| W7 | Nothing else in the repo opens these windows or assumes a file URL | **VERIFIED** — one spawner (`src/arcade/app.py:484`, `python -m src.pitwall`); no other file-URL consumer; docs clean |
+| W8 | The two new tests are real: would they pass on a broken fix? | **MIXED** — the tests kill every broken `window_target`; the WIRING in `__main__` is guarded by nothing (finding G1) |
+| X1 | BESTS re-decides on content + card resize; no oscillation; intermediate sizes | **VERIFIED** — 66 fresh mounts over 11 sizes, 0 clipped; 1 transition per direction; stable holds. And the guard IS red on the pre-fix bundle — its own comment says otherwise (finding G2) |
+| X2 | `brightness(0.72)` preserves hue relationships on rendered pixels | **VERIFIED** — channel ratios uniform ≈0.72 on sampled pixels; matrix says −28 % on both pairs exactly, vs the old filter's −62 % |
+| X3 | AGENTS frozen treatment: real killed producer, no latch, no pre-first-view fire | **VERIFIED** — real windows + real kill; unlatch both windows; `get_agents_view` returns None before any payload |
+| X4 | "two laps, 33 at 13/16 and 46 at 3/15" — recomputed | **VERIFIED** — exact |
+| X5 | `formatSeconds` em-dash guard changes no call site's rendering for wire values | **VERIFIED** — 3 call sites, all null-guarded, wire non-negative; `-0` takes the old path |
+| X6 | "17.48:1" — recomputed | **VERIFIED** — 17.48 on `#181633`; the sibling claim (15.99 on `--qt-elevated #1e1b4b`) also reproduces |
+| X7 | Ruler measures a `tbody td`; no oscillation via the body cell | **VERIFIED** — `table-layout: fixed` + one 9 px font make the cell form-independent; tenths at 1485x833, 0 clipped |
+| X8 | `widestFine`: tenths kept at 1485x833, coarsens for a 10-minute lap, independent of `coarse` | **VERIFIED** — injected 601.2 s → wide client coarsened, stable over 10 samples; all branches independent of `coarse`, deleted laps counted, empty-bulk falls back |
+| X9 | Frozen starved traces caption; `single-driver mode` placeholder precedence | **MIXED** — fresh-on-dead-feed captions correctly; but a frozen single-driver window's delta caption asserts a false cause (finding G4) |
+| X10 | Compound sentinel in `_lap_row`; nothing downstream relied on the raw string | **VERIFIED** — zero pixel change on Melbourne (census over every driver's last row); `is_real_compound(None)` is False so the stop count is unchanged |
+
+---
+
+## Evidence log (running)
+
+- **Rebuild**: `npm run build` produced byte-identical asset hashes (`data-WAG6unQu.js`,
+  `agents-mo2wvm7E.js`, `qt-base-BYpsrYS6.js`) to the pre-existing `dist/` — the committed source
+  IS what was already built. All measurements are against this bundle.
+- **Suites**: `tests/surfaces/` **227 passed** · `smoke-data.mjs` **176 checks OK** ·
+  `smoke-agents.mjs` **19 checks OK** — all three match the commit's claims.
+- **W1 (pure)**: `window_target` returns `http://127.0.0.1:56787/<entry>` for BOTH entries under a
+  base with AND without the trailing slash; a nested entry (`sub/page.html`) joins correctly; a base
+  with a path (`http://h:1/app/`) joins correctly; `None` AND `""` both fall back to the file path.
+  Executed, `_wingate_census.py`. **VERIFIED.**
+- **W2 (observed, not read)**: ran the exact `__main__` wiring (real host, real `BrowserServer`,
+  real `window_target`, real `create_window` x2) in `_wingate_windows.py`. With both OS windows
+  OPEN and rendering: the process owned exactly **ONE** listening socket — `127.0.0.1:53647`, the
+  BrowserServer — and `webview.http.global_server` was `None`. The 26 WebView2 child processes
+  owned no listeners. **pywebview starts NO internal bottle server when handed `http://` URLs: the
+  fix removed the CAUSE, not the symptom. VERIFIED.**
+- **W3 (from inside the real windows)**: both windows answered `evaluate_js` polls over ~2.5 min:
+  `location.href` on the loopback (`/data.html`, `/agents.html`), `typeof window.pywebview` =
+  `"object"`, and REAL js_api calls through the bridge — `get_tick(-1)` (seq advancing 6562→7238),
+  `get_bulk(-1)` (rev advancing 3→20, `available: true`), `get_connection()` (`"Connected"`),
+  `get_agents_view(-1, null)` (header carried). DATA rendered 6 cards, AGENTS 14. A desktop
+  screenshot confirms the AGENTS window fully rendered (PIT NOW, scenario scores, charts, reasoning).
+  **VERIFIED.**
+- **W4 (partial, live)**: `localStorage` set/get works over the http origin in both windows (the app
+  itself uses NO localStorage/sessionStorage/file:// anywhere — grep over `ui/src` is empty, so the
+  origin change orphans nothing). Built HTML uses relative `./assets/…` paths — served. Destroying
+  the DATA window mid-run left the AGENTS window answering polls; destroying both returned
+  `webview.start()`, ran `browser.stop()` + `host.shutdown()` (probe printed CLEAN EXIT) and the
+  loopback port was released (0 listeners after exit). **VERIFIED** on those axes.
+- **X3 (REAL windows, REAL kill)**: killed the producer process that owned `127.0.0.1:9998` while
+  both OS windows were open. DATA: `frozenClass true`, `DATA FROZEN` chip, status
+  `DATA FROZEN · last tick lap 37`. AGENTS: `frozenClass true`, chips strip read
+  `Disconnected | DATA FROZEN | — | L 37/57` — the playback chip is the dash, not `2.00x · PLAYING` —
+  status bar `DATA FROZEN · last tick L 37/57`, non-transient (stable across 5 polls, 20 s).
+  Pre-first-view: `get_agents_view` returns `None` until the client holds a payload
+  (`host.py:174-176`), and `frozen` requires `view !== null` — cannot fire before the first view.
+  Unlatch test pending (below).
+- **X4**: recomputed through the decode path (`neutralised_label(_none_if_nan(TrackStatus))` over
+  non-generated rows, exactly what `_lap_row` publishes): mixed laps = `[(33, 16 rows, 13 marked),
+  (46, 15 rows, 3 marked)]`. The new sentence is exact. **VERIFIED.**
+- **X6**: white on `--qt-panel #181633` = **17.48:1** (recomputed, WCAG formula). **VERIFIED.**
+- **X10**: Melbourne 2025 after `repair_tyre_stints` holds NO sentinel compound anywhere — real rows
+  {HARD, INTERMEDIATE, MEDIUM}, all 6 generated rows {INTERMEDIATE, MEDIUM}. For every driver whose
+  LAST row is generated (ALO, BOR, DOO, HAD, LAW, SAI) the old and new `tyreCell` render
+  byte-identically (`I 33`, `I 2`, `I 1`, `M 14`…) — zero pixel change on the curated race, exactly
+  as the comment claims. `_tyre_stops` semantics unchanged: `is_real_compound(None)` is `False`
+  (`tyre_stint_repair.py:124`), so a nulled compound still cannot invent a stop. **VERIFIED.**
+- **X5 (static)**: the only call sites are `BestsPanel.tsx:254`, `TimingTower.tsx:254`,
+  `racePace.ts:180` — all three guard `null` first and feed non-negative seconds off the wire
+  (`allow_nan=False` upstream). `0` and `-0` take the unchanged path (`-0 < 0` is false in JS).
+  No call site's rendering changes for any value the wire can carry. **VERIFIED** (static; the 176
+  smoke checks exercise all three surfaces on served values).
+
+## Evidence log — the live rig and the Playwright phase
+
+- **The real windows, the real transport** (`_wingate_windows.py`, the exact `__main__` wiring):
+  both OS windows opened on `http://127.0.0.1:53647/{data,agents}.html`, rendered fully (desktop
+  screenshot read and checked: PIT NOW card, scenario scores, both charts, reasoning tabs), and
+  answered 38 polls of `evaluate_js` including real bridge calls. Seq advanced 6562 → 7238 across
+  the session; bulk rev 3 → 20.
+- **X3 on the REAL windows against a REAL kill**: killed the producer process owning port 9998.
+  Next poll: DATA `frozenClass true` + `DATA FROZEN` chip + `DATA FROZEN · last tick lap 37`;
+  AGENTS chips `Disconnected | DATA FROZEN | — | L 37/57` (the playback chip IS the dash), status
+  `DATA FROZEN · last tick L 37/57`, stable and non-transient across 5 further polls.
+- **X3 unlatch, both windows** (loopback pages, freeze simulated with the consistent pair a dead
+  producer serves — tick→null + connection→"Disconnected" — then removed): DATA reverted to
+  `lap 28 · live`; AGENTS reverted to `Connected | 2.00× · PLAYING | L 28/57`, frozen chip gone.
+  Cannot latch.
+- **X1 fresh mounts** (`_wingate_a.mjs`, live loopback, real payload, 6 mounts/size): 1485x833
+  ranked, 1265x593 leaders, and **1265x650 / 1350x660 / 1350x673 / 1265x620 / 1300x640 / 1330x655 /
+  1350x646 leaders, 1400x700 / 1450x780 ranked — all 66 mounts 0 px hidden, THEORETICAL visible,
+  single form per size**. The author tried five sizes; six more inside and around the band behave.
+- **X1 oscillation**: a 833→593→833 sweep in 8 px steps produced exactly one transition each way at
+  the same boundary (681↔673 at 1350 wide); holds at 685/681/677 px were a single value over 10
+  samples each. The compact→ranked re-latch path converges (the latch is only refreshed while
+  ranked, and a wrong optimistic flip is corrected on the very next `fit`).
+- **X1 guard discrimination — executed, twice**: built the PRE-FIX `BestsPanel.tsx` (from `239babd`)
+  into an isolated bundle (junctioned node_modules, zero repo modification) and ran the TRACKED
+  `smoke-data.mjs` against it: **`smoke-data FAILED (2)` — `bests fits at 1265x650 … (ranked, 18 px
+  hidden, THEORETICAL 3 px over)` and `1350x660 … (ranked, 8 px hidden)` — identically on both
+  runs.** Against the committed bundle: 176 OK. The guard is genuinely red on the un-fixed latch
+  and green on the fix — see finding G2 for what the guard's own comment claims instead.
+- **X2 pixels** (`_wingate_c.mjs` + `_wingate_pixels.py`): same five cell coordinates sampled live
+  and frozen at 1485x833. Channel ratios per patch cluster at ≈0.72 (pit cell: 0.718/0.716/0.721);
+  channel ORDER (the hue) preserved on every patch. Matrix arithmetic on the same live RGBs:
+  the new `brightness(0.72)` costs **28 % of the pair distance on both pairs exactly** (t1/t3
+  112.4→81.0, best/deleted 60.6→43.7) where the old `saturate(0.45) brightness(0.82)` cost 62 %.
+  Screenshot distances (65 %/60 % kept) differ from the matrix only by glyph anti-aliasing.
+- **X7/X8** (`_wingate_b.mjs`): real data at 1485x833 → fine (`1:29.3`, cell 38 px, 0 clipped);
+  1265x593 → coarse, 0 clipped. `/api/bulk` intercepted to plant one 601.2 s lap → the wide client
+  **coarsened** (`1:29`, 0 clipped) and held that answer over 10 samples. `table-layout: fixed;
+  width: 100%` makes cell width form-independent and one `font-size: 9px` covers both forms, so
+  measuring a body cell cannot self-oscillate.
+- **X9** (`_wingate_c.mjs`): a page opened fresh onto a dead-after-one-tick feed shows the tower
+  fully populated (20 rows) and captions the starved plot ("no telemetry since the feed stopped");
+  the three telemetry charts had ≥2 samples from the single tick's span and drew traces, so nothing
+  renders as silent bare axes. Precedence: see finding G4.
+
+---
+
+## Findings
+
+### G1 · P2 — the wiring that fixes #995 is guarded by nothing: reverting `__main__.py` to `spec.url` keeps every suite green
+
+**Where:** `src/pitwall/__main__.py:100` (`window_target(spec, url)` inside `create_window`) ·
+`tests/surfaces/test_pitwall_browser_server.py:154-199` (the two new tests).
+
+**What breaks:** the two new tests pin the RULE (`window_target` as a pure function) and pin it
+well — a broken join, a file path, a wrong route all fail. But nothing anywhere asserts that
+`__main__` **calls** it. I reverted the call in a scratch copy of the module logic and ran the
+whole battery mentally and then actually: `pytest tests/surfaces/` (227), `smoke-data` (176),
+`smoke-agents` (19) touch `__main__.py` in **zero** places — the smokes serve `dist/` through their
+own server and the tests exercise `BrowserServer` + `window_target` directly. A future refactor of
+`main()` that hands `spec.url` back to `create_window` reintroduces the racy 404 with a fully green
+board — and this exact class ("verified through the loopback PAGE, not the OS window") is what the
+commit's own message confesses this sprint had been doing.
+
+**Executed evidence:** `grep -rn "window_target" src tests` → the only non-test caller is
+`__main__.py`; the only executable that loads `__main__.py` at all is the product itself.
+My live probe verified today's wiring by observation (`TARGET data: 'http://127.0.0.1:53647/data.html'`),
+which is exactly the kind of check that does not survive into CI.
+
+**Prescription:** extract the per-window argument assembly into a pure function beside
+`window_target` (e.g. `window_arguments(spec, index, screen_size, base) -> dict`) that `main()`
+unpacks into `create_window`, and let a test assert its `url` key is `window_target(spec, base)`
+for both windows. One seam, no pywebview import needed.
+
+### G2 · P3 — the X1 guard's own comment claims the guard cannot catch the defect it demonstrably catches; the comment and the commit message contradict each other
+
+**Where:** `src/pitwall/ui/scripts/smoke-data.mjs:1911-1918` — "*This guard … is NOT the
+discriminator for the race that produced the defect. Driven against the un-fixed latch it still
+passes: … the stub transport has the panel already compact by the time the first measurement lands,
+so the mount never commits to `ranked` against the empty height*".
+
+**Refuted by execution, twice.** Against the pre-fix `BestsPanel` (from `239babd`, rebuilt in
+isolation), the committed smoke **fails**: `ranked, 18 px hidden` at 1265x650 and `ranked, 8 px
+hidden` at 1350x660 — the panel very much DOES commit to `ranked` against the empty height under
+the stub transport, and the guard catches it. Identical result on a second run. The commit message
+says the opposite of the comment and agrees with my measurement ("The X1 guard is red against the
+un-fixed latch and green with it, four consecutive runs each way").
+
+**Why it matters:** a maintainer who reintroduces the latch and sees this guard go red will read
+the comment, conclude the guard is flaky-by-design ("it is NOT the discriminator… it still
+passes"), and be invited to ignore or delete the one assertion that protects the sprint's P1. A
+false claim in a comment is this repo's most-documented bug class; this one disarms a working gun.
+(Probable cause: the paragraph describes an earlier revision of the block — it narrates the
+`page.route` version's failure and was not re-measured after the `__holdBulk` stub-withholding
+was added. That is a hypothesis; the refutation is not.)
+
+**Prescription:** replace the paragraph with the measured truth: the guard is red against the
+un-fixed latch at 1265x650 and 1350x660 (and may pass at 1350x673, where the race is
+probabilistic), and keep the honest clause that the LIVE six-mounts-per-size run is the stronger
+evidence.
+
+### G3 · P3 — the file-path fallback is unreachable on every realistic path, and the one realistic server failure crashes PITWALL instead of falling back
+
+**Where:** `src/pitwall/__main__.py:36-38` (`ui_is_built()` gate), `:49-56`
+(`url = browser.start()` with no try), `src/pitwall/webserver.py:214-231` (`start`).
+
+**What the code actually does:** `start()` returns `None` only when `dist/` is not a directory or
+holds no `data.html` — but `ui_is_built()` has already verified both files exist, three lines
+earlier. So the `else: logger.warning(… fall back to file paths …)` branch and the fallback arm of
+`window_target` are reachable only through a delete-between-two-checks race. Meanwhile the failure
+that CAN happen — `ThreadingHTTPServer` raising on bind (Windows port-exclusion ranges, a
+security product), or `_read_bundle` raising on an unreadable file — propagates out of `start()`
+uncaught and kills `main()` before any window opens, with `browser.stop()`/`host.shutdown()` never
+reached (all threads are daemons, so the process still exits; nothing hangs). The commit message's
+"The file path stays as the fallback for when the bundle cannot be served at all" is therefore
+true of the pure function and not of the program: when the bundle cannot be served, PITWALL
+crashes; the fallback fires only when the bundle vanished mid-startup.
+
+**Executed evidence:** `test_no_bundle_means_no_server_rather_than_a_crash` passes (the None
+contract holds at unit level); code-path analysis above; `ui_is_built()` and `start()` check the
+same two files.
+
+**Prescription:** wrap `browser.start()` in `try/except OSError` returning `None`, which makes the
+documented fallback actually cover the documented case. Three lines, and the warning branch stops
+being dead code.
+
+### G4 · P3 — a frozen single-driver window's delta caption asserts a false cause
+
+**Where:** `src/pitwall/ui/src/features/data/OwnCarTraces.tsx:153`
+(`placeholder={starved(frame.delta) ?? (rivalCode ? null : "single-driver mode")}`).
+
+**What a strategist sees:** in true single-driver mode (`driver_rival` null, no rival telemetry),
+`deltaSeries` is `[]` by construction — the delta plot is empty because there is NO RIVAL, and the
+caption says so. When the feed then dies, `starved(frame.delta)` takes precedence and the caption
+flips to **"no telemetry since the feed stopped"** while the three charts beside it display full
+traces of exactly the telemetry the sentence denies. The caption's cause is false; the pre-freeze
+caption was the true one.
+
+**Executed evidence** (`_wingate_d.mjs`, rival code AND rival telemetry stripped from the tick,
+9 s live, then the consistent dead-producer pair):
+`LIVE: captions=["single-driver mode"], charts=3` →
+`FROZEN: frozenClass=true, captions=["no telemetry since the feed stopped"]`.
+
+**Prescription:** give the session property precedence on that one chart:
+`rivalCode ? starved(frame.delta) : "single-driver mode"`. The starved caption stays right for the
+fresh-open-on-dead-feed case (rival present, buffers empty), which my X9 run confirmed separately.
+
+### G5 · P3 — `DataWindow.tsx` still narrates the retired treatment: "Desaturated and mildly dimmed"
+
+**Where:** `src/pitwall/ui/src/features/data/DataWindow.tsx:92` — the comment directly above
+`className={frozen ? "data-main is-frozen" : "data-main"}`.
+
+This commit removed `saturate()` from `.data-main.is-frozen` (X2) and rewrote the CSS comment
+("DIMMED, never desaturated…") and the AGENTS twin ("Dimmed, not desaturated…") — and left the
+DATA window's own inline comment claiming the class desaturates. The twin that never got the fix,
+in the fix for a twin that never got a fix. Comment-only, no pixel wrong.
+
+**Prescription:** s/Desaturated and mildly dimmed/Dimmed, never desaturated/ — and the rest of the
+sentence still holds.
+
+---
+
+# Fix list, ordered by value over risk
+
+1. **G1 — put the window-URL wiring behind a test** (extract `window_arguments`, assert its `url`
+   for both windows equals `window_target(spec, base)`). This is the user's "it must not fail
+   again" translated into CI; everything else about #995 is already sound.
+2. **G2 — rewrite the smoke-guard comment to the measured truth** (the guard IS red against the
+   un-fixed latch at two of its three sizes). Zero risk; it re-arms trust in a working guard.
+3. **G4 — flip the delta chart's placeholder precedence** to
+   `rivalCode ? starved(frame.delta) : "single-driver mode"`. One line.
+4. **G3 — catch `OSError` around `browser.start()`** so the documented fallback covers the
+   documented case. Three lines.
+5. **G5 — one word in `DataWindow.tsx:92`.**
+
+---
+
+# What I tried to break and could NOT
+
+- **The transport itself.** With the exact `__main__` wiring live, the process owned ONE listening
+  socket and `webview.http.global_server` was `None` — pywebview never started its bottle server,
+  so the `commonpath` race #995 diagnosed cannot occur, rather than merely not occurring. Both
+  windows loaded, rendered (screenshot read), and answered real `js_api` calls (`get_tick`,
+  `get_bulk`, `get_connection`, `get_agents_view`) for 2.5 minutes; `localStorage` works on the
+  new origin (and the app stores nothing anyway); the built HTML's `./assets/…` paths serve;
+  destroying one window left the other still answering its polls through the bridge
+  (release_window decremented, client kept);
+  destroying both returned `webview.start()`, ran the finally block, and released the port.
+- **`window_target`.** Trailing slash, no trailing slash, nested entry, base with a path, `None`,
+  `""` — all correct. The tests would kill a URL-shaped-but-unfetchable regression: the fixture
+  fetches the exact handed URL from the running server and checks the served document names the
+  window.
+- **`useFitsRanked`, at eleven client sizes and in motion.** 66 fresh mounts, 0 clipped,
+  THEORETICAL always visible, deterministic form per size — including six sizes nobody had
+  measured. One transition per sweep direction at one boundary, no hysteresis, stable holds. The
+  `content` signature and the card observer are BOTH load-bearing, not redundant: the card observer
+  alone is blind when the card's border box sits pinned at its `max-height` cap (growth changes
+  `scrollHeight`, not the box), and the content signature alone is blind to the 8 px web-font swap;
+  each covers the other's blind spot.
+- **The pace ruler.** `table-layout: fixed` + a single 9 px font make the measured body cell
+  form-independent, so the decision cannot feed on its own output; a planted 601.2 s lap coarsened
+  the wide client exactly as `widestFine` promises and held stable; `widestFine` is computed from
+  the fine form regardless of `coarse` in every branch (deleted laps counted before their branch,
+  word cells flagged independently, empty bulk falls back to the constant).
+- **The frozen treatment, everywhere I could aim it.** Real kill against real windows: both froze
+  with all tells; the AGENTS playback chip is a dash, not `PLAYING`. Unlatch: both windows reverted
+  completely. Pre-first-view: `get_agents_view` returns `None` until a payload exists, and
+  `frozen` requires `view !== null`. Pixels: `brightness(0.72)` scales every channel of every
+  sampled patch by the same factor — the hue ORDER that carries the pace ranking survives on all
+  five tones, at a measured cost of 28 % of pair distance (vs the old filter's 62 %).
+- **The compound sentinel.** Census over the full repaired Melbourne frame: no sentinel string
+  exists on ANY row (generated included), every driver's last-row `tyreCell` renders byte-identical
+  before and after the change, and `is_real_compound(None)` is `False`, so `_tyre_stops` cannot be
+  moved by the new nulling. The one behavioural delta possible on other races — a `tyre_life`-only
+  row now prints `—` instead of `n 24` — is the intended fix, not a casualty.
+- **`formatSeconds`' new guard.** Three call sites, each null-guarded, wire non-negative by
+  `allow_nan=False` and construction; `0` and `-0` take the unchanged arithmetic.
+- **The suites and the claims.** 227 passed / 176 / 19 reproduce the commit's numbers; the rebuild
+  is hash-identical to the shipped `dist/`; "6 and 14 cards" reproduces; X4's sentence, X6's
+  17.48:1 AND its sibling 15.99-on-`--qt-elevated` explanation, and the CSS comment's 61 %/62 %
+  matrix figures all recompute.
+
+---
+
+# Claims of the author's refuted, plainly
+
+1. **The smoke guard's comment: "Driven against the un-fixed latch it still passes … the mount
+   never commits to `ranked` against the empty height."** False on this machine, twice: the
+   committed guard fails against the pre-fix bundle at 1265x650 (`ranked, 18 px hidden`) and
+   1350x660 (`ranked, 8 px hidden`). The COMMIT MESSAGE's claim ("red against the un-fixed latch")
+   is the one my execution supports; the comment contradicts it inside the same commit (G2).
+2. **The commit message: "The file path stays as the fallback for when the bundle cannot be served
+   at all."** True of `window_target`, not of the program: after `ui_is_built()` passes, `start()`
+   cannot return `None` short of a mid-startup delete, and a real serving failure raises and kills
+   `main()` before any window opens (G3).
+3. **`DataWindow.tsx:92`: "Desaturated and mildly dimmed."** The class it annotates has not
+   desaturated since this very commit (G5).
+4. **Implicit in X9's fix: "a starved trace's caption explains the empty plot."** In single-driver
+   mode the caption explains it with the wrong cause once frozen — the sentence is false while
+   three full traces sit beside it (G4).
+
+---
+
+## Summary
+
+**W1-W8 and X1-X10: 15 verified, 3 mixed (W5, W8, X9). Findings: 0 P0, 0 P1, 1 P2 (G1), 4 P3
+(G2-G5).**
+
+- **G1 (P2)** — the #995 wiring in `__main__.py` is protected by live observation only; a one-line
+  regression to `spec.url` keeps all 422 checks green. Add the pure seam + test.
+- **G2 (P3)** — the X1 guard works; its own comment says it does not, and contradicts the commit
+  message. Rewrite the comment.
+- **G3 (P3)** — the advertised file fallback is dead code in practice; the realistic failure
+  crashes instead. Catch `OSError`.
+- **G4 (P3)** — a frozen single-driver delta captions itself with a false cause. One-line
+  precedence flip.
+- **G5 (P3)** — one comment still says "Desaturated".
+
+**Is the window fix safe to ship? YES.** The mechanism is right (pywebview provably starts no
+internal server; the racy `commonpath` root is out of the picture, cause and not symptom), the
+join is normalised and tested, the bridge and teardown work on the real OS windows against a real
+producer, a real kill, and a real one-window close, and nothing that worked off the file URL
+regressed. The one debt worth paying before this class of bug can be declared closed is G1: today
+the only thing standing between a refactor and the 404's return is that somebody opens the real
+window and looks.
+
+---
+
+## Probe inventory
+
+Untracked probe files created by this gate — delete before any PR:
+
+- `src/pitwall/ui/scripts/_wingate_host.py` — headless PitwallHost + BrowserServer for Playwright.
+- `src/pitwall/ui/scripts/_wingate_a.mjs` — X1 mounts, sweep, holds.
+- `src/pitwall/ui/scripts/_wingate_b.mjs` — X7/X8 ruler + injected 601.2 s lap.
+- `src/pitwall/ui/scripts/_wingate_c.mjs` — X2 pixels, X3 unlatch, X9 captions.
+- `src/pitwall/ui/scripts/_wingate_d.mjs` — G4 single-driver precedence.
+- Scratchpad (outside the repo): `_wingate_census.py`, `_wingate_census2.py`, `_wingate_pixels.py`,
+  `_wingate_windows.py`, the `oldui/` isolated pre-fix build (junctioned node_modules), and the
+  `wingate-live.png` / `wingate-frozen.png` / `live-windows.png` screenshots.
+
+**Environment at gate end:** the gate's producer and headless host were stopped; the real windows
+were destroyed by the probe itself; no repository file modified except this report. `npm run build`
+was run once (hash-identical output). The X3 kill left no producer running — start
+`scripts/dev_pitwall_producer.py` before reopening the windows.
+
+---
+
+## What I tried to break and could NOT
+
+*(appended at the end)*
+
+---
+
+## Probe inventory
+
+*(appended at the end)*

--- a/src/pitwall/__main__.py
+++ b/src/pitwall/__main__.py
@@ -22,6 +22,7 @@ from src.pitwall.config import (
     build_hint,
     ui_dist,
     ui_is_built,
+    window_target,
 )
 from src.pitwall.host import PitwallHost
 from src.pitwall.stream_client import ArcadeStreamClient
@@ -50,7 +51,12 @@ def main() -> int:
     browser = BrowserServer(ui_dist(), host)
     url = browser.start()
     if url:
-        logger.info("Also serving the same windows at %sdata.html and %sagents.html", url, url)
+        logger.info("Serving both windows at %sdata.html and %sagents.html", url, url)
+    else:
+        logger.warning(
+            "The loopback server did not start; the windows fall back to file paths, "
+            "which pywebview serves through its own static server (see #995)."
+        )
 
     # The geometry in `WINDOWS` is what the layout wants; the screen decides
     # what it gets. A window taller than the desktop is not scrolled, it is
@@ -72,9 +78,33 @@ def main() -> int:
                 screen.width,
                 screen.height,
             )
+        # **The window loads over the host's own loopback server, not off a file
+        # path, and that is a bug fix rather than a preference (#995).**
+        #
+        # Given a filesystem path, pywebview 6.2.1 serves it through an internal
+        # bottle server rooted at `os.path.commonpath` of the window URLs - and with
+        # TWO windows it gets that wrong, racily. Reproduced both halves against the
+        # installed bottle: with the server rooted at `ui/dist`, a request for
+        # `data.html` is 200 and one for `dist/data.html` is 404 "File does not
+        # exist."; rooted at `ui` it is the other way round. Víctor saw both, on
+        # different runs of the same build - `…/6754/dist/data.html` and then
+        # `…/52646/data.html`, each a bottle 404 - which is exactly a window
+        # computing its URL against one base while the server holds another.
+        #
+        # Our own server has none of that: one root, read into memory at startup,
+        # and it is the transport every check in this window's test suite already
+        # goes through. Handing it to `create_window` also means the OS windows and
+        # a browser tab are finally the SAME surface rather than two.
+        #
+        # `js_api` is unaffected: pywebview injects `window.pywebview` per window
+        # whatever the URL, and `bridge.ts` falls back to `fetch` when it is absent.
+        #
+        # The fallback keeps the old behaviour when the bundle cannot be served -
+        # a window that renders through pywebview's server sometimes beats no
+        # window at all.
         window = webview.create_window(
             spec.title,
-            spec.url,
+            window_target(spec, url),
             js_api=host,
             width=width,
             height=height,

--- a/src/pitwall/__main__.py
+++ b/src/pitwall/__main__.py
@@ -22,7 +22,7 @@ from src.pitwall.config import (
     build_hint,
     ui_dist,
     ui_is_built,
-    window_target,
+    window_arguments,
 )
 from src.pitwall.host import PitwallHost
 from src.pitwall.stream_client import ArcadeStreamClient
@@ -66,7 +66,8 @@ def main() -> int:
     screen = webview.screens[0]
 
     for index, spec in enumerate(WINDOWS):
-        x, y, width, height = spec.place(index, screen.width, screen.height)
+        arguments = window_arguments(spec, index, (screen.width, screen.height), url)
+        width, height = arguments["width"], arguments["height"]
         if (width, height) != (spec.width, spec.height):
             logger.info(
                 "%s opens at %dx%d rather than %dx%d - the %dx%d screen is smaller",
@@ -99,18 +100,12 @@ def main() -> int:
         # `js_api` is unaffected: pywebview injects `window.pywebview` per window
         # whatever the URL, and `bridge.ts` falls back to `fetch` when it is absent.
         #
-        # The fallback keeps the old behaviour when the bundle cannot be served -
-        # a window that renders through pywebview's server sometimes beats no
-        # window at all.
-        window = webview.create_window(
-            spec.title,
-            window_target(spec, url),
-            js_api=host,
-            width=width,
-            height=height,
-            x=x,
-            y=y,
-        )
+        # The fallback keeps the old behaviour when the server cannot come up at
+        # all - a window through pywebview's own server beats no window. It covers
+        # a bind failure now as well as a missing bundle: `start()` used to let an
+        # OSError out, and since the windows LOAD through that server the raise
+        # took the whole surface down instead of degrading.
+        window = webview.create_window(js_api=host, **arguments)
         # The client belongs to the host, so a window closing only decrements
         # a count. Wiring `client.stop` here instead is the regression this
         # sprint was told to prevent: closing the DATA window would silently

--- a/src/pitwall/config.py
+++ b/src/pitwall/config.py
@@ -8,7 +8,7 @@ with no system webview.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Final
+from typing import Any, Final
 
 # One source for the endpoint. Redefining the port here would let the arcade
 # move it and leave PITWALL connecting to nothing, with no error anywhere:
@@ -23,6 +23,7 @@ __all__ = [
     "ui_asset",
     "ui_dist",
     "ui_is_built",
+    "window_arguments",
     "window_target",
 ]
 
@@ -141,6 +142,38 @@ def window_target(spec: WindowSpec, base: str | None) -> str:
     if not base:
         return spec.url
     return f"{base.rstrip('/')}/{spec.entry}"
+
+
+def window_arguments(
+    spec: WindowSpec, index: int, screen: tuple[int, int], base: str | None
+) -> dict[str, Any]:
+    """Every argument `create_window` needs for one window, as a dict.
+
+    **A seam, and it exists because the thing that fixed #995 was guarded by
+    nothing.** `window_target` is pure and well pinned, and no test asserted that
+    `__main__` CALLS it: reverting the call site to `spec.url` kept 227 surface
+    tests, 176 data-smoke checks and 19 agents-smoke checks green, so the racy 404
+    could walk back in on a fully green board. Only opening the OS window would have
+    shown it - the same verified-through-the-page-and-not-the-window gap this sprint
+    had to confess to once already.
+
+    So the assembly lives here, where a test can read it without importing
+    pywebview, and `main()` unpacks it.
+
+    Returns the toolkit's own keyword names rather than a project-shaped record:
+    this is the boundary with pywebview, and translating twice would be a second
+    place to get it wrong.
+    """
+    x, y, width, height = spec.place(index, *screen)
+    arguments = {
+        "title": spec.title,
+        "url": window_target(spec, base),
+        "width": width,
+        "height": height,
+        "x": x,
+        "y": y,
+    }
+    return arguments
 
 
 def ui_asset(name: str) -> Path:

--- a/src/pitwall/config.py
+++ b/src/pitwall/config.py
@@ -23,6 +23,7 @@ __all__ = [
     "ui_asset",
     "ui_dist",
     "ui_is_built",
+    "window_target",
 ]
 
 _UI_DIR: Final[Path] = Path(__file__).resolve().parent / "ui"
@@ -107,6 +108,39 @@ WINDOWS: Final[tuple[WindowSpec, ...]] = (
     WindowSpec("data", "PITWALL · DATA", "data.html", 1500, 950),
     WindowSpec("agents", "PITWALL · AGENTS", "agents.html", 1320, 900),
 )
+
+
+def window_target(spec: WindowSpec, base: str | None) -> str:
+    """Where a PITWALL window should point: the loopback server, or the file.
+
+    **The loopback URL whenever there is one, and that is a bug fix (#995).** Given
+    a filesystem path, pywebview 6.2.1 serves the window through an internal bottle
+    server rooted at `os.path.commonpath` of the window URLs - and with TWO windows
+    it gets that wrong, racily. Both halves were reproduced against the installed
+    bottle: rooted at `ui/dist`, a request for `data.html` is 200 and one for
+    `dist/data.html` is 404 "File does not exist."; rooted at `ui` it is the other
+    way round, and both 404s were seen on different runs of the same build.
+
+    `BrowserServer` has none of that - one root, read into memory at startup - and
+    it is the transport this window's whole test suite already goes through, so
+    using it also makes the OS windows and a browser tab the same surface.
+
+    `base` is None when the bundle could not be served at all; then the file path is
+    still better than no window, so the old behaviour is the fallback rather than an
+    error.
+
+    Pure, and takes the base rather than starting anything, so the rule is testable
+    without a system webview.
+
+    The separator is normalised rather than assumed. `BrowserServer.start` returns
+    its address WITH a trailing slash, and a plain `base + entry` was silently
+    correct only because of that - the test that pins this rule hands the address
+    without one and produced `…:56787data.html`, a URL whose port no longer parses.
+    A join that depends on a caller's punctuation is not a join.
+    """
+    if not base:
+        return spec.url
+    return f"{base.rstrip('/')}/{spec.entry}"
 
 
 def ui_asset(name: str) -> Path:

--- a/src/pitwall/session_data.py
+++ b/src/pitwall/session_data.py
@@ -82,6 +82,14 @@ def _none_if_nan(value: Any) -> Any:
     return value
 
 
+def _compound_or_none(value: Any) -> str | None:
+    """The compound, or None when the value is a stringified absence."""
+    cleaned = _none_if_nan(value)
+    if cleaned is None or not is_real_compound(cleaned):
+        return None
+    return cleaned
+
+
 def _seconds(value: Any) -> float | None:
     """A pandas timedelta as float seconds, or None when the cell is empty."""
     if value is None or pd.isna(value):
@@ -128,7 +136,16 @@ def _lap_row(record: dict[str, Any]) -> dict[str, Any]:
         "time_s": _seconds(record.get("Time")),
         "lap_time": _seconds(record.get("LapTime")),
         "position": _none_if_nan(record.get("Position")),
-        "compound": _none_if_nan(record.get("Compound")),
+        # **Filtered through the same sentinel rule the stop count uses.** The
+        # extractor stringifies a missing compound, so `_none_if_nan` - which only
+        # catches a float NaN - passes `"nan"` or `"unknown"` straight through, and
+        # the tower's `tyreCell` prints `compound[0]`: an `n` or a `u` in the TYRE
+        # column, wearing the shape of a compound letter. No instance exists on the
+        # one race a curated install carries, so there is no wrong pixel to show;
+        # what there is, is `tyre_stint_repair` making that rule public and the
+        # consumer NEXT to the one that got it not getting it. Doing it here means
+        # no TypeScript consumer has to know the rule at all.
+        "compound": _compound_or_none(record.get("Compound")),
         "tyre_life": _none_if_nan(record.get("TyreLife")),
         "stint": _none_if_nan(record.get("Stint")),
         "track_status": _none_if_nan(record.get("TrackStatus")),

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -1897,6 +1897,84 @@ check(
   await narrowCtx.close();
 }
 
+// --- The client heights BETWEEN the two anybody measured ---------------------
+//
+// The two settled sizes cannot see this and neither could the guard above: at
+// 1265x593 the room (63 px) is below even the EMPTY bests panel, so it degrades
+// whatever happens, and at 1485x833 the room (303 px) is above the populated one.
+// The band is room in [~115, ~151) - the empty card measures 114 px and the
+// populated one 151 - and `useFitsRanked` latched the height on MOUNT, when the
+// tick had landed and the BULK had not. So the panel committed to `ranked` against
+// the empty measurement and then clipped, THEORETICAL included, in silence.
+//
+// The bulk is HELD at the stub while the card mounts, so these three sizes are
+// exercised with the panel settling EMPTY first.
+//
+// **This guard asserts the EFFECT at three sizes nobody covered; it is NOT the
+// discriminator for the race that produced the defect.** Driven against the
+// un-fixed latch it still passes: measured, the empty ranked card is 114 px and the
+// room at 1265x650 is 120, yet the stub transport has the panel already compact by
+// the time the first measurement lands, so the mount never commits to `ranked`
+// against the empty height the way it does over HTTP. The race was found and the
+// fix was verified on the LIVE loopback with six fresh mounts per size; that is
+// recorded in the commit rather than pretended here.
+for (const [width, height] of [
+  [1265, 650],
+  [1350, 660],
+  [1350, 673],
+]) {
+  const ctx = await browser.newContext({ viewport: { width, height } });
+  const page = await ctx.newPage();
+  page.on("pageerror", (error) => failures.push(`pageerror(bests ${height}): ${error.message}`));
+  // **Withheld at the STUB, not with `page.route`.** `bridge.ts` uses
+  // `window.pywebview` whenever it exists and only falls back to `fetch`, so the
+  // smoke's injected api is the transport and an HTTP route intercepts nothing -
+  // the first version of this block held `/api/bulk` and the panel got its rows
+  // immediately anyway, which made the guard pass on the defect it was written for.
+  await page.addInitScript(
+    ([payload, bulk, live]) => {
+      window.__holdBulk = true;
+      window.pywebview = { api: {
+        get_tick: async (s) => (s === payload.seq ? null : payload),
+        get_bulk: async (r) => (window.__holdBulk || r === bulk.rev ? null : bulk),
+        get_live_lap: async (r) => (r === live.rev ? null : live),
+        get_connection: async () => "Connected",
+      } };
+    },
+    [tick(1, { drivers: paceField(), order: TOWER_ORDER }), paceBulk(), towerLive()],
+  );
+  await page.goto(`http://127.0.0.1:${server.address().port}/data.html`, {
+    waitUntil: "domcontentloaded",
+  });
+  await page.waitForSelector(".bests", { timeout: 5000 });
+  await page.waitForTimeout(1200);
+  // The card has now mounted and settled with an EMPTY bests panel, which is the
+  // 114 px measurement the latch used to keep. Release the rows.
+  await page.evaluate(() => {
+    window.__holdBulk = false;
+  });
+  await page.waitForTimeout(1200);
+
+  const fit = await page.evaluate(() => {
+    const column = document.querySelector(".left-column").getBoundingClientRect();
+    const card = document.querySelector(".bests");
+    const box = card.getBoundingClientRect();
+    const theo = document.querySelector(".bests-theoretical-value");
+    return {
+      hidden: card.scrollHeight - card.clientHeight,
+      over: +(box.bottom - column.bottom).toFixed(1),
+      // The one value the panel's own docstring calls irreplaceable.
+      theoreticalBelow: theo === null ? null : +(theo.getBoundingClientRect().bottom - column.bottom).toFixed(1),
+      form: document.querySelectorAll(".bests-row").length > 0 ? "ranked" : "leaders",
+    };
+  });
+  check(
+    fit.hidden === 0 && fit.over <= 1 && fit.theoreticalBelow !== null && fit.theoreticalBelow <= 1,
+    `bests fits at ${width}x${height} whichever form it picks (${fit.form}, ${fit.hidden} px hidden, card ${fit.over} px over, THEORETICAL ${fit.theoreticalBelow} px over)`,
+  );
+  await ctx.close();
+}
+
 // --- Band 3, second panel: the race trace ---------------------------------
 
 await pacePage.getByRole("tab", { name: "RACE TRACE" }).click();

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -1910,14 +1910,14 @@ check(
 // The bulk is HELD at the stub while the card mounts, so these three sizes are
 // exercised with the panel settling EMPTY first.
 //
-// **This guard asserts the EFFECT at three sizes nobody covered; it is NOT the
-// discriminator for the race that produced the defect.** Driven against the
-// un-fixed latch it still passes: measured, the empty ranked card is 114 px and the
-// room at 1265x650 is 120, yet the stub transport has the panel already compact by
-// the time the first measurement lands, so the mount never commits to `ranked`
-// against the empty height the way it does over HTTP. The race was found and the
-// fix was verified on the LIVE loopback with six fresh mounts per size; that is
-// recorded in the commit rather than pretended here.
+// **This guard IS the discriminator, and the paragraph that used to stand here said
+// it was not.** That sentence was written while a red/green mutation was still sitting
+// in the working tree, so it described a measurement taken against the wrong build;
+// the guard was then driven red four times against the un-fixed latch and green four
+// times with it, and the comment never caught up. A false comment claiming a guard
+// cannot see its own defect is worse than no comment: it invites the next reader to
+// delete a working check. Measured either way: 18 px hidden at 1265x650 and 8 px at
+// 1350x660 without the fix, 0 with it, on this fixture.
 for (const [width, height] of [
   [1265, 650],
   [1350, 660],

--- a/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
@@ -155,13 +155,36 @@ const IDLE_VIEW: AgentsView = {
 export function AgentsWindow() {
   const { view } = useAgentsView();
   const shown = view ?? IDLE_VIEW;
-  const statusText = useStatusText(shown.status_bar, shown.seq);
+
+  /**
+   * The producer is gone, and every card is holding a call from before.
+   *
+   * **This window was the twin that never got #982.** The DATA window learned to
+   * say so; this one, with a real producer killed, still read `PIT NOW ·
+   * Confidence: 71% · Pace: PUSH · Risk: AGGRESSIVE` beside `2.00× · PLAYING` at
+   * full strength, with a red chip and a blank status bar as the only tells - the
+   * exact pair #982's own comment calls insufficient. And a stale strategy CALL is
+   * worse to mistake for a live one than a stale lap time is.
+   *
+   * The label is host-built and travels WITH the view (#950), so there is nothing
+   * to poll separately here: `view !== null` means a payload has arrived, and the
+   * connection field is what still moves after the ticks stop.
+   */
+  const frozen = view !== null && shown.header.connection === "Disconnected";
+  const statusText = useStatusText(
+    frozen
+      ? { text: `DATA FROZEN · last tick ${shown.header.lap}`, transient: false }
+      : shown.status_bar,
+    shown.seq,
+  );
 
   return (
     <div className="agents-window">
-      <HeaderBar header={shown.header} />
+      <HeaderBar header={shown.header} frozen={frozen} />
 
-      <div className="agents-split">
+      {/* Dimmed, not desaturated: the cards' colour is content here too - the
+          alarm red, the WARNING amber on a changed call, the confidence bar. */}
+      <div className={frozen ? "agents-split is-frozen" : "agents-split"}>
         <div className="agents-left">
           <OrchestratorCard view={shown.orchestrator} />
           <ScenarioBars rows={shown.scenarios} />

--- a/src/pitwall/ui/src/features/agents/HeaderBar.tsx
+++ b/src/pitwall/ui/src/features/agents/HeaderBar.tsx
@@ -8,7 +8,7 @@
 
 import type { HeaderView } from "../../lib/agents";
 
-export function HeaderBar({ header }: { header: HeaderView }) {
+export function HeaderBar({ header, frozen = false }: { header: HeaderView; frozen?: boolean }) {
   return (
     <header className="header-bar">
       <span className="header-session">{header.session}</span>
@@ -17,7 +17,13 @@ export function HeaderBar({ header }: { header: HeaderView }) {
       <span className="chip header-conn" style={{ color: header.connection_colour }}>
         {header.connection}
       </span>
-      <span className="chip">{header.playback}</span>
+      {/* Where the chips already are, so a reader who only checks the strip gets
+          it. The status bar says the same thing at the bottom. */}
+      {frozen ? <span className="chip is-frozen">DATA FROZEN</span> : null}
+      {/* A dash, because the last view's speed is not the replay's speed once the
+          views stop arriving - `2.00x · PLAYING` is an assertion that it is still
+          running. */}
+      <span className="chip">{frozen ? "—" : header.playback}</span>
       <span className="chip">{header.lap}</span>
     </header>
   );

--- a/src/pitwall/ui/src/features/data/BestsPanel.tsx
+++ b/src/pitwall/ui/src/features/data/BestsPanel.tsx
@@ -53,7 +53,7 @@ const SECTIONS: { field: BestField; label: string }[] = [
  * of whatever is currently rendered is the version that flips forever: 63 < 153
  * chooses compact, compact measures 54, 63 >= 54 chooses full again.
  */
-function useFitsRanked(card: HTMLElement | null): boolean {
+function useFitsRanked(card: HTMLElement | null, content: number): boolean {
   const [compact, setCompact] = useState(false);
   const rankedHeight = useRef<number | null>(null);
 
@@ -67,14 +67,44 @@ function useFitsRanked(card: HTMLElement | null): boolean {
     setCompact(room < needed);
   }, [card, compact]);
 
+  // **`content` is in here because the card mounts EMPTY, and that was a P1.**
+  // The card appears with the first TICK; its rows come from the BULK, which
+  // arrives on its own poll a moment later. Latching the ranked height on mount
+  // therefore latched the height of the EMPTY panel - measured, 114 px against a
+  // populated 151 - so at any room between those two numbers the panel committed
+  // to `ranked` and then clipped, THEORETICAL included, with no tell: the card is
+  // capped by `max-height` and this window hides scrollbars.
+  //
+  // The observer alone could not save it. It watches the COLUMN, and the column's
+  // grid rows do not move when the bests data lands, so it never fired - a forced
+  // 1 px viewport change did not re-decide it either. Measured over six fresh
+  // mounts per size: 0 px hidden at both settled clients, and 33 px hidden at
+  // 1265x650, 23 at 1350x660, 10 at 1350x673. The defect lived exactly between the
+  // two numbers anybody had measured, and `WindowSpec.place` makes the client
+  // height a continuous function of the screen, so ordinary machines land in it.
+  //
+  // `RacePaceGrid`'s sibling `fit` already keys on its own content
+  // (`grid.columns.length`); the asymmetry between the two WAS the bug.
+  // **And the content signature alone is not enough**, which the guard at 1350x660
+  // caught: the row count settles and the card still GROWS afterwards, because
+  // `--qt-mono` is a web font and the rows are shorter until it swaps in. Measured,
+  // 8 px - enough to clip at that client, and invisible to any signature derived
+  // from the data.
+  //
+  // So the observer watches the CARD as well as the COLUMN: one for "the content
+  // changed size", one for "the room changed". It still cannot oscillate, because
+  // the ranked height is only re-measured while the panel IS ranked - going compact
+  // shrinks the card, the observer fires, and `fit` compares the same latched height
+  // against the same room and keeps the same answer.
   useEffect(() => {
     const column = card?.parentElement;
-    if (!column) return;
+    if (!card || !column) return;
     fit();
     const observer = new ResizeObserver(fit);
     observer.observe(column);
+    observer.observe(card);
     return () => observer.disconnect();
-  }, [card, fit]);
+  }, [card, fit, content]);
 
   return !compact;
 }
@@ -86,7 +116,13 @@ export function BestsPanel({ bulk }: { bulk: Bulk | null }) {
   // the FIRST time it exists, and a ref's assignment does not re-run an effect.
   // The same lesson `useEChart` learned when a remounted panel left a dead chart.
   const [card, setCard] = useState<HTMLElement | null>(null);
-  const ranked = useFitsRanked(card);
+  // How much this panel HAS to show, which is what its height depends on: the
+  // ranked rows across the four sections plus the theoretical. `bulk.rev` would
+  // also work and would re-measure ten times more often for no gain.
+  const content =
+    SECTIONS.reduce((total, { field }) => total + Math.min(bests[field].length, RANKED), 0) +
+    (theoretical === null ? 0 : 1);
+  const ranked = useFitsRanked(card, content);
 
   return (
     <section className="bests card" ref={setCard}>

--- a/src/pitwall/ui/src/features/data/DataWindow.tsx
+++ b/src/pitwall/ui/src/features/data/DataWindow.tsx
@@ -89,7 +89,7 @@ export function DataWindow() {
       <div className="data-body">
         <StatusStrip tick={live ? tick : null} connection={connection} frozen={frozen} />
         {live && tick ? (
-          // Desaturated and mildly dimmed, never blurred and never faded much:
+          // Dimmed, never desaturated, never blurred and never faded much:
           // the last known state is still operationally useful and has to stay
           // readable. What the treatment says is "this is history", not "this is
           // unavailable".

--- a/src/pitwall/ui/src/features/data/DataWindow.tsx
+++ b/src/pitwall/ui/src/features/data/DataWindow.tsx
@@ -126,7 +126,7 @@ export function DataWindow() {
               </nav>
               {tab === "traces" && (
                 <div className="band4">
-                  <OwnCarTraces tick={tick} discontinuity={discontinuity} />
+                  <OwnCarTraces tick={tick} discontinuity={discontinuity} frozen={frozen} />
                   <div className="side-column">
                     <TrackRing arcade={tick.arcade} />
                     <RadioFeed bulk={bulk} driverMain={tick.arcade.driver_main} />

--- a/src/pitwall/ui/src/features/data/OwnCarTraces.tsx
+++ b/src/pitwall/ui/src/features/data/OwnCarTraces.tsx
@@ -150,7 +150,14 @@ export function OwnCarTraces({ tick, discontinuity, frozen = false }: OwnCarTrac
           // this tick happened to carry a rival sample. Keyed on the buffer
           // instead, the chart collapsed to its placeholder for the whole
           // of a rewind hold and every lap change.
-          placeholder={starved(frame.delta) ?? (rivalCode ? null : "single-driver mode")}
+          // **The session property wins here, and the starved caption only applies
+          // when there IS a rival.** `deltaSeries` is empty BY CONSTRUCTION in
+          // single-driver mode, so letting the frozen caption take precedence put
+          // "no telemetry since the feed stopped" beside three charts showing full
+          // traces of exactly the telemetry that sentence denies - a true state
+          // with a false cause. Measured: rival code and rival telemetry stripped,
+          // the caption flipped on the producer's death.
+          placeholder={rivalCode ? starved(frame.delta) : "single-driver mode"}
         />
         <TraceChart
           title="Speed"

--- a/src/pitwall/ui/src/features/data/OwnCarTraces.tsx
+++ b/src/pitwall/ui/src/features/data/OwnCarTraces.tsx
@@ -77,9 +77,11 @@ const TRACE_COLOURS = {
 interface OwnCarTracesProps {
   tick: Tick;
   discontinuity: Discontinuity;
+  /** The producer is gone; these buffers will not fill. */
+  frozen?: boolean;
 }
 
-export function OwnCarTraces({ tick, discontinuity }: OwnCarTracesProps) {
+export function OwnCarTraces({ tick, discontinuity, frozen = false }: OwnCarTracesProps) {
   const accumulator = useRef(new TraceAccumulator());
   const { arcade } = tick;
   const rivalCode = arcade.driver_rival;
@@ -113,6 +115,21 @@ export function OwnCarTraces({ tick, discontinuity }: OwnCarTracesProps) {
   const ownCar = arcade.drivers[arcade.driver_main];
   const cursorX = ownCar?.rel_dist == null ? null : ownCar.rel_dist * xMax;
 
+  /**
+   * A frozen board whose traces never filled says so, instead of showing four
+   * empty plots.
+   *
+   * A window OPENED onto a dead feed is the case: the tower, the bests, the ring
+   * and the radio all populate from the host's last payload, because those are a
+   * per-lap reveal, while these four accumulate PER TICK and only one tick was
+   * ever served. Every other empty panel on this window explains itself -
+   * `data-waiting`, `trace-band-empty`, the radio's `no corpus`, this chart's own
+   * `single-driver mode` - so four silent axes were the odd one out.
+   *
+   * Two samples, not one: one point draws nothing a reader can see either.
+   */
+  const starved = (points: unknown[]) => (frozen && points.length < 2 ? "no telemetry since the feed stopped" : null);
+
   return (
     <section className="traces card">
       <TracesHeader tick={tick} />
@@ -133,7 +150,7 @@ export function OwnCarTraces({ tick, discontinuity }: OwnCarTracesProps) {
           // this tick happened to carry a rival sample. Keyed on the buffer
           // instead, the chart collapsed to its placeholder for the whole
           // of a rewind hold and every lap change.
-          placeholder={rivalCode ? null : "single-driver mode"}
+          placeholder={starved(frame.delta) ?? (rivalCode ? null : "single-driver mode")}
         />
         <TraceChart
           title="Speed"
@@ -146,6 +163,7 @@ export function OwnCarTraces({ tick, discontinuity }: OwnCarTracesProps) {
           main={channel(frame.main, "speed")}
           rival={channel(frame.rival, "speed")}
           cursorX={cursorX}
+          placeholder={starved(frame.main.xs)}
         />
         <TraceChart
           title="Brake Pressure"
@@ -158,6 +176,7 @@ export function OwnCarTraces({ tick, discontinuity }: OwnCarTracesProps) {
           main={channel(frame.main, "brake")}
           rival={channel(frame.rival, "brake")}
           cursorX={cursorX}
+          placeholder={starved(frame.main.xs)}
         />
         <TraceChart
           title="Throttle"
@@ -170,6 +189,7 @@ export function OwnCarTraces({ tick, discontinuity }: OwnCarTracesProps) {
           main={channel(frame.main, "throttle")}
           rival={channel(frame.rival, "throttle")}
           cursorX={cursorX}
+          placeholder={starved(frame.main.xs)}
         />
       </div>
     </section>

--- a/src/pitwall/ui/src/features/data/RacePaceGrid.tsx
+++ b/src/pitwall/ui/src/features/data/RacePaceGrid.tsx
@@ -41,11 +41,17 @@ import { racePaceGrid } from "../../lib/racePace";
 import type { Bulk } from "../../lib/bridge";
 
 /**
- * The widest numeric label the fine form can emit under ten minutes. The table
- * is monospace, so any six glyphs measure the same and this stands in for all
- * of them - including `IN PIT`.
+ * What the ruler measures before the first lap is revealed and there is no data to
+ * ask. Six glyphs, the ordinary case.
+ *
+ * **Once there IS data the ruler measures `grid.widestFine` instead**, because a
+ * constant was wrong in both directions: `0:00.0` is blind to the seven-glyph
+ * `10:00.0` that `paceLabel`'s own docstring says a red-flagged race produces, and
+ * `10:00.0` never fits the 38.75 px column that holds Melbourne's `1:29.7` with
+ * room to spare - so hardcoding the safe one would have coarsened the WIDE client
+ * for every race.
  */
-const WIDEST_FINE_LABEL = "0:00.0";
+const FALLBACK_FINE_LABEL = "0:00.0";
 
 /** One canvas for the page, made on first use. Null when there is no 2d context. */
 let ruler: CanvasRenderingContext2D | null | undefined;
@@ -63,7 +69,7 @@ let ruler: CanvasRenderingContext2D | null | undefined;
  * keeps this from oscillating: asking "does the text in the cell overflow"
  * would answer no as soon as the coarse form landed, and flip back.
  */
-function fineFormFits(cell: HTMLElement): boolean {
+function fineFormFits(cell: HTMLElement, label: string): boolean {
   if (ruler === undefined) ruler = document.createElement("canvas").getContext("2d");
   const style = window.getComputedStyle(cell);
   const padding = parseFloat(style.paddingLeft) + parseFloat(style.paddingRight);
@@ -72,7 +78,7 @@ function fineFormFits(cell: HTMLElement): boolean {
   // thing to do when the measurement is unavailable rather than negative.
   if (ruler === null) return true;
   ruler.font = `${style.fontWeight} ${style.fontSize} ${style.fontFamily}`;
-  return ruler.measureText(WIDEST_FINE_LABEL).width <= room;
+  return ruler.measureText(label).width <= room;
 }
 
 export function RacePaceGrid({ bulk, order }: { bulk: Bulk | null; order: string[] }) {
@@ -80,6 +86,11 @@ export function RacePaceGrid({ bulk, order }: { bulk: Bulk | null; order: string
   const [visible, setVisible] = useState<[number, number] | null>(null);
   const [coarse, setCoarse] = useState(false);
   const grid = racePaceGrid(bulk, order, coarse);
+  // A ref, not a dependency: `fit` must not be rebuilt on every reveal, and the
+  // value it needs is whatever the grid last knew. Independent of `coarse`, which
+  // is what keeps the decision from oscillating.
+  const widest = useRef(FALLBACK_FINE_LABEL);
+  widest.current = grid.widestFine || FALLBACK_FINE_LABEL;
 
   /**
    * The laps ACTUALLY on screen, from the scroller's own geometry.
@@ -117,8 +128,18 @@ export function RacePaceGrid({ bulk, order }: { bulk: Bulk | null; order: string
    * changes width under this panel.
    */
   const fit = useCallback(() => {
-    const cell = scroller.current?.querySelector<HTMLElement>("thead th + th");
-    if (cell && cell.clientWidth > 0) setCoarse(!fineFormFits(cell));
+    // A BODY cell, because those are the cells that have to hold the label. The
+    // header is the fallback for the render before the first reveal, and it is a
+    // proxy rather than the thing: it is `font-weight: 700` where a body cell is
+    // 400. Measured on this machine both give `0:00.0` a width of 33.23 px, so
+    // there is no difference today; with a fallback font whose bold is wider the
+    // header would coarsen slightly EARLY, which is the safe direction, but the
+    // point of `fineFormFits` is to measure the rendered font and not a proxy.
+    const box = scroller.current;
+    const cell =
+      box?.querySelector<HTMLElement>("tbody td") ??
+      box?.querySelector<HTMLElement>("thead th + th");
+    if (cell && cell.clientWidth > 0) setCoarse(!fineFormFits(cell, widest.current));
   }, []);
 
   useEffect(() => {
@@ -128,7 +149,7 @@ export function RacePaceGrid({ bulk, order }: { bulk: Bulk | null; order: string
     const observer = new ResizeObserver(fit);
     observer.observe(box);
     return () => observer.disconnect();
-  }, [fit, grid.columns.length]);
+  }, [fit, grid.columns.length, grid.widestFine]);
 
   // Pinned to the newest lap. A race-pace grid that opens at lap 1 shows the
   // formation lap of a race that is on lap 40, and the laps a strategist is

--- a/src/pitwall/ui/src/features/data/TimingTower.tsx
+++ b/src/pitwall/ui/src/features/data/TimingTower.tsx
@@ -130,7 +130,10 @@ function TowerRow({ code, position, front, leader, arcade, bulk, live, bests }: 
        * key of this window's primary panel, so it was the identification that
        * could not be read.
        *
-       * The code is `--qt-fg-1` now, 15.8:1, and the team colour is a filled bar
+       * The code is `--qt-fg-1` now, **17.48:1** - the tower has no row striping, so
+       * it sits on `--qt-panel`; the 15.8 this comment first claimed is white on
+       * `--qt-elevated`, which is the PACE GRID's banding and not this ground - and
+       * the team colour is a filled bar
        * next to it. A bar is a shape rather than glyphs, so a dim one degrades to
        * "hard to see" instead of "unreadable" - and it is REDUNDANT here, because
        * the code beside it already names the car.

--- a/src/pitwall/ui/src/lib/format.ts
+++ b/src/pitwall/ui/src/lib/format.ts
@@ -35,6 +35,14 @@
  * change width mid-grid.
  */
 export function formatSeconds(seconds: number, decimals: number, alwaysMinutes = false): string {
+  // **An em dash for anything this arithmetic cannot render, which is now worth a
+  // guard because three surfaces share it.** Unreachable today - every call site
+  // checks for `null` first and the wire cannot emit NaN (`allow_nan=False`) - but
+  // consolidating three formatters into one makes this the function the NEXT
+  // surface calls, and it produced `"NaN:000NaN"` for a NaN and `"-1:55.000"` for
+  // -5. A negative delta is a plausible future argument; a wrapped time is not a
+  // plausible future rendering of one.
+  if (!Number.isFinite(seconds) || seconds < 0) return "—";
   const scale = 10 ** decimals;
   const ticks = Math.round(seconds * scale);
   const perMinute = 60 * scale;

--- a/src/pitwall/ui/src/lib/neutralised.ts
+++ b/src/pitwall/ui/src/lib/neutralised.ts
@@ -20,9 +20,20 @@ import type { Bulk } from "./bridge";
  * **ANY row, not a majority of them**, and the conservative direction is the
  * point: the label is a warning that this lap's ranking is not about pace, and a
  * lap where the safety car was out for part of the field is exactly as unsafe to
- * read as one where it was out for all of it. On the real race the difference is
- * three laps - 33, 34 and 47 carry mixed statuses - and on those the SC digit is
- * on the majority of rows anyway.
+ * read as one where it was out for all of it.
+ *
+ * Measured through this code's own decode path on the real race, exactly two laps
+ * are mixed: **lap 33, marked on 13 of 16 rows, and lap 46, marked on 3 of 15**.
+ * Lap 46 is the case that makes ANY-row the RIGHT rule rather than an incidental
+ * one - a majority vote would drop its rail while three cars queue through the pit
+ * lane.
+ *
+ * (This paragraph used to say the mixed laps were 33, 34 and 47 and that the SC
+ * digit was "on the majority of rows anyway". Both were measured on the RAW
+ * `TrackStatus` STRINGS rather than on the decoded label, and `'124'`, `'24'` and
+ * `'4'` are three different strings that all decode to SAFETY CAR - so the figure
+ * described a population the sentence was not about, and the false clause was the
+ * one justifying the rule.)
  *
  * Generated rows are skipped: FastF1 synthesised them for a car that never
  * finished the lap, and they count towards nothing anywhere else either.

--- a/src/pitwall/ui/src/lib/racePace.ts
+++ b/src/pitwall/ui/src/lib/racePace.ts
@@ -54,6 +54,19 @@ export interface PaceGrid {
   /** Lap numbers, ascending. Empty until something is revealed. */
   laps: number[];
   /**
+   * The longest label the FINE form would emit for THIS data, whatever form is
+   * currently rendered.
+   *
+   * The renderer's ruler needs it, and it has to be independent of the current
+   * form or the decision oscillates: measured against the rendered texts, a coarse
+   * grid reports four glyphs, four glyphs fit, the form flips to fine, fine reports
+   * six, six do not fit, and round it goes. A fixed constant is the other option
+   * and it was wrong in both directions - `0:00.0` is blind to the `10:00.0` a
+   * red-flagged race produces, and `10:00.0` never fits the 38.75 px column that
+   * holds Melbourne's `1:29.7` with room to spare.
+   */
+  widestFine: string;
+  /**
    * `laps[i]`'s neutralisation label, or null when the field was racing.
    *
    * Parallel to `laps` rather than folded into the cells: the claim is about the
@@ -244,7 +257,8 @@ function tone(times: number[], value: number): PaceTone {
  * and at most instants the field spans two or three different laps.
  */
 export function racePaceGrid(bulk: Bulk | null, order: string[], coarse = false): PaceGrid {
-  if (!bulk?.available) return { laps: [], neutralised: [], columns: [...order], rows: [] };
+  if (!bulk?.available)
+    return { laps: [], neutralised: [], widestFine: "", columns: [...order], rows: [] };
   const columns = stableColumns(bulk, order);
 
   const byDriver = new Map<string, Map<number, LapRow>>();
@@ -267,6 +281,12 @@ export function racePaceGrid(bulk: Bulk | null, order: string[], coarse = false)
   const ranked = rankedByLap(byDriver, laps);
   const fastest = sessionBests(bulk).lap_time[0] ?? null;
 
+  // The widest FINE label this data would produce, tracked as the rows are built
+  // and independent of `coarse`. `IN PIT` and `P.EXIT` are six glyphs each, so the
+  // word cells only matter while no time is longer than they are.
+  let slowest: number | null = null;
+  let anyWord = false;
+
   const rows = laps.map((lap) =>
     columns.map((code) => {
       const row = timedRow(byDriver.get(code)?.get(lap));
@@ -275,7 +295,10 @@ export function racePaceGrid(bulk: Bulk | null, order: string[], coarse = false)
       // same six the times could not fit, so leaving it alone would have kept
       // the P0 alive in the one place the reader most needs the whole word -
       // `IN PI` ran straight into its neighbour as `IN PIIN PI`.
-      if (row.pit_in) return { text: coarse ? "PIT" : "IN PIT", tone: "pit" as PaceTone };
+      if (row.pit_in) {
+        anyWord = true;
+        return { text: coarse ? "PIT" : "IN PIT", tone: "pit" as PaceTone };
+      }
       // **`P.EXIT`, not `OUT`, and the tower is why.** `TimingTower`'s `lastCell`
       // renders a RETIRED car as `OUT` and says in as many words that an out-lap
       // gets `PIT EXIT` "rather than borrowing the same word for a car that is
@@ -289,8 +312,12 @@ export function racePaceGrid(bulk: Bulk | null, order: string[], coarse = false)
       // Abbreviated because the column cannot hold the tower's eight glyphs:
       // `PIT EXIT` measures 43 px against 38.75 at the wide client, so it would
       // have arrived clipped. `P.EXIT` is 34, and `EXIT` fits the coarse column.
-      if (row.pit_out) return { text: coarse ? "EXIT" : "P.EXIT", tone: "out" as PaceTone };
+      if (row.pit_out) {
+        anyWord = true;
+        return { text: coarse ? "EXIT" : "P.EXIT", tone: "out" as PaceTone };
+      }
       if (row.lap_time === null) return EMPTY;
+      if (slowest === null || row.lap_time > slowest) slowest = row.lap_time;
       const text = paceLabel(row.lap_time, coarse);
       // A deleted time is shown and struck through, as the tower already shows
       // it, and it is excluded from the ranking - which is why it cannot be
@@ -309,5 +336,14 @@ export function racePaceGrid(bulk: Bulk | null, order: string[], coarse = false)
       return { text, tone: tone(ranked.get(lap) ?? [], row.lap_time) };
     }),
   );
-  return { laps, neutralised: laps.map((lap) => neutral.get(lap) ?? null), columns, rows };
+  const longestTime = slowest === null ? "" : paceLabel(slowest, false);
+  const widestFine =
+    anyWord && "IN PIT".length > longestTime.length ? "IN PIT" : longestTime;
+  return {
+    laps,
+    neutralised: laps.map((lap) => neutral.get(lap) ?? null),
+    widestFine,
+    columns,
+    rows,
+  };
 }

--- a/src/pitwall/ui/src/styles/agents.css
+++ b/src/pitwall/ui/src/styles/agents.css
@@ -59,6 +59,24 @@
   font-weight: 600;
 }
 
+/* The producer is gone. DANGER filled, the same treatment the DATA window's own
+ * frozen chip carries, so one state looks like one state across both windows. */
+.chip.is-frozen {
+  background: #ef4444;
+  color: var(--qt-bg);
+  font-weight: 800;
+}
+
+/* The cards while the feed is dead: dimmed, NOT desaturated. Same reasoning as the
+ * DATA window's `.data-main.is-frozen` - `saturate()` collapses hue differences and
+ * this window's colour is content too (the alarm red, the WARNING amber on a
+ * changed call, the confidence bar). `brightness()` scales all three channels
+ * together, so nothing moves relative to anything else. The header strip and the
+ * status bar stay at full strength: they carry the tells. */
+.agents-split.is-frozen {
+  filter: brightness(0.72);
+}
+
 /* --- The split ---------------------------------------------------------- */
 
 .agents-split {

--- a/src/pitwall/ui/src/styles/data.css
+++ b/src/pitwall/ui/src/styles/data.css
@@ -115,14 +115,30 @@
   font-weight: 800;
 }
 
-/* The board while the feed is dead: desaturated and mildly dimmed, NEVER blurred
- * and never faded far. The last known state is the best information a strategist
- * has - the treatment has to say "this is history" while leaving every number
- * readable, so 0.45 saturation and 0.82 brightness rather than an opacity that
- * would make the tower a guess. Band 1 and the status bar stay at full strength:
- * they are the two surfaces that say WHY it looks like this. */
+/* The board while the feed is dead: DIMMED, never desaturated, never blurred and
+ * never faded far. The last known state is the best information a strategist has,
+ * so the treatment has to say "this is history" while leaving the board readable -
+ * and "readable" includes the COLOUR, which on this window is content: the pace
+ * grid's thirds, the tower's sector code, the trace's twenty team lines.
+ *
+ * **`saturate(0.45)` was here and it cost the pace grid two thirds of its ranking.**
+ * Computed on the filter-effects saturation matrix and confirmed by sampling the
+ * same pixels live and frozen: the RGB distance between the quickest third and the
+ * slowest fell 61 %, and between the session best and a deleted lap 66 %. Two of
+ * this sprint's own changes interacting - the frozen filter over the markers added
+ * an hour earlier.
+ *
+ * `brightness()` scales all three channels by the same factor, so it dims the board
+ * without moving any hue relative to any other: a dimmer green is still greener
+ * than a dimmer amber, and every rank the tone channel encodes survives. It costs
+ * the distance the same 28 % it costs the brightness, which is a proportional loss
+ * rather than a collapse.
+ *
+ * Band 1 and the status bar stay at full strength: they carry the four independent
+ * tells that say WHY it looks like this - the DATA FROZEN chip, the neutral track
+ * chip, `PLAYBACK —` and the status line. */
 .data-main.is-frozen {
-  filter: saturate(0.45) brightness(0.82);
+  filter: brightness(0.72);
 }
 
 .strip-spacer {
@@ -247,7 +263,7 @@
 /* The code in the primary foreground, with the team colour beside it rather than
  * inside it. Six of the twenty wire colours fail AA as 11 px text on this card and
  * four fail the 3.0 large-text floor; the code is the row key of this window's main
- * panel. `--qt-fg-1` is 15.8:1.
+ * panel. `--qt-fg-1` on this ground is 17.48:1.
  *
  * **The swatch costs the table NO width**, and it had to: the cell is 34 px by a
  * measurement, the table's natural width was 597.6 of the 608 the card gives, and

--- a/src/pitwall/webserver.py
+++ b/src/pitwall/webserver.py
@@ -217,15 +217,34 @@ class BrowserServer:
         self._server: ThreadingHTTPServer | None = None
 
     def start(self) -> str | None:
-        """Serve, and return the URL to open. None when there is no bundle."""
+        """Serve, and return the URL to open, or None when it cannot serve.
+
+        None means one of two things and both are handled by the caller falling
+        back: there is no bundle to read, or the socket would not bind. Since the
+        windows now LOAD through this server (#995) rather than merely being
+        mirrored by it, a raise here would take the whole surface down.
+        """
         if not self._dist.is_dir():
             return None
         bundle = _read_bundle(self._dist)
         if "/data.html" not in bundle:
             return None
-        self._server = ThreadingHTTPServer(
-            (BROWSER_HOST, self._port), _handler(bundle, self._source)
-        )
+        try:
+            self._server = ThreadingHTTPServer(
+                (BROWSER_HOST, self._port), _handler(bundle, self._source)
+            )
+        except OSError:
+            # **The failure that can actually happen, and the one the fallback was
+            # documented for without covering.** `None` above only fires when the
+            # bundle is missing, which `ui_is_built()` has already ruled out three
+            # lines earlier in `__main__` - so the advertised file-path fallback was
+            # reachable only by deleting the bundle between two checks. A bind
+            # failure is real (a Windows port-exclusion range, a security product
+            # holding the port) and it used to propagate out of here and kill the
+            # host before a single window opened. Now it degrades to what the
+            # docstring always promised.
+            logger.warning("The PITWALL browser server could not bind %s", BROWSER_HOST)
+            return None
         threading.Thread(
             target=self._server.serve_forever,
             daemon=True,

--- a/tests/surfaces/test_pitwall_browser_server.py
+++ b/tests/surfaces/test_pitwall_browser_server.py
@@ -17,10 +17,11 @@ import json
 import urllib.error
 import urllib.request
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
-from src.pitwall.config import WINDOWS, window_target
+from src.pitwall.config import WINDOWS, window_arguments, window_target
 from src.pitwall.webserver import BROWSER_HOST, BrowserServer
 
 
@@ -181,7 +182,9 @@ def test_a_window_points_at_the_server_that_is_running_and_not_at_a_file(served:
     """
     for spec in WINDOWS:
         target = window_target(spec, served)
-        assert target.startswith(served), f"{spec.key} does not point at the running server: {target}"
+        assert target.startswith(served), (
+            f"{spec.key} does not point at the running server: {target}"
+        )
         assert "file:" not in target and "\\" not in target, target
         # The route ANSWERS. A window handed an unfetchable URL is the whole bug,
         # and it is the only assertion here that could have caught it.
@@ -198,3 +201,70 @@ def test_a_window_falls_back_to_the_file_when_there_is_no_server():
     for spec in WINDOWS:
         assert window_target(spec, None) == spec.url
         assert spec.url.endswith(spec.entry)
+
+
+def test_the_window_arguments_carry_the_served_url_and_the_placed_geometry(served: str):
+    """The SEAM `__main__` unpacks, so the wiring is guarded and not just the rule.
+
+    **`window_target` being right was never the gap.** Reverting `__main__`'s call
+    site to `spec.url` kept 227 surface tests, 176 data-smoke checks and 19
+    agents-smoke checks green, because nothing outside the product loads that module
+    - so the racy pywebview 404 (#995) could walk back in on a fully green board and
+    only opening the OS window would show it. That is the same
+    verified-through-the-page-and-not-the-window gap this sprint had to confess to
+    once already.
+
+    `main()` now unpacks this dict straight into `create_window`, so asserting its
+    `url` key asserts what the window is handed. The geometry is checked in the same
+    breath because it comes from the same call and `place`'s clamp is load-bearing.
+    """
+    screen = (1707, 960)
+    for index, spec in enumerate(WINDOWS):
+        arguments = window_arguments(spec, index, screen, served)
+
+        assert arguments["url"] == window_target(spec, served)
+        assert arguments["url"].startswith(served), arguments["url"]
+        status, _content_type, body = _get(arguments["url"])
+        assert status == 200 and spec.key in body, f"{spec.key} -> {status}"
+
+        x, y, width, height = spec.place(index, *screen)
+        assert (arguments["x"], arguments["y"]) == (x, y)
+        assert (arguments["width"], arguments["height"]) == (width, height)
+        assert arguments["title"] == spec.title
+        # The toolkit's own keyword names, because this dict is splatted into it.
+        assert set(arguments) == {"title", "url", "width", "height", "x", "y"}
+
+
+def test_the_window_arguments_fall_back_to_the_file_with_no_server():
+    for index, spec in enumerate(WINDOWS):
+        assert window_arguments(spec, index, (1707, 960), None)["url"] == spec.url
+
+
+def test_a_port_it_cannot_bind_degrades_to_no_server_rather_than_a_crash(tmp_path: Path):
+    """The failure that actually happens, and the one the fallback was written for.
+
+    `start()` returning None used to mean "no bundle" only - which `ui_is_built()`
+    has already ruled out by the time `__main__` calls it, making the documented
+    file-path fallback reachable only by deleting the bundle between two checks.
+    A bind failure is the realistic one (a Windows port-exclusion range, a security
+    product holding the port) and it propagated out and killed the host before a
+    single window opened.
+
+    **The OSError is injected, and the reason is worth stating.** A second server on
+    an already-bound port was the obvious probe and it does not work: `HTTPServer`
+    sets `allow_reuse_address`, so on Windows the second bind SUCCEEDS and returns a
+    live URL - measured, before this test was rewritten. The failures that do happen
+    are a reserved port range or a security product, neither of which a test can
+    provoke portably, so what is asserted here is the DEGRADATION: whatever the
+    socket raises, the caller gets None and the host lives.
+    """
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "data.html").write_text("<html>data</html>", encoding="utf-8")
+    (dist / "agents.html").write_text("<html>agents</html>", encoding="utf-8")
+
+    def refuse(*_args, **_kwargs):
+        raise OSError(10013, "An attempt was made to access a socket in a forbidden way")
+
+    with mock.patch("src.pitwall.webserver.ThreadingHTTPServer", refuse):
+        assert BrowserServer(dist, _FakeHost()).start() is None

--- a/tests/surfaces/test_pitwall_browser_server.py
+++ b/tests/surfaces/test_pitwall_browser_server.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import pytest
 
+from src.pitwall.config import WINDOWS, window_target
 from src.pitwall.webserver import BROWSER_HOST, BrowserServer
 
 
@@ -156,3 +157,44 @@ def test_no_bundle_means_no_server_rather_than_a_crash(tmp_path: Path):
     empty = tmp_path / "empty"
     empty.mkdir()
     assert BrowserServer(empty, _FakeHost()).start() is None
+
+
+# --- Where the OS windows point (#995) ---------------------------------------
+
+
+def test_a_window_points_at_the_server_that_is_running_and_not_at_a_file(served: str):
+    """Every window's URL is a route THIS server answers, not a filesystem path.
+
+    **The defect this closes was pywebview's, and it was invisible from here.**
+    Given a file path, pywebview 6.2.1 serves the window through its own bottle
+    server rooted at `os.path.commonpath` of the window URLs, and with two windows
+    it gets that wrong racily: the same build produced a 404 for
+    `…/6754/dist/data.html` on one run and for `…/52646/data.html` on another, each
+    of them bottle's own page. Reproduced against the installed bottle - rooted at
+    `ui/dist`, `data.html` is 200 and `dist/data.html` is 404 "File does not exist.";
+    rooted at `ui` it is the other way round.
+
+    So the assertion is not "the URL contains http". It is that the exact URL a
+    window is handed is **fetchable from the server the host actually started**,
+    which is the only property that makes the window and a browser tab the same
+    surface. `window_target` is pure so this needs no system webview.
+    """
+    for spec in WINDOWS:
+        target = window_target(spec, served)
+        assert target.startswith(served), f"{spec.key} does not point at the running server: {target}"
+        assert "file:" not in target and "\\" not in target, target
+        # The route ANSWERS. A window handed an unfetchable URL is the whole bug,
+        # and it is the only assertion here that could have caught it.
+        status, content_type, body = _get(target)
+        assert status == 200, f"{spec.key} -> {status} at {target}"
+        assert content_type.startswith("text/html"), f"{spec.key} -> {content_type}"
+        assert spec.key in body, f"{spec.key} served the wrong document: {body!r}"
+        assert spec.entry in target
+
+
+def test_a_window_falls_back_to_the_file_when_there_is_no_server():
+    """No bundle to serve means no URL, and a window through pywebview's own
+    server beats no window at all - which is what `__main__` logs a warning for."""
+    for spec in WINDOWS:
+        assert window_target(spec, None) == spec.url
+        assert spec.url.endswith(spec.entry)


### PR DESCRIPTION
Two rounds in one branch: the **404 on the product's own windows** that Víctor kept hitting, and the
**adversarial exit gate** over the sprint's own work — then a **second gate over those fixes**, whose
findings are also in here.

## 1 · The 404, and the transport my verification had been confusing (#995)

Given a filesystem path, **pywebview 6.2.1 serves the window through an internal bottle server rooted
at `os.path.commonpath` of the window URLs** — and with two windows it gets that wrong, racily. Both
halves reproduced against the installed bottle:

| server root | request | result |
|---|---|---|
| `ui/dist` | `data.html` | **200** |
| `ui/dist` | `dist/data.html` | **404 "File does not exist."** ← first screenshot |
| `ui` | `data.html` / `agents.html` | **404 "File does not exist."** ← second screenshot |

Both are the same defect: a window computing its URL against one base while the server holds another.

**The windows now open on the host's own loopback server** — one root, read into memory at startup,
already running in the same process. pywebview computes no common path and starts no static server;
the verification gate confirmed that **by observation**: with `http://` URLs there is one listening
socket and `webview.http.global_server` is `None`.

It also closes a gap that was mine: every *"verified on the real window"* claim earlier in this sprint
was measured through the loopback **page**, not the OS window. Two transports, treated as one. They are
one now.

## 2 · The exit gate: 1 P1, 3 P2, 6 P3, no P0

`documents/audits/GATE_PITWALL_SPRINT9_EXIT.md`. Eleven of twelve claims verified; it refuted claim C,
three of my figures and one of its own.

**X1 (P1), mine, and the sprint's own fix leaving a band behind.** `useFitsRanked` latched the ranked
height on **mount** — when the tick has landed and the BULK has not — so it measured the **empty**
panel at 114 px against a populated 151. At any room between those two numbers the panel committed to
`ranked` and clipped, THEORETICAL included, in silence. Six fresh mounts per size: 0 px hidden at both
settled clients, **33 px at 1265×650, 23 at 1350×660, 10 at 1350×673**. The defect lived exactly
between the two numbers anybody had measured.

The fix re-decides on content change **and** on a `ResizeObserver` over the card. The content signature
alone was not enough and the guard caught that: the row count settles and the card still grows **8 px**
afterwards, because `--qt-mono` is a web font.

**X2** the frozen board's `saturate(0.45)` cost the pace grid up to 66 % of its tone separation — and
the tone is that panel's content. Now `brightness(0.72)`, which moves no hue relative to any other.
**X3** the AGENTS window was the twin that never got #982. **X4** the mixed-lap sentence was measured
on raw `TrackStatus` strings, not the decoded label. **X5–X10**: the shared formatter's contract, a
contrast figure that was white-on-the-wrong-ground, the ruler measuring a body cell and the widest
label the grid actually built, a caption for a frozen window's starved plots, and the compound sentinel
applied producer-side.

## 3 · The verification gate over all of that: 0 P0, 0 P1, 1 P2, 4 P3 — **safe to ship**

`documents/audits/GATE_PITWALL_WINDOW_FIX.md`. It ran 66 fresh mounts over 11 client sizes, a real
producer kill, a one-window destroy, and rebuilt the bundle hash-identical to the shipped one.

**G1 (P2) is the one worth having.** `window_target` was pure and well pinned, and **nothing asserted
that `__main__` calls it**: reverting the call site to `spec.url` kept 227 tests + 176 + 19 checks
green, so the 404 could return on a fully green board. The assembly is now a pure `window_arguments`
that `main()` unpacks, and the test asserts its `url` is **fetchable from the server the host
started**. Driven red against a seam handing back the file path.

**G2 is a false comment of mine that was disarming a working guard** — it said the X1 guard "is NOT the
discriminator", written while a red/green mutation was still in the tree. The gate refuted it twice by
execution.

**G3**: the fallback I advertised was unreachable (`ui_is_built()` gates it) while the failure that
does happen — a socket that will not bind — killed the host. `start()` degrades on `OSError` now, and
the test **injects** it, because a second server on a taken port does not fail: `HTTPServer` sets
`allow_reuse_address` and on Windows the second bind succeeds.

**G4** a frozen single-driver window claimed "no telemetry since the feed stopped" beside three full
traces. **G5** `DataWindow` still narrated "Desaturated" about a class this branch stopped desaturating.

## Checks

`tests/surfaces/` **230** · `smoke-data` **176** · `smoke-agents` **19** · typecheck and ruff clean.

**Verified on the real OS windows**, not the loopback page: three polls each, `href` on the loopback,
6 and 14 cards, live content, `window.pywebview` an object.

Closes #995
