### PR TITLE
feat(pitwall): the pace grid draws the whole race, not the part that has run

### DIFF
--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -1897,6 +1897,116 @@ check(
   await narrowCtx.close();
 }
 
+// --- The axis is the WHOLE RACE, not the part that has happened --------------
+//
+// The grid used to stop at the last revealed lap, so the table grew downward and the
+// card had to be anchored to the column's bottom to hold the newest row at a stable
+// height - which left a 382 px void above it for two thirds of a race, and Victor
+// called it out on the shipped window. Drawing the full lap axis is the motorsport
+// convention (a tyre-strategy chart plots laps 1..N and lets the stints fill in) and
+// it is deliberately NOT the web's loading-skeleton idiom, which signals a fetch.
+//
+// The reveal is capped at the STUB, because `bridge.ts` uses `window.pywebview`
+// whenever it exists and an HTTP route intercepts nothing - the lesson the BESTS
+// guard above had to learn the hard way.
+{
+  const partialCtx = await browser.newContext({ viewport: { width: 1485, height: 833 } });
+  const partial = await partialCtx.newPage();
+  partial.on("pageerror", (error) => failures.push(`pageerror(skeleton): ${error.message}`));
+  const REVEALED_TO = 30;
+  await partial.addInitScript(
+    ([payload, bulk, live, cap]) => {
+      for (const driver of Object.values(bulk.drivers)) {
+        driver.laps = driver.laps.filter((lap) => lap.lap <= cap);
+      }
+      window.pywebview = {
+        api: {
+          get_tick: async (s) => (s === payload.seq ? null : payload),
+          get_bulk: async (r) => (r === bulk.rev ? null : bulk),
+          get_live_lap: async (r) => (r === live.rev ? null : live),
+          get_connection: async () => "Connected",
+        },
+      };
+    },
+    [tick(1, { drivers: paceField(), order: TOWER_ORDER }), paceBulk(), towerLive(), REVEALED_TO],
+  );
+  await partial.goto(`http://127.0.0.1:${server.address().port}/data.html`, {
+    waitUntil: "domcontentloaded",
+  });
+  await partial.getByRole("tab", { name: "RACE PACE", exact: true }).click();
+  await partial.waitForSelector(".pace-table", { timeout: 5000 });
+  await partial.waitForTimeout(600);
+
+  const skeleton = await partial.evaluate(() => {
+    const lin = (v) => (v / 255 <= 0.03928 ? v / 255 / 12.92 : ((v / 255 + 0.055) / 1.055) ** 2.4);
+    const L = ([r, g, b]) => 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+    const ratio = (a, b) => {
+      const [hi, lo] = [L(a), L(b)].sort((x, y) => y - x);
+      return (hi + 0.05) / (lo + 0.05);
+    };
+    const parse = (value) => value.match(/[0-9]+/g).slice(0, 3).map(Number);
+    const rows = [...document.querySelectorAll(".pace-table tbody tr")];
+    const future = rows.filter((row) => row.classList.contains("is-future"));
+    const driven = rows.filter((row) => !row.classList.contains("is-future"));
+    const newest = driven[driven.length - 1];
+    const box = document.querySelector(".pace-scroll").getBoundingClientRect();
+    const card = parse(getComputedStyle(document.querySelector(".pace")).backgroundColor);
+    // Tolerant of there being NO future rows, because that is exactly the defect
+    // this block exists to catch: reading `future[0]` blind turned a red check into
+    // a thrown exception, and a stack trace names nothing.
+    let futureRatio = null;
+    if (future.length > 0) {
+      const style = getComputedStyle(future[0].querySelector("th"));
+      const alpha = Number(style.opacity);
+      const composited = parse(style.color).map((v, i) =>
+        Math.round(card[i] + alpha * (v - card[i])),
+      );
+      futureRatio = +ratio(composited, card).toFixed(2);
+    }
+    const newestBox = newest.getBoundingClientRect();
+    return {
+      rows: rows.length,
+      driven: driven.length,
+      future: future.length,
+      futureWithText: future.filter((row) =>
+        [...row.querySelectorAll("td")].some((cell) => cell.textContent.trim().length > 0),
+      ).length,
+      lastLapNumber: Number(rows[rows.length - 1].querySelector("th").textContent),
+      newestLap: Number(newest.querySelector("th").textContent),
+      newestVisible: newestBox.top >= box.top - 1 && newestBox.bottom <= box.bottom + 1,
+      futureRatio,
+    };
+  });
+
+  check(
+    skeleton.rows === PACE_LAPS && skeleton.lastLapNumber === PACE_LAPS,
+    `the grid draws the whole race, not the part that has run (${skeleton.rows} rows, last lap ${skeleton.lastLapNumber} of ${PACE_LAPS})`,
+  );
+  check(
+    skeleton.driven === REVEALED_TO && skeleton.future === PACE_LAPS - REVEALED_TO,
+    `and it knows which half is which (${skeleton.driven} driven, ${skeleton.future} future)`,
+  );
+  // The whole point of drawing them: they say how much race is left and NOTHING else.
+  check(
+    skeleton.futureWithText === 0 && skeleton.newestLap === REVEALED_TO,
+    `a lap nobody has driven carries its number and no data (${skeleton.futureWithText} with text, newest driven ${skeleton.newestLap})`,
+  );
+  // Replaces what the bottom-anchored card was bought for: the row every decision is
+  // about stays on screen. Asserted as visibility, not as a scroll offset - the offset
+  // is 0 whenever the newest lap is still inside the first viewport.
+  check(
+    skeleton.newestVisible,
+    `the newest driven lap is on screen with the future drawn below it (lap ${skeleton.newestLap})`,
+  );
+  // A future lap number MEANS something - how much race is left - so it clears the 3:1
+  // floor for a meaningful graphic. The first version used `--qt-border`: 1.29:1.
+  check(
+    skeleton.futureRatio !== null && skeleton.futureRatio >= 3,
+    `and a future lap number is legible against its card (${skeleton.futureRatio}:1)`,
+  );
+  await partialCtx.close();
+}
+
 // --- The client heights BETWEEN the two anybody measured ---------------------
 //
 // The two settled sizes cannot see this and neither could the guard above: at

