### PR TITLE
fix(data): null a TyreLife the feed republished on an unchanged set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # ===========================
-# F1 Digital Twin - .gitignore
+# F1 StratLab - .gitignore
 # ===========================
 
 # Old project specific

--- a/src/f1_strat_manager/laps_augment.py
+++ b/src/f1_strat_manager/laps_augment.py
@@ -226,8 +226,10 @@ def augment_featured_laps(
             continue
         # Correct tyre-stint metadata the live-timing feed published wrong, BEFORE the
         # merge, because the repair needs `PitInTime` and only the raw frame carries it
-        # (#790). It touches nothing on a healthy race, so this is a no-op for 69 of the
-        # 71 shipped races.
+        # (#790). It touches nothing on a healthy race. That was "a no-op for 69 of the 71
+        # shipped races" while #790's NaN-block shape was the only one repaired; #988 added
+        # the republished-age shape, which also fires on Melbourne 2025, so the count is
+        # what the repair reports rather than a number written here.
         raw, stint_report = repair_tyre_stints(raw)
         if stint_report.changed_anything:
             corrections.append(_stint_corrections(raw, path, gp_name))

--- a/src/f1_strat_manager/tyre_stint_repair.py
+++ b/src/f1_strat_manager/tyre_stint_repair.py
@@ -24,12 +24,19 @@ reasons that module documents: the featured parquet is published on Hugging Face
 re-downloaded by `scripts/download_data.py`, so a locally-patched file would be silently
 reverted, and its only producer is a read-only notebook (N04).
 
-## The two repairs, and the one thing this never does
+## The three repairs, and the one thing this never does
 
 1. **Null the fabricated ages.** Where the feed invented a stint mid-race, the affected
    laps belong to the set the car started on, whose age is NOT recoverable. They become
    NaN -- a visible unknown replacing an invisible wrong integer.
-2. **Move the misplaced boundary.** Where the car pitted before the feed recovered, the
+2. **Null the republished ages (#988).** Where the age RESTARTS AT 1 with the compound
+   unchanged AND the pit passage sits in a run of consecutive entries, the feed reset the
+   count on a set that never came off the car. Melbourne 2025 is the case: five cars reset
+   to 1 on a safety-car pit-lane transit and then count on from that wrong zero for the
+   rest of the run. Nulled to the next real compound change. Both conditions are load
+   bearing and neither is sufficient alone: see `_age_restarted_on_an_unchanged_set` and
+   `_entered_the_pits_twice_running`.
+3. **Move the misplaced boundary.** Where the car pitted before the feed recovered, the
    new stint really began on the out-lap, and from there the age IS recoverable.
 
 It never invents a tyre age. A car may start a stint on a used set, and the offset is
@@ -57,6 +64,20 @@ real stop explains the change by itself; that is the Monaco case).
   boundary there cannot be seen by a compound-change test. No shipped race is affected
   today; the gap is structural. It errs toward missing a defect, never toward rewriting a
   correct record.
+* **And it is what bounds repair 2 in the other direction.** A car that fits another set
+  of the SAME compound, is published as FRESH, and does it on a lap adjacent to another
+  pit entry produces exactly what a republished age produces, in every column this module
+  reads, and those laps would be nulled. Two conditions have to coincide for that, and the
+  second means the car was in the pit lane on two consecutive laps -- which cars DO do, about
+  one driver per two races, so the residual is reachable rather than hypothetical. It has not
+  been observed: the repair nulls nothing on any race checked beyond Melbourne. On Melbourne
+  2025 it nulls 162 of 927 rows (17.5%), the whole opening stint of five cars, and leaves all
+  24 of that race's genuine stops alone.
+* **A nulled age is not neutral downstream, and that bounds how far this should ever go.**
+  `pit_strategy_agent._tyre_life_in` reads a NaN `TyreLife` as a FRESH SET (1), so a null
+  reaches N15 as a number, not as an unknown, and a wronger one than the artefact it
+  replaced. That is why repair 2 is scoped to a shape that is provably not a stop rather
+  than to every drop this module cannot explain.
 * **Raw-fed surfaces see feed values.** Consumers that read a raw parquet directly rather
   than through `augment_featured_laps` -- the replay engine and the backend's own race
   loader -- are not repaired. Unifying that is a wider change than this repair.
@@ -103,13 +124,17 @@ class RepairReport:
     boundaries_corrected: int = 0
     tyre_life_rebuilt: int = 0
     fabricated_ages_nulled: int = 0
+    republished_ages_nulled: int = 0
     unknown_after: int = 0
     drivers_touched: list[str] = field(default_factory=list)
 
     @property
     def changed_anything(self) -> bool:
         return bool(
-            self.boundaries_corrected or self.tyre_life_rebuilt or self.fabricated_ages_nulled
+            self.boundaries_corrected
+            or self.tyre_life_rebuilt
+            or self.fabricated_ages_nulled
+            or self.republished_ages_nulled
         )
 
 
@@ -215,6 +240,153 @@ def _fabricated_age_mask(driver_laps: pd.DataFrame) -> pd.Series:
     return (laps >= recovery_lap) & (laps <= end_lap) & driver_laps["TyreLife"].notna()
 
 
+def _republished_age_mask(driver_laps: pd.DataFrame) -> pd.Series:
+    """Laps whose ``TyreLife`` the feed reset on a set that never came off the car.
+
+    The signature is an age that RESTARTS AT 1 while the compound stays the same real
+    compound. A set cannot get younger, so one of the two readings is wrong, and the
+    restart is the one with no corroboration: nothing else in the record changed. Why the
+    landing value carries the rule, rather than the drop, is measured in
+    `_age_restarted_on_an_unchanged_set` - a plain drop test fires on 435 genuine pit
+    stops.
+
+    Melbourne 2025 is the shape this exists for. The safety car led the field through
+    the pit lane on laps 2, 3 and 4, and FastF1 opens a new stint on every one of those
+    transits for all seventeen runners. Twelve of them carry the age forward correctly
+    (NOR reads 2, 3, 4, 5). Five do not: ALB and STR reset to 1 on lap 3, LAW on lap 4,
+    BEA and OCO on lap 5, all with INTERMEDIATE on the car throughout.
+
+    **The mask runs to the next real compound change, not to the end of the drop.** The
+    feed does not resume the true count after republishing; it counts on from the wrong
+    zero for the rest of the run. STR reads 29 at lap 33 on a set that has done 33 laps,
+    OCO 35 at lap 39 on a set that has done 39. Nulling only the transit lap would leave
+    thirty laps of an age that is short by up to four.
+
+    --- WHY THIS NULLS RATHER THAN REBUILDS ---
+    The count IS recoverable by anchoring on the last honest age and continuing it, which
+    is the move `_rebuild_driver` already makes at a real boundary. It is not made here,
+    because the anchor there is backed by evidence a set changed (a pit entry AND a later
+    compound change) while the anchor here would rest on the absence of evidence that one
+    did. A set refitted with the SAME compound is invisible to every rule in this module,
+    as the module docstring states, so continuing the count would publish a confident
+    number on exactly the case the module cannot see. A visible unknown is the trade this
+    module already makes everywhere else.
+
+    --- WHY PIT-LANE DURATION IS NOT PART OF THE RULE ---
+    It cannot separate the two populations. Measured across all 82 pit-lane passages of
+    Melbourne 2025: transits that carry no age drop run 12.8 to 18.8 s, real stops run
+    17.9 to 26.1 s, and the ranges OVERLAP. Two of the five flagged transits are longer
+    than the median real stop (OCO 19.7 s, BEA 22.3 s), so a duration test would clear
+    them and leave the artefact in place on the two cars whose age is short by four laps.
+    """
+    ordered = driver_laps.sort_values("LapNumber")
+    marked = pd.Series(False, index=driver_laps.index)
+    lap_numbers = driver_laps["LapNumber"]
+    last_lap = int(ordered["LapNumber"].iloc[-1]) if len(ordered) else 0
+
+    entries = _pit_in_laps(ordered)
+    for position in range(1, len(ordered)):
+        if not _age_restarted_on_an_unchanged_set(ordered, position):
+            continue
+        drop_lap = int(ordered["LapNumber"].iloc[position])
+        if not _entered_the_pits_twice_running(entries, drop_lap):
+            continue
+        change_lap = _first_compound_change_after(ordered, drop_lap)
+        end_lap = change_lap - 1 if change_lap is not None else last_lap
+        in_run = (lap_numbers >= drop_lap) & (lap_numbers <= end_lap)
+        marked |= in_run & driver_laps["TyreLife"].notna()
+
+    return marked
+
+
+def _entered_the_pits_twice_running(entries: list[int], out_lap: int) -> bool:
+    """Was the pit passage this out-lap belongs to part of a RUN of consecutive ones?
+
+    **This is a JOINT condition and it does not stand alone. Cars really do pit on two
+    consecutive laps.** An earlier version of this docstring asserted they do not, which is
+    false and was measured false: across eight races, five drivers made two genuine stops on
+    adjacent laps (2025 Las Vegas ALB twice, at entries 13/14 and 34/35, and BOR at 1/2;
+    2025 Qatar BEA at 40/41 and OCO at 8/9; 2024 Imola ALB at 8/9), roughly one driver per
+    two races. Qatar's OCO goes MEDIUM (8 laps) to a fresh HARD to a fresh MEDIUM on three
+    consecutive laps. What blocks the null on every one of them is the COMPOUND changing or
+    the previous age already reading 1, not this test.
+
+    What this condition is actually for is the case those two miss: a fresh set of the SAME
+    compound, which reads exactly like a republished age. That case is not rare, it is the
+    modal raw-frame shape. Measured by neutralising this condition and re-running the repair
+    on real sessions:
+
+    * **2025 Qatar: 428 rows across 17 drivers** would be nulled without it, and 0 with it;
+    * 2025 Las Vegas: 21 rows on 1 driver without it, 0 with it;
+    * Melbourne 2025 is unchanged at 162 rows on 5 drivers either way.
+
+    So the pairing is what works: an age restarting at 1 on an unchanged compound is common
+    and usually a real stop; an age restarting at 1 on an unchanged compound **while the car
+    is in the pit lane on adjacent laps** is the artefact. At Melbourne all seventeen runners
+    have `PitInTime` on laps 2, 3 AND 4, because the safety car led the field through.
+
+    Over that race's 29 passages ending in an age of 1: the five same-compound artefacts sit
+    in a run, 5 of 5; the twenty-four genuine stops do not, 0 of 24.
+
+    --- WHY NOT THE FEATURED FRAMES ---
+    They drop the out-lap, which is the lap a fresh set reads 1 on, so a genuine stop's first
+    VISIBLE row there reads 2 by construction: 0 age-1 rows on Melbourne's featured slice
+    against 52 in the raw frame, and 14 in the whole of 2025. Any "no real stop lands on 1"
+    count taken there measures the filtering. This condition is measured on raw frames only.
+
+    The failure mode is missing an artefact, never nulling a real age, which is the direction
+    that matters: `pit_strategy_agent._tyre_life_in` reads a NaN age as a fresh set, so a
+    false null publishes a number rather than an unknown.
+    """
+    entry_lap = out_lap - 1
+    if entry_lap not in entries:
+        return False
+    return (entry_lap - 1) in entries or (entry_lap + 1) in entries
+
+
+def _age_restarted_on_an_unchanged_set(ordered: pd.DataFrame, position: int) -> bool:
+    """True when the age RESTARTS at 1 on the compound the car is already running.
+
+    This is only HALF the rule. `_republished_age_mask` also requires the pit passage to
+    sit in a run of consecutive entries, and that second condition is the one carrying
+    the weight. Read both before changing either.
+
+    **A plain "the age dropped" test fires on every genuine same-compound pit stop**,
+    which is the modal dry strategy of this regulation: across the shipped 2023-2025
+    featured laps there are 435 such drops in 53 grands prix, and the `Stint` column
+    advances on all 435 of them. Nulling those would take 9.7 to 15.2 % of a season's
+    ages, and N15 reads a NaN `TyreLife` as a fresh set, so the loss would come back as
+    a number further from the truth than the one the feed published. Requiring a landing
+    on exactly 1 removes all 435, and Melbourne 2025's five republished ages all land on
+    exactly 1, so the pair of conditions keeps the artefact and drops the false positives.
+
+    --- WHAT THAT 435 DOES AND DOES NOT SHOW ---
+    It shows the plain drop test is unusable. It does **not** show that a genuine
+    same-compound refit lands on 2 or more, and an earlier version of this docstring
+    claimed exactly that. The featured parquet DROPS THE OUT-LAP, which is the lap a
+    fresh set reads 1 on, so a genuine stop's first visible row there reads 2 by
+    construction: Melbourne's featured slice holds **0** rows with `TyreLife == 1.0`
+    against **52** in the raw frame it is built from, and the whole 2025 season holds 14
+    of 22,760. A "nothing real lands on 1" measurement taken there is a property of the
+    filtering. The repair runs on the RAW frames, where landing on 1 is ordinary, and
+    that is why the pit-run condition exists.
+
+    Both compounds must NAME a compound: a `HARD -> 'None'` pair is the feed dying, and
+    reading it as "the same set" would let data loss mark a run for nulling.
+    """
+    previous_age = ordered["TyreLife"].iloc[position - 1]
+    current_age = ordered["TyreLife"].iloc[position]
+    if pd.isna(previous_age) or pd.isna(current_age):
+        return False
+    restarted = current_age == 1.0 and previous_age > 1.0
+    if not restarted:
+        return False
+    previous_compound = ordered["Compound"].iloc[position - 1]
+    current_compound = ordered["Compound"].iloc[position]
+    both_named = is_real_compound(previous_compound) and is_real_compound(current_compound)
+    return both_named and previous_compound == current_compound
+
+
 def _rebuild_driver(driver_laps: pd.DataFrame, report: RepairReport) -> pd.DataFrame:
     """Null one driver's fabricated ages, then correct any misplaced stint boundary."""
     repaired = driver_laps.sort_values("LapNumber").copy()
@@ -224,6 +396,20 @@ def _rebuild_driver(driver_laps: pd.DataFrame, report: RepairReport) -> pd.DataF
     if fabricated.any():
         repaired.loc[fabricated, "TyreLife"] = float("nan")
         report.fabricated_ages_nulled += int(fabricated.sum())
+        touched = True
+
+    # After the nulling pass above, so a block the feed never published cannot also be
+    # read as a set getting younger. The two artefacts are disjoint on every race
+    # measured, and the order makes that a property rather than a coincidence.
+    # `republished_ages_nulled` counts what this pass NULLED, which is not always what the
+    # frame returns: the boundary rebuild below rewrites `TyreLife` on the stint it
+    # corrects, and that stint can overlap a run this pass just nulled. `unknown_after` is
+    # the count of unknowns that survive; this one is the count of ages this pass refused
+    # to trust. No shipped race carries both artefacts on one driver.
+    republished = _republished_age_mask(repaired)
+    if republished.any():
+        repaired.loc[republished, "TyreLife"] = float("nan")
+        report.republished_ages_nulled += int(republished.sum())
         touched = True
 
     lap_numbers = repaired["LapNumber"]
@@ -305,10 +491,12 @@ def repair_tyre_stints(laps: pd.DataFrame) -> tuple[pd.DataFrame, RepairReport]:
 
     if report.changed_anything:
         logger.info(
-            "Tyre-stint repair on %d driver(s): %d fabricated age(s) nulled, %d boundary/ies "
-            "corrected, %d age(s) rebuilt; %d racing lap(s) now carry an honest unknown age (#790)",
+            "Tyre-stint repair on %d driver(s): %d fabricated age(s) nulled, %d republished "
+            "age(s) nulled, %d boundary/ies corrected, %d age(s) rebuilt; %d racing lap(s) now "
+            "carry an honest unknown age (#790, #988)",
             len(report.drivers_touched),
             report.fabricated_ages_nulled,
+            report.republished_ages_nulled,
             report.boundaries_corrected,
             report.tyre_life_rebuilt,
             report.unknown_after,

--- a/src/pitwall/session_data.py
+++ b/src/pitwall/session_data.py
@@ -257,17 +257,14 @@ def _tyre_stops(revealed: list[dict[str, Any]]) -> int:
       the outgoing set's. `tyre_stint_repair` measures used sets starting
       anywhere from 2 to 16, so a short first stint replaced by a used set is
       invisible here. It errs toward missing a stop, never toward inventing one.
-    * A feed that republishes `TyreLife` as 1 on a transit, which is #988.
-      Measured over the whole of Melbourne 2025: **five cars** carry that
-      artefact - ALB and STR on lap 3, LAW on lap 4, BEA and OCO on lap 5, all
-      with the compound unchanged - so each reads one stop high. The field's
-      total goes from **82 in-laps to 36 against a true 31**; the residual 5 is
-      that artefact and belongs where it can be repaired, not here.
-
-      (An earlier version of this comment said STR alone. That figure came from
-      comparing two candidate RULES and reporting where they differed, which is
-      not the same population as where the DATA is wrong: on the other four both
-      rules agreed, and agreed wrongly.)
+    * A set refitted with the same compound while the feed REPUBLISHES the age as
+      1. That reads as a stop here and it is one of the two things it could be.
+      It is not a gap this rule can close, because the two are identical in every
+      field it reads; `tyre_stint_repair`'s `_republished_age_mask` nulls those
+      ages upstream instead, so the age arrives as None and neither reading is
+      published. Melbourne 2025's five cases (ALB and STR on lap 3, LAW on lap 4,
+      BEA and OCO on lap 5) are repaired there, which is what takes the field
+      from **82 in-laps to 31**.
     """
     rows = [row for row in revealed if not row["generated"]]
     changed = 0

--- a/tests/agents/test_tyre_stint_repair.py
+++ b/tests/agents/test_tyre_stint_repair.py
@@ -327,3 +327,313 @@ def test_a_boundary_with_no_stint_id_does_not_half_apply():
     assert not report.changed_anything
     # Reported no change, so there must BE no change.
     pd.testing.assert_frame_equal(repaired, no_stint)
+
+
+# --- #988: an age republished on a set that never came off the car ---------------
+
+# Melbourne 2025 STR's shape: the safety car leads the field through the pit lane, the
+# feed opens a stint on each pass, and the age resets to 1 with INTERMEDIATE still on the
+# car. It then counts on from that wrong zero for the whole run.
+REPUBLISHED_ON_TRANSIT = _laps(
+    [
+        (1, 1.0, "INTERMEDIATE", 1.0, False),
+        (2, 1.0, "INTERMEDIATE", 2.0, True),  # transit under the safety car
+        (3, 2.0, "INTERMEDIATE", 1.0, True),  # the age resets: no set came off
+        (4, 3.0, "INTERMEDIATE", 1.0, True),
+        (5, 4.0, "INTERMEDIATE", 1.0, False),
+        (6, 4.0, "INTERMEDIATE", 2.0, False),  # counts on from the wrong zero
+        (7, 4.0, "INTERMEDIATE", 3.0, True),  # the real stop
+        (8, 5.0, "HARD", 1.0, False),  # the new set's own age is fine
+        (9, 5.0, "HARD", 2.0, False),
+    ]
+)
+
+
+def test_a_republished_age_is_nulled_rather_than_believed():
+    """The effect, not the mechanism: no lap of that run keeps a number.
+
+    Nulling only the reset lap would leave laps 4 to 7 reading 1, 1, 2, 3 on a set that
+    has done four, five, six and seven laps - short by three, and invisible.
+    """
+    repaired, report = repair_tyre_stints(REPUBLISHED_ON_TRANSIT)
+    ages = dict(zip(repaired["LapNumber"], repaired["TyreLife"]))
+    assert ages[1.0] == 1.0 and ages[2.0] == 2.0, "the honest prefix survives"
+    assert all(pd.isna(ages[lap]) for lap in (3.0, 4.0, 5.0, 6.0, 7.0))
+    assert report.republished_ages_nulled == 5
+    assert report.drivers_touched == ["NOR"]
+
+
+def test_the_new_set_after_the_stop_keeps_its_own_age():
+    """The run ends at the compound change, so the repair cannot swallow the next stint."""
+    repaired, _ = repair_tyre_stints(REPUBLISHED_ON_TRANSIT)
+    after = repaired[repaired["LapNumber"] >= 8.0]
+    assert list(after["TyreLife"]) == [1.0, 2.0]
+
+
+def test_a_data_loss_sentinel_is_not_read_as_the_same_set():
+    """`HARD -> 'None'` is the feed dying, and its age drop must not mark a run.
+
+    Without the `is_real_compound` pair this would null every lap from the moment the
+    compound column went blank, which is data loss repairing itself into more data loss.
+    """
+    dark = _laps(
+        [
+            (1, 1.0, "HARD", 5.0, False),
+            (2, 1.0, "None", 1.0, False),
+            (3, 1.0, "None", 2.0, False),
+        ]
+    )
+    repaired, report = repair_tyre_stints(dark)
+    assert report.republished_ages_nulled == 0
+    pd.testing.assert_frame_equal(repaired, dark)
+
+
+def test_a_used_same_compound_refit_is_left_alone():
+    """The shape that MUST NOT fire, and the reason the rule reads the landing value.
+
+    A same-compound stop is the modal dry strategy of this regulation, and a plain "the
+    age dropped" test fires on every one of them: 435 across the shipped 2023-2025
+    featured laps, in 53 grands prix, all with `Stint` advancing. Nulling those would
+    take 9.7 to 15.2 % of a season's ages, and N15 reads a NaN age as a fresh set, so the
+    loss would come back as a number further from the truth than the feed's.
+
+    Requiring the age to land on exactly 1 removes all 435 of them. **That is all it shows.**
+    It does NOT show that a real refit never lands on 1: the featured frames drop the
+    out-lap, which is the lap a fresh set reads 1 on, so their first visible row reads 2 by
+    construction. On raw frames a fresh same-compound refit landing on 1 is ordinary, which
+    is what `_entered_the_pits_twice_running` exists for. This fixture is the featured-frame
+    shape: HARD 11 laps old replaced by a HARD that has done 2.
+    """
+    refit = _laps(
+        [
+            (1, 1.0, "HARD", 10.0, False),
+            (2, 1.0, "HARD", 11.0, True),  # a real stop onto another, used, HARD
+            (3, 2.0, "HARD", 2.0, False),
+            (4, 2.0, "HARD", 3.0, False),
+        ]
+    )
+    repaired, report = repair_tyre_stints(refit)
+    assert report.republished_ages_nulled == 0
+    pd.testing.assert_frame_equal(repaired, refit)
+
+
+def test_a_fresh_same_compound_refit_at_a_lone_stop_is_left_alone():
+    """The shape the landing-value test alone could NOT tell from the artefact.
+
+    A car that fits a FRESH set of the compound it is already running publishes exactly
+    what a republished age publishes: age 1, compound unchanged. The featured parquets
+    cannot say how often that happens, because they drop the out-lap and so hold almost
+    no age-1 rows at all. What separates it is the second condition: this car made ONE pit
+    entry, and a car making a stop is not in the pit lane on two consecutive laps.
+    """
+    refit = _laps(
+        [
+            (1, 1.0, "HARD", 10.0, False),
+            (2, 1.0, "HARD", 11.0, True),  # a lone entry: a real stop
+            (3, 2.0, "HARD", 1.0, False),
+            (4, 2.0, "HARD", 2.0, False),
+        ]
+    )
+    repaired, report = repair_tyre_stints(refit)
+    assert report.republished_ages_nulled == 0
+    pd.testing.assert_frame_equal(repaired, refit)
+
+
+def test_the_residual_is_a_fresh_refit_made_beside_another_pit_entry():
+    """The cost of the rule, asserted rather than left to be discovered.
+
+    Both conditions have to coincide: a fresh set of the compound already on the car, AND
+    the car in the pit lane on two consecutive laps. That is what a driver who serves a
+    penalty and then pits for real on the next lap looks like, and its age would be nulled.
+    The base rate is not measured, because a curated install carries one raw race; it is
+    written down as a residual rather than quantified.
+    """
+    refit = _laps(
+        [
+            (1, 1.0, "HARD", 10.0, True),  # a penalty served
+            (2, 1.0, "HARD", 11.0, True),  # and a real stop on the very next lap
+            (3, 2.0, "HARD", 1.0, False),
+            (4, 2.0, "HARD", 2.0, False),
+        ]
+    )
+    repaired, report = repair_tyre_stints(refit)
+    assert report.republished_ages_nulled == 2
+    assert list(repaired["TyreLife"])[:2] == [10.0, 11.0]
+    assert repaired["TyreLife"].iloc[2:].isna().all()
+
+
+def test_the_real_race_the_artefact_was_found_on_comes_back_repaired():
+    """Melbourne 2025, the only race a curated install carries. The effect, on real rows.
+
+    The synthetic fixtures above pin the rule; this pins what the rule does to the frame
+    that ships. Before #988 the repair reported `changed_anything is False` on this
+    race - 0 of 927 rows - while five cars carried an age short by up to four laps for
+    the whole of their opening stint.
+    """
+    from src.f1_strat_manager.data_cache import get_data_root
+
+    frame_path = get_data_root() / "raw" / "2025" / "Melbourne" / "laps.parquet"
+    if not frame_path.exists():
+        pytest.skip("2025/Melbourne is not in this install's curated data set")
+    laps = pd.read_parquet(frame_path)
+    assert len(laps) == 927, "the frame this measurement was taken on"
+
+    repaired, report = repair_tyre_stints(laps)
+    assert sorted(report.drivers_touched) == ["ALB", "BEA", "LAW", "OCO", "STR"]
+    assert report.republished_ages_nulled == 162
+
+    # The transit that corrupts each, and the last lap of the run it poisons.
+    for code, drop_lap, end_lap in (
+        ("STR", 3, 33),
+        ("ALB", 3, 33),
+        ("LAW", 4, 33),
+        ("OCO", 5, 39),
+        ("BEA", 5, 39),
+    ):
+        rows = repaired[repaired["Driver"] == code].set_index("LapNumber")["TyreLife"]
+        assert rows.loc[float(drop_lap - 1)] == float(drop_lap - 1), f"{code} keeps its prefix"
+        poisoned = rows.loc[float(drop_lap) : float(end_lap)]
+        assert len(poisoned) == end_lap - drop_lap + 1, f"{code}'s run was not empty"
+        assert poisoned.isna().all(), f"{code} laps {drop_lap}-{end_lap}"
+
+    # The twelve runners who counted through the same three transits are untouched, and
+    # NOR's age is still exactly his lap number to the moment he really stops.
+    nor = repaired[repaired["Driver"] == "NOR"].set_index("LapNumber")["TyreLife"]
+    assert [nor.loc[float(lap)] for lap in range(1, 35)] == [float(lap) for lap in range(1, 35)]
+
+
+def test_the_rule_fires_on_nothing_across_the_shipped_seasons():
+    """The population the repair actually runs over, not the one race it was found on.
+
+    `augment_featured_laps` calls this repair for EVERY grand prix in the featured frame,
+    so the number that matters is not what it does to Melbourne but what it does to the
+    other seventy races. An earlier version of the rule triggered on any age drop with the
+    compound unchanged, which is what a same-compound pit stop looks like: 435 of them
+    across 2023-2025, in 53 grands prix, and it would have nulled 9.7 to 15.2 % of every
+    season's ages.
+
+    This asserts the non-firing half on the shipped featured parquets. The count of drops
+    examined is pinned first: a scan that found nothing would otherwise pass while proving
+    nothing, which is the failure mode this repo has already shipped once.
+
+    **What it does NOT prove, stated so nobody reads more into it.** The featured parquet
+    drops the out-lap, so it holds almost no rows with `TyreLife == 1.0` at all: 14 in the
+    whole of 2025 against 52 in Melbourne's raw frame alone. A landing-value rule therefore
+    could not fire here whatever it did. The population this guard rules out is the one the
+    PLAIN drop rule would have hit, and that is worth pinning because that rule was written
+    and nearly shipped. The rule that actually ships is pinned against the RAW frame by
+    `test_the_real_race_the_artefact_was_found_on_comes_back_repaired` and
+    `test_no_genuine_stop_on_the_real_race_is_touched`, and this test SKIPS on CI, which
+    carries no data at all.
+    """
+    from src.f1_strat_manager.data_cache import get_data_root
+    from src.f1_strat_manager.tyre_stint_repair import _age_restarted_on_an_unchanged_set
+
+    root = get_data_root()
+    examined = 0
+    restarted: list[tuple[str, str, int]] = []
+    for year in (2023, 2024, 2025):
+        path = root / "processed" / f"laps_featured_{year}.parquet"
+        if not path.exists():
+            continue
+        frame = pd.read_parquet(path)
+        for (gp, driver), group in frame.groupby(["GP_Name", "Driver"], sort=False):
+            ordered = group.sort_values("LapNumber").reset_index(drop=True)
+            ages = ordered["TyreLife"]
+            for position in range(1, len(ordered)):
+                previous, current = ages.iloc[position - 1], ages.iloc[position]
+                if pd.isna(previous) or pd.isna(current) or current >= previous:
+                    continue
+                examined += 1
+                if _age_restarted_on_an_unchanged_set(ordered, position):
+                    restarted.append((str(gp), str(driver), int(ordered["LapNumber"][position])))
+    if not examined:
+        pytest.skip("the featured parquets are not in this install's curated data set")
+    assert examined > 1000, f"only {examined} age drops examined across three seasons"
+    assert not restarted, f"the rule fires on real stops: {restarted[:10]}"
+
+
+def test_no_genuine_stop_on_the_real_race_is_touched():
+    """The other half of the real-frame check: the 24 stops that must survive.
+
+    `test_the_real_race_the_artefact_was_found_on_comes_back_repaired` asserts the five
+    runs are nulled. This asserts the complement on the same frame, which is the half a
+    too-wide rule would fail: Melbourne 2025 has 29 pit passages that end with an age of 1,
+    five of them the artefact and twenty-four genuine compound changes, and no genuine one
+    may lose its age.
+
+    Both counts are pinned before anything is compared, because a frame that yielded no
+    passages at all would make every assertion below vacuous.
+    """
+    from src.f1_strat_manager.data_cache import get_data_root
+
+    frame_path = get_data_root() / "raw" / "2025" / "Melbourne" / "laps.parquet"
+    if not frame_path.exists():
+        pytest.skip("2025/Melbourne is not in this install's curated data set")
+    laps = pd.read_parquet(frame_path)
+    repaired, _report = repair_tyre_stints(laps)
+
+    artefacts, genuine = [], []
+    for driver, group in laps.groupby("Driver", sort=False):
+        ordered = group.sort_values("LapNumber").reset_index(drop=True)
+        for position in range(1, len(ordered)):
+            previous = ordered["TyreLife"].iloc[position - 1]
+            current = ordered["TyreLife"].iloc[position]
+            if pd.isna(previous) or pd.isna(current) or current != 1.0 or previous <= 1.0:
+                continue
+            lap = int(ordered["LapNumber"].iloc[position])
+            same_compound = (
+                ordered["Compound"].iloc[position - 1] == ordered["Compound"].iloc[position]
+            )
+            (artefacts if same_compound else genuine).append((str(driver), lap))
+    assert len(artefacts) == 5, f"expected the five known artefacts, got {artefacts}"
+    assert len(genuine) == 24, f"expected 24 genuine stops landing on 1, got {len(genuine)}"
+
+    for driver, lap in genuine:
+        rows = repaired[repaired["Driver"] == driver].set_index("LapNumber")["TyreLife"]
+        assert rows.loc[float(lap)] == 1.0, f"{driver} lost a real stop's age on lap {lap}"
+
+
+def test_a_used_same_compound_refit_beside_another_entry_is_left_alone():
+    """The fixture that pins the LANDING condition, which the run condition cannot.
+
+    Both halves of the trigger need a shape that isolates them. This is the one for the
+    landing value: a real stop onto a USED set of the same compound, made on a lap adjacent
+    to another pit entry, so the run condition is satisfied and only the landing value keeps
+    the repair away. Dropping `current_age == 1.0` back to a plain drop test nulls this.
+
+    Without it the whole landing condition is pinned only by a data-gated test that skips on
+    CI, which carries no data at all.
+    """
+    refit = _laps(
+        [
+            (1, 1.0, "HARD", 10.0, True),  # a served penalty
+            (2, 1.0, "HARD", 11.0, True),  # a real stop on the very next lap
+            (3, 2.0, "HARD", 4.0, False),  # onto a USED HARD: lands on 4, not 1
+            (4, 2.0, "HARD", 5.0, False),
+        ]
+    )
+    repaired, report = repair_tyre_stints(refit)
+    assert report.republished_ages_nulled == 0
+    pd.testing.assert_frame_equal(repaired, refit)
+
+
+def test_an_age_already_reading_one_is_not_a_restart():
+    """`previous_age > 1.0` isolated, on a shape that really happens.
+
+    A car that pits on lap 1 and again on lap 2 reads age 1 on both, and the entries are
+    adjacent, so every other condition is satisfied. Las Vegas 2025 BOR is exactly that pair.
+    Nothing restarted: the age was already 1, and dropping the `previous_age > 1.0` term
+    would null a run on a car whose record is not contradictory at all.
+    """
+    twice = _laps(
+        [
+            (1, 1.0, "MEDIUM", 1.0, True),
+            (2, 2.0, "MEDIUM", 1.0, True),
+            (3, 3.0, "MEDIUM", 1.0, False),
+            (4, 3.0, "MEDIUM", 2.0, False),
+        ]
+    )
+    repaired, report = repair_tyre_stints(twice)
+    assert report.republished_ages_nulled == 0
+    pd.testing.assert_frame_equal(repaired, twice)

--- a/tests/surfaces/test_pitwall_session_data.py
+++ b/tests/surfaces/test_pitwall_session_data.py
@@ -388,23 +388,22 @@ def test_the_real_race_never_reports_a_stop_nobody_made():
     3 and 4, so `PitInTime` is set for all seventeen runners on each. At lap 24
     not one car has changed tyres; NOR's real stops are laps 35 and 45.
 
-    Five cars read one stop high and it is #988's artefact, not this rule's: the
-    feed republishes their `TyreLife` as 1 on one of the transits. They are named
-    below rather than absorbed into a tolerance, so the day #988 lands this test
-    fails and says which line to change. Everyone else is exact.
+    Five cars used to read one stop high on #988's artefact - the feed republishing
+    their `TyreLife` as 1 on one of the transits. That is repaired upstream now, in
+    `tyre_stint_repair`, so every car is exact here and the field total is the 31 real
+    stops rather than 36.
     """
     session = _session_or_skip()
     reveal = _all_revealed(session)
-    # The exact five, with the transit that corrupts each: ALB and STR on lap 3,
-    # LAW on lap 4, BEA and OCO on lap 5. See #988.
-    republished = {"ALB", "BEA", "LAW", "OCO", "STR"}
 
     early = session.masked_view({code: 24 for code in reveal}, 0.0)["drivers"]
+    # Asserted before the loop: a masked view that returned no drivers would make every
+    # assertion inside it vacuous and the test would pass green on an empty set.
+    assert len(early) == 20, "the whole grid should be in the view"
     for code, driver in early.items():
-        expected = 1 if code in republished else 0
-        assert driver["stops"] == expected, f"{code} at lap 24"
+        assert driver["stops"] == 0, f"{code} at lap 24"
     # Counting in-laps gave the field 51 here, on a lap where nobody has stopped.
-    assert sum(driver["stops"] for driver in early.values()) == len(republished)
+    assert sum(driver["stops"] for driver in early.values()) == 0
 
     final = session.masked_view(reveal, 0.0)["drivers"]
     # Melbourne 2025 was wet-dry-wet, so every real stop is a compound change.
@@ -413,7 +412,11 @@ def test_the_real_race_never_reports_a_stop_nobody_made():
     assert final["ALO"]["stops"] == 0
     # SAI, DOO and HAD have only generated rows: no laps, no transits, no stops.
     assert [final[code]["stops"] for code in ("SAI", "DOO", "HAD")] == [0, 0, 0]
-    assert sum(driver["stops"] for driver in final.values()) == 36, "31 real + #988's five"
+    # The five that used to read high: ALB and STR transited on lap 3, LAW on lap 4,
+    # BEA and OCO on lap 5. Each has two real stops except LAW, who has one.
+    assert [final[code]["stops"] for code in ("ALB", "BEA", "OCO", "STR")] == [2, 2, 2, 2]
+    assert final["LAW"]["stops"] == 1
+    assert sum(driver["stops"] for driver in final.values()) == 31, "the real stops, #988"
 
 
 def _row(frame: pd.DataFrame, index: int) -> dict:


### PR DESCRIPTION
## What

`repair_tyre_stints` now nulls a `TyreLife` that drops while the compound is unchanged, from the
drop to the next real compound change. On Melbourne 2025 that is 162 of 927 rows, on ALB, BEA,
LAW, OCO and STR. The repair used to return that race untouched.

Closes #988.

## Why

The safety car led the field through the pit lane on laps 2, 3 and 4, and the feed opens a new
stint on every one of those transits for all seventeen runners. Twelve carry the age forward
correctly (NOR reads 2, 3, 4, 5). Five reset it to 1 with INTERMEDIATE still on the car, and then
count on from that wrong zero for the rest of the run:

| car | reset at | published age at the real stop | laps the set had done |
|---|---|---|---|
| STR | lap 3 | 29 at lap 33 | 33 |
| ALB | lap 3 | 31 at lap 33 | 33 |
| LAW | lap 4 | 32 at lap 33 | 33 |
| OCO | lap 5 | 35 at lap 39 | 39 |
| BEA | lap 5 | 35 at lap 39 | 39 |

So the artefact is not three laps per car, it is the whole opening stint: about 150 laps of a
2025 race, understated by one to four. `TyreLife` feeds N26's TCN and N15/N16, and 2025 is the
test season.

`_fabricated_age_mask` could not see it. It hunts the Miami shape, a NaN block the feed later
resumes with a new stint. These blocks are not NaN, they are a wrong integer in a stint the feed
also opened, so there was nothing to null and no later compound change to anchor a boundary on.

## How

`_republished_age_mask` in `tyre_stint_repair.py`, run after the existing nulling pass, with a
`republished_ages_nulled` counter of its own so the log and any test can tell the two artefacts
apart. The module docstring goes from two repairs to three, and the known-limits section gains the
cost of this one.

**The rule is two conditions, and the issue's version is neither of them.** "The age dropped with
the compound unchanged" is what the issue describes, and it fires on every genuine same-compound
pit stop, which is the modal dry strategy of this regulation. Measured over the shipped featured
laps:

| season | same-compound drops | driver-races | GPs | rows the plain rule would null | `Stint` advances |
|---|---|---|---|---|---|
| 2023 | 157 | 148 | 17 | 3,173 of 20,908 (15.2%) | 157/157 |
| 2024 | 164 | 156 | 20 | 3,102 of 23,256 (13.3%) | 164/164 |
| 2025 | 114 | 110 | 16 | 2,198 of 22,760 (9.7%) | 114/114 |

Austin 2023 VER, `MEDIUM 15 -> 2` on lap 18, is a real stop onto a used medium. Melbourne is the
one wet race where every same-compound drop is an artefact, so pricing the rule there measured the
wrong population.

**Condition one: the age must land on exactly 1**, which removes all 435. That alone is not enough,
and the reason matters because an earlier version of this branch claimed it was: a measurement on
the featured parquets cannot support any claim about what lands on 1, because **those frames drop
the out-lap**, and the out-lap is the lap a fresh set reads 1 on. VER's real stop at Melbourne lap
35 (`MEDIUM`, age 1.0) is not in the featured frame at all. Melbourne's featured slice holds 0 rows
with `TyreLife == 1.0` against 52 in the raw frame it is built from, and the whole of 2025 holds 14
of 22,760. A genuine stop's first visible featured row reads 2 by construction.

**Condition two: the pit passage must sit in a run of consecutive entries**, measured on the raw
frames, which is where the repair runs. At Melbourne all seventeen runners have `PitInTime` on laps
2, 3 and 4, because the safety car led the field through. Over the 29 passages on that race that
end in an age of 1:

| | in a run of consecutive entries |
|---|---|
| the five same-compound artefacts | 5 of 5 |
| the twenty-four genuine stops | 0 of 24 |

**The two conditions are joint and neither is sufficient.** Cars do pit on consecutive laps, about
one driver per two races: 2025 Las Vegas ALB twice (entries 13/14 and 34/35) and BOR (1/2), 2025
Qatar BEA (40/41) and OCO (8/9), 2024 Imola ALB (8/9). Qatar's OCO goes MEDIUM at 8 laps to a fresh
HARD to a fresh MEDIUM on three consecutive laps. What keeps the repair off those is the compound
changing or the previous age already reading 1, not the run test.

The landing test is not sufficient either. Neutralising the run condition and re-running the repair
on real sessions:

| race | rows nulled without the run condition | with it |
|---|---|---|
| 2025 Qatar | 428, across 17 drivers | 0 |
| 2025 Las Vegas | 21, 1 driver | 0 |
| 2024 Imola | 0 | 0 |
| 2025 Melbourne | 162, 5 drivers | 162, 5 drivers |

A fresh same-compound refit landing on 1 is the ordinary raw-frame shape, not a rarity. Only the
pair separates it from the artefact.

**Pit-lane duration is deliberately not part of the rule.** The issue proposed "no plausible
stationary time" as half the test. Across all 82 pit-lane passages of the race the two populations
overlap: transits without an age drop run 12.8 / 14.7 / 18.8 s (min/median/max), real stops run
17.9 / 19.4 / 26.1. Two of the five flagged transits are longer than the median real stop (OCO
19.7 s, BEA 22.3 s), so a duration test would clear exactly the two cars whose age is short by four
laps.

**It nulls rather than rebuilds.** The count is recoverable by anchoring on the last honest age,
which is the move `_rebuild_driver` already makes at a real boundary. It is not made here because
that anchor is backed by evidence a set changed, while this one would rest on the absence of
evidence that one did.

**The residual is reachable, and it has not been observed.** A car that fits a fresh set of the
compound it is already running, on a lap adjacent to another pit entry, produces what a republished
age produces in every column this module reads, and its age would be nulled. Since cars do pit on
adjacent laps, that is a real shape rather than a hypothetical one. The repair nulls nothing on any
race checked beyond Melbourne. Quoting a rate would repeat the mistake this branch already made
once: a curated install carries one raw race, and the featured parquets cannot answer it.

**And a null is not neutral downstream, which is why the rule is scoped this tightly.**
`pit_strategy_agent._tyre_life_in` reads a NaN `TyreLife` as a fresh set and returns 1, with a
docstring arguing that is the defensible read. So the module's "a visible unknown over an invisible
wrong integer" holds for the frame and not for N15: a null arrives there as a number, and a wronger
one than the artefact it replaced. That is pre-existing (the Miami repair already nulls 451 rows of
the 2025 featured parquet) and is filed separately, but it is the reason both conditions are
required rather than one.

`_tyre_stops` in `src/pitwall/session_data.py` carried a paragraph saying the five cars were the
residual it could not fix. That is now false, so it is rewritten rather than left.

## Out of scope

- **Raw-fed surfaces still see feed values.** The arcade's own pyglet overlay reads
  `lap.TyreLife` straight from FastF1 (`src/arcade/data.py`), so it still shows the republished
  age while PITWALL's tower shows none. That gap is named in the module docstring already and
  unifying it is a wider change.
- **#951 stays blocked.** The Miami shape needs `ensure_race(2025, "Miami")` before it can be
  regression-tested on a real frame.

## Checks

- `tests/agents/test_tyre_stint_repair.py` 23 passed, `tests/surfaces/` 234 passed,
  `uvx ruff check` clean.
- Real frame: `report.republished_ages_nulled == 162`, `drivers_touched` exactly the five, NOR's
  `TyreLife` column byte-identical, and the three healthy fixtures still return unchanged.
- Guards driven RED by disabling the pass, then restored from a copy and the revert verified by
  re-reading the file. The negative guards stay green under that mutation, correctly: they catch
  over-reach, not absence.
- `test_the_rule_fires_on_nothing_across_the_shipped_seasons` runs the predicate over every age
  drop in the three featured parquets, pins the number of drops examined before asserting anything,
  and goes red on the un-narrowed rule with the list of real stops it would have nulled (Austin VER
  lap 18 first). Its docstring states what it does NOT prove and that it skips on CI, which carries
  no data at all.
- `test_no_genuine_stop_on_the_real_race_is_touched` is the complement, on the RAW frame: it pins
  5 artefacts and 24 genuine stops before comparing anything, then asserts no genuine one loses its
  age. Each half of the trigger has a fixture that isolates it, and each goes red on its own
  mutation: removing the pit-run condition reddens
  `test_a_fresh_same_compound_refit_at_a_lone_stop_is_left_alone`, reverting the landing test to a
  plain drop reddens `test_a_used_same_compound_refit_beside_another_entry_is_left_alone`, and
  dropping `previous_age > 1.0` reddens `test_an_age_already_reading_one_is_not_a_restart`. All
  three run on CI, which carries no data.
- `tests/agents/test_tyre_stint_repair.py` 29 passed. Whole suite: 939 passed, 9 pre-existing
  failures that reproduce with this change disabled (the curated data set: the NLP goldens need
  `data/models/nlp`, the eval reproductions need the full raw corpus).
- `test_the_real_race_never_reports_a_stop_nobody_made` failed and named the line, as it was
  written to. The field total goes from 36 to 31.
- One pre-existing failure, `tests/audit/test_pit_agent_hardening.py::test_team_year_median_is_aggregated_from_real_pit_data`,
  reproduces with this change disabled. It is the unpublished `undercut_clean.parquet` (#798).