--- a/src/pitwall/ui/src/features/data/RacePaceGrid.tsx
+++ b/src/pitwall/ui/src/features/data/RacePaceGrid.tsx
@@ -165,9 +165,20 @@ export function RacePaceGrid({ bulk, order }: { bulk: Bulk | null; order: string
   // for one commit, and it is not what ships. See the `.pace` rule.)
   useEffect(() => {
     const box = scroller.current;
-    if (box) box.scrollTop = box.scrollHeight;
+    if (!box) return;
+    // **Pinned to the newest REVEALED lap, not to the bottom of the table.** The
+    // table is the whole race now, so its bottom is lap 57 - the future - and
+    // scrolling there would show a wall of empty rows. Putting the newest revealed
+    // row against the scroller's bottom edge keeps the property the bottom-anchored
+    // card was bought for (the row every decision is about sits at a fixed height)
+    // without the void that came with it.
+    const rows = box.querySelectorAll<HTMLElement>("tbody tr");
+    const newest = grid.revealedTo > 0 ? rows[grid.revealedTo - 1] : undefined;
+    box.scrollTop = newest
+      ? newest.offsetTop + newest.offsetHeight - box.clientHeight
+      : box.scrollHeight;
     measure();
-  }, [grid.laps.length, measure]);
+  }, [grid.revealedTo, grid.laps.length, measure]);
 
   const total = bulk?.race.total_laps ?? grid.laps.length;
   const [first, last] = visible ?? [grid.laps[0], grid.laps[grid.laps.length - 1]];
@@ -206,7 +217,13 @@ export function RacePaceGrid({ bulk, order }: { bulk: Bulk | null; order: string
           </thead>
           <tbody>
             {grid.rows.map((row, index) => (
-              <tr key={grid.laps[index]}>
+              <tr
+                key={grid.laps[index]}
+                // A lap nobody has driven yet. It carries its number and nothing
+                // else, so the panel shows how much race is left without pretending
+                // to know anything about it.
+                className={grid.laps[index] > grid.revealedTo ? "is-future" : undefined}
+              >
                 {/* The rail on the lap number is the whole marker: on a
                  * neutralised lap the colour thirds rank the safety car's queue,
                  * not pace, and 213 of the 776 cells this grid ranks on the real

--- a/src/pitwall/ui/src/lib/racePace.ts
+++ b/src/pitwall/ui/src/lib/racePace.ts
@@ -51,8 +51,16 @@ export interface PaceCell {
 }
 
 export interface PaceGrid {
-  /** Lap numbers, ascending. Empty until something is revealed. */
+  /** Lap numbers, ascending: the WHOLE race, not only the part that has happened. */
   laps: number[];
+  /**
+   * The highest lap ANY driver has revealed, so the renderer can tell the race
+   * that has been driven from the race that has not - and so the scroll pin has a
+   * row to pin to that is not the bottom of the table.
+   *
+   * 0 before the first reveal.
+   */
+  revealedTo: number;
   /**
    * The longest label the FINE form would emit for THIS data, whatever form is
    * currently rendered.
@@ -258,7 +266,7 @@ function tone(times: number[], value: number): PaceTone {
  */
 export function racePaceGrid(bulk: Bulk | null, order: string[], coarse = false): PaceGrid {
   if (!bulk?.available)
-    return { laps: [], neutralised: [], widestFine: "", columns: [...order], rows: [] };
+    return { laps: [], revealedTo: 0, neutralised: [], widestFine: "", columns: [...order], rows: [] };
   const columns = stableColumns(bulk, order);
 
   const byDriver = new Map<string, Map<number, LapRow>>();
@@ -272,7 +280,25 @@ export function racePaceGrid(bulk: Bulk | null, order: string[], coarse = false)
     byDriver.set(code, rows);
   }
 
-  const laps = Array.from({ length: lastLap }, (_, index) => index + 1);
+  // **The axis is the WHOLE RACE, not the part that has happened.**
+  //
+  // It used to stop at the last revealed lap, so the table grew downward and the
+  // card had to be anchored to the column's bottom to keep the newest row at a
+  // stable height - which left a 382 px void above it for the first two thirds of
+  // a race. Víctor called that out on the shipped window.
+  //
+  // Drawing the full lap axis is the motorsport convention rather than a UI trick:
+  // a tyre-strategy chart and a lap chart both plot laps 1..N for the whole race
+  // and let the stints fill into it. It is deliberately NOT the web's "skeleton"
+  // idiom, which is a LOADING signal - these rows are not waiting for a fetch, they
+  // are laps that have not been driven, and the shimmer would say the wrong thing.
+  //
+  // Nothing about the reveal changes: a cell beyond `revealedTo` finds no row and
+  // falls through to EMPTY exactly as an unrevealed cell always did, so this leaks
+  // nothing. `total_laps` is already on the wire and already printed in the header
+  // as "of 57".
+  const total = bulk.race.total_laps || lastLap;
+  const laps = Array.from({ length: Math.max(total, lastLap) }, (_, index) => index + 1);
   // **The ranking is unchanged on these laps, and the marker is why that is
   // honest.** Excluding them would leave holes in a history panel; re-ranking
   // them against something else would invent a scale. What was wrong was
@@ -341,6 +367,7 @@ export function racePaceGrid(bulk: Bulk | null, order: string[], coarse = false)
     anyWord && "IN PIT".length > longestTime.length ? "IN PIT" : longestTime;
   return {
     laps,
+    revealedTo: lastLap,
     neutralised: laps.map((lap) => neutral.get(lap) ?? null),
     widestFine,
     columns,

--- a/src/pitwall/ui/src/styles/data.css
+++ b/src/pitwall/ui/src/styles/data.css
@@ -1035,7 +1035,6 @@ td.col-drv {
  * it the content-sized card would grow past the grid row and spill, and the
  * scroller - which needs a bounded height to scroll at all - would never bound. */
 .pace {
-  align-self: end;
   display: flex;
   flex-direction: column;
   gap: 6px;
@@ -1079,9 +1078,28 @@ td.col-drv {
   overflow-y: auto;
 }
 
-/* "Now", findable in one saccade. Every other lap number is `--qt-fg-3`; the
- * newest one is the row every decision is about. */
-.pace-table tbody tr:last-child th.pace-lapcol {
+/* A lap that has not been driven. The number stays - that is the point, it says how
+ * much race is left - and it steps back so the driven race is what the eye lands on.
+ * No cell treatment is needed: an unrevealed cell already renders empty.
+ *
+ * **`--qt-fg-3` at 0.6, not `--qt-border`, and the first attempt was measured wrong.**
+ * `--qt-border` came out at **1.29:1** on the card and 1.18 on the banded columns -
+ * invisible, on an element that CARRIES MEANING (how much race is left), so the 3:1
+ * floor for a meaningful graphic applies rather than nothing at all. The palette has
+ * no grey between `BORDER_COLOR` and `TEXT_TERTIARY`, so rather than invent a hex the
+ * cell steps `--qt-fg-3` back with opacity: 0.6 composites to 3.31:1 on the card and
+ * 3.16 on the banded columns, both clear, and it adds no colour for
+ * `test_pitwall_tokens.py` to pin. 0.55 was the other candidate and lands at 2.99 -
+ * under the floor on the card and 2.86 on the banding. */
+.pace-table tbody tr.is-future th.pace-lapcol {
+  color: var(--qt-fg-3);
+  opacity: 0.6;
+}
+
+/* "Now", findable in one saccade: the newest lap that HAS been driven, which is the
+ * last row before the future ones rather than the last row of the table. */
+.pace-table tbody tr:not(.is-future):last-of-type th.pace-lapcol,
+.pace-table tbody tr:not(.is-future):has(+ tr.is-future) th.pace-lapcol {
   color: var(--qt-fg-1);
   font-weight: 700;
 }


### PR DESCRIPTION
Víctor, on the shipped window: *"en race pace hay un espacio enorme en blanco"*. Measured: **382 px**
of it above the card with 26 of 57 laps revealed.

That void was the price of the fix one commit earlier — the card was anchored to the bottom of its
column so the newest lap, the only row anybody reads, would stop migrating ~12 px per lap (434 px over
a race). It bought a stable eye line and paid in emptiness.

## The lap axis is now the whole race

Void above: **382 px → 32**. The card fills its column again (718 of 750) and the `align-self: end`
anchor is gone, because there is nothing left to anchor.

## Why this shape, since the research was asked for

- The web's **skeleton** pattern is a **loading** idiom — [uxpatterns.dev](https://uxpatterns.dev/patterns/user-feedback/skeleton)
  and [setproduct's data-table guide](https://www.setproduct.com/blog/data-table-ui-design) both frame
  it as holding the layout steady while a fetch completes. These rows are not waiting for a fetch. A
  shimmer would say the wrong thing.
- The **motorsport** convention is the one taken: a tyre-strategy chart and a lap chart both plot laps
  1..N for the whole race and let the stints fill in ([per-race strategy charts](https://coffeecornermotorsport.com/f1-australian-grand-prix-2026-tyre-strategy/)).
- And an F1 timing screen never leaves a cell blank as a placeholder — it writes a word in it, which is
  what `IN PIT` and `P.EXIT` already do here ([trackside timing guide](https://www.grandprixpal.com/blog/f1-trackside-timing-screen-explained)).

So: full axis, numbered rows, **no data invented**. A cell past the revealed lap finds no row and falls
through to `EMPTY` exactly as an unrevealed cell always did, and `total_laps` was already on the wire
and already printed in the header as *"of 57"*.

## The pin moved with it

`scrollTop` targets the newest **revealed** row rather than the bottom of the table, because the bottom
of the table is now the future. That keeps what the bottom-anchored card was bought for, and the offset
is legitimately 0 while the newest lap is still inside the first viewport — which is why the guard
asserts **visibility**, not a scroll number.

## A measurement that corrected me

A future lap number carries meaning: how much race is left. So it gets the 3:1 floor for a meaningful
graphic — and my first attempt failed it. `--qt-border` measured **1.29:1** on the card and 1.18 on the
banded columns: invisible. The palette has no grey between `BORDER_COLOR` and `TEXT_TERTIARY`, so rather
than invent a hex the cell steps `--qt-fg-3` back with `opacity: 0.6` → **3.31:1** and 3.16, both clear,
and `test_pitwall_tokens.py` needs no new name. 0.55 was the other candidate: 2.99, under the floor.

## Guards

Five new, **driven red** against an axis that stops at the last revealed lap: `30 rows, last lap 30 of
57`, `30 driven, 0 future`, and the contrast one at `null`.

The probe is deliberately tolerant of there being no future rows, because that **is** the defect —
reading `future[0]` blind turned the red check into a thrown exception, and a stack trace names nothing.
The reveal is capped at the **stub**, not with `page.route`, since `bridge.ts` prefers
`window.pywebview` and an HTTP route intercepts nothing.

## Checks

`smoke-data` **181** · `smoke-agents` 19 · `tests/surfaces/` 230 · typecheck clean.

Verified live at both clients: 57 rows, 22 future, **0** of them carrying data, and the newest driven
lap 2 px off the scroller's bottom edge at 1265×593.
