### PR TITLE
fix(pitwall): an empty window says whether the socket is up

### DIFF
--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -205,6 +205,11 @@ await page.addInitScript((view) => {
     api: {
       get_agents_view: async (sinceSeq) => (sinceSeq >= view.seq ? null : view),
       get_tick: async () => null,
+      // Stubbed since #1004: `getConnection` falls back to `fetch("/api/connection")`
+      // when the injected api has no such method, and the static server answers 404.
+      // A missing stub method is a 404 in the console, not a thrown error, so it
+      // costs three console failures and no clue about which call made them.
+      get_connection: async () => "Connected",
     },
   };
 }, VIEW);
@@ -395,6 +400,89 @@ check(
 );
 
 await live.close();
+
+// --- The IDLE window before the first view, and #1004's two states ------------
+//
+// `get_agents_view` returns null until a tick has arrived, so this window has no
+// connection word at all for the whole startup: measured on the real path, null
+// on all 169 samples across 11 s, of which the last 3 s had the socket UP and the
+// arcade loading its session. The status bar said "Waiting for arcade stream…"
+// throughout, which describes only the first 8 s.
+//
+// The word is polled with `useConnection` while `view` is null, and the two
+// states must be TELLABLE APART from the rendered bar. Reading one of them would
+// pass on a build that hardcoded the string.
+async function idleStatusBar(connection) {
+  const context = await browser.newContext({ viewport: { width: 1320, height: 900 } });
+  const idlePage = await context.newPage();
+  idlePage.on("pageerror", (error) =>
+    failures.push(`pageerror(idle/${connection}): ${error.message}`),
+  );
+  await idlePage.addInitScript((state) => {
+    window.pywebview = {
+      api: {
+        get_agents_view: async () => null,
+        get_tick: async () => null,
+        get_connection: async () => state,
+      },
+    };
+  }, connection);
+  await idlePage.goto(`http://127.0.0.1:${server.address().port}/agents.html`, {
+    waitUntil: "domcontentloaded",
+  });
+  await idlePage.waitForSelector(".agents-window", { timeout: 5000 });
+  // 1.2 s, because `useConnection` polls at 1 Hz behind `whenBridgeReady`: a
+  // shorter wait reads the null-connection frame, which renders the same
+  // sentence for both stubs and would make this pass while seeing one branch.
+  await idlePage.waitForTimeout(1200);
+  const bar = (await idlePage.locator(".status-bar").textContent()) ?? "";
+  await context.close();
+  return bar;
+}
+
+const idleUp = await idleStatusBar("Connected");
+const idleDown = await idleStatusBar("Connecting...");
+check(
+  idleUp !== idleDown,
+  `the idle status bar tells the two socket states apart (up: "${idleUp}", down: "${idleDown}")`,
+);
+check(
+  idleUp.includes("Connected"),
+  `with the socket up the idle bar says so ("${idleUp}")`,
+);
+
+// The view, once it exists, still wins over the polled word: it is host-built and
+// travels WITH the payload, so it cannot disagree with the lap beside it. Stubbed
+// with a DISAGREEING connection, or a bar that ignored the poll entirely would
+// pass this too.
+const servedBar = await (async () => {
+  const context = await browser.newContext({ viewport: { width: 1320, height: 900 } });
+  const viewPage = await context.newPage();
+  await viewPage.addInitScript(
+    ([view, state]) => {
+      window.pywebview = {
+        api: {
+          get_agents_view: async (sinceSeq) => (sinceSeq >= view.seq ? null : view),
+          get_tick: async () => null,
+          get_connection: async () => state,
+        },
+      };
+    },
+    [VIEW, "Connecting..."],
+  );
+  await viewPage.goto(`http://127.0.0.1:${server.address().port}/agents.html`, {
+    waitUntil: "domcontentloaded",
+  });
+  await viewPage.waitForSelector(".agent-card", { timeout: 5000 });
+  await viewPage.waitForTimeout(1200);
+  const bar = (await viewPage.locator(".status-bar").textContent()) ?? "";
+  await context.close();
+  return bar;
+})();
+check(
+  servedBar === "lap 23 · streaming",
+  `a rendered view keeps its own host-built status line, not the polled word ("${servedBar}")`,
+);
 
 await browser.close();
 server.close();

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -3820,6 +3820,64 @@ check(
 
 await paceCtx.close();
 
+// --- The EMPTY window, and the two states behind it (#1004) ------------------
+//
+// The producer takes about 11 s to reach its first tick because it unpickles a
+// 382 MB session, and the socket is accepted at about 8 s of that. So a blank
+// window is two different situations, measured on the real path, and the copy
+// used to be one sentence across both: "Start a replay with --strategy", which
+// is an instruction to do the thing that has already been running for 3 s.
+//
+// Asserted as an EFFECT and as a DIFFERENCE. Reading one string would pass on a
+// build that hardcoded it; requiring the two to differ cannot.
+async function waitingCopy(connection) {
+  const context = await browser.newContext({ viewport: { width: 1500, height: 950 } });
+  const emptyPage = await context.newPage();
+  emptyPage.on("pageerror", (error) =>
+    failures.push(`pageerror(waiting/${connection}): ${error.message}`),
+  );
+  await emptyPage.addInitScript((state) => {
+    window.pywebview = {
+      api: {
+        get_tick: async () => null,
+        get_bulk: async () => null,
+        get_live_lap: async () => null,
+        get_connection: async () => state,
+      },
+    };
+  }, connection);
+  await emptyPage.goto(url, { waitUntil: "domcontentloaded" });
+  await emptyPage.waitForSelector(".data-waiting", { timeout: 5000 });
+  // 1.2 s: `useConnection` polls at 1 Hz and its first read is behind
+  // `whenBridgeReady`, so a shorter wait measures the null-connection frame,
+  // which is the "Connecting..." copy whichever state was stubbed - a guard that
+  // would pass on both branches while seeing only one.
+  await emptyPage.waitForTimeout(1200);
+  const body = (await emptyPage.locator(".data-waiting").textContent()) ?? "";
+  const bar = (await emptyPage.locator(".status-bar").textContent()) ?? "";
+  await context.close();
+  return { body, bar };
+}
+
+const waitingUp = await waitingCopy("Connected");
+const waitingDown = await waitingCopy("Connecting...");
+check(
+  waitingUp.body !== waitingDown.body,
+  `an empty window says something DIFFERENT once the socket is up (up: "${waitingUp.body}", down: "${waitingDown.body}")`,
+);
+check(
+  waitingDown.body.includes("--strategy"),
+  "with no producer the window still says how to start one",
+);
+check(
+  !waitingUp.body.includes("--strategy"),
+  `with the socket up it stops telling you to start a replay ("${waitingUp.body}")`,
+);
+check(
+  waitingUp.bar !== waitingDown.bar && waitingUp.bar.includes("Connected"),
+  `the status bar tracks the same two states (up: "${waitingUp.bar}", down: "${waitingDown.bar}")`,
+);
+
 await browser.close();
 server.close();
 

--- a/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
@@ -23,7 +23,9 @@
  * lasts milliseconds and is not a state anybody sees.
  */
 
+import { useConnection } from "../../lib/useConnection";
 import { useStatusText } from "../../lib/useStatusText";
+import { waitingStatus } from "../../lib/waitingCopy";
 
 import { AgentCard } from "./AgentCard";
 import { OrchestratorCard } from "./OrchestratorCard";
@@ -149,12 +151,30 @@ const IDLE_VIEW: AgentsView = {
     },
   },
   history: { pace: [], tire: [] },
+  // Replaced by `waitingStatus(connection)` while `view` is null: the idle
+  // view cannot know whether the socket is up, and this window has no other
+  // channel that does before the first tick arrives (#1004).
   status_bar: { text: "Waiting for arcade stream…", transient: false },
 };
 
 export function AgentsWindow() {
   const { view } = useAgentsView();
   const shown = view ?? IDLE_VIEW;
+  /**
+   * Polled separately, and ONLY while there is no view (#1004).
+   *
+   * `get_agents_view` returns None until a tick has arrived, so this window has
+   * no connection word at all for the whole startup - measured on the real path,
+   * None on all 169 samples across 11 s, including the last 3 s during which the
+   * socket was up and the arcade was loading its session. The DATA window has
+   * polled `get_connection` since #982; this one had nothing to poll it for until
+   * the wait itself became the thing worth describing.
+   *
+   * Once a view exists the view's own label wins: it is host-built and travels
+   * WITH the payload (#950), so it cannot disagree with the lap beside it, which
+   * a separately-polled word could.
+   */
+  const connection = useConnection();
 
   /**
    * The producer is gone, and every card is holding a call from before.
@@ -174,7 +194,9 @@ export function AgentsWindow() {
   const statusText = useStatusText(
     frozen
       ? { text: `DATA FROZEN · last tick ${shown.header.lap}`, transient: false }
-      : shown.status_bar,
+      : view === null
+        ? { text: waitingStatus(connection), transient: false }
+        : shown.status_bar,
     shown.seq,
   );
 

--- a/src/pitwall/ui/src/features/data/DataWindow.tsx
+++ b/src/pitwall/ui/src/features/data/DataWindow.tsx
@@ -36,8 +36,7 @@ import { useConnection } from "../../lib/useConnection";
 import { useLiveLap } from "../../lib/useLiveLap";
 import { useStatusText } from "../../lib/useStatusText";
 import { useTick } from "../../lib/useTick";
-
-const WAITING = { text: "Waiting for arcade stream…", transient: false } as const;
+import { waitingBody, waitingStatus } from "../../lib/waitingCopy";
 
 /**
  * The right column's tabs, in the order a strategist reaches for them.
@@ -77,7 +76,7 @@ export function DataWindow() {
   // it is why the only remaining signal used to be an EMPTY bar. It also has to
   // stop saying `live`, or the window contradicts its own banner one line down.
   const status = !tick
-    ? WAITING
+    ? { text: waitingStatus(connection), transient: false }
     : frozen
       ? { text: `DATA FROZEN · last tick lap ${tick.arcade.lap}`, transient: false }
       : { text: `lap ${tick.arcade.lap} · live`, transient: true };
@@ -138,9 +137,7 @@ export function DataWindow() {
             </div>
           </div>
         ) : (
-          <p className="data-waiting">
-            Waiting for the arcade broadcast. Start a replay with <code>--strategy</code>.
-          </p>
+          <p className="data-waiting">{waitingBody(connection)}</p>
         )}
       </div>
       <footer className="status-bar">{statusText}</footer>

--- a/src/pitwall/ui/src/lib/waitingCopy.ts
+++ b/src/pitwall/ui/src/lib/waitingCopy.ts
@@ -1,0 +1,47 @@
+/**
+ * What an empty window says, and it depends on whether the socket is up (#1004).
+ *
+ * Both windows paint in about 1.7 s and the arcade's first tick lands at about
+ * 11 s, because the producer spends that long unpickling a 382 MB session. The
+ * socket itself is accepted at about 8 s. So there are two different states
+ * behind one blank window, measured on the real path:
+ *
+ *   0.4 -> 8.0 s   no producer at all. `get_connection()` says "Connecting...".
+ *   8.0 -> 11.0 s  the arcade is there and loading. It says "Connected".
+ *
+ * The window used to print one sentence across both, and that sentence told the
+ * reader to start a replay - an instruction that is right for the first three
+ * seconds of the wait and wrong for the last three, when the thing it asks for
+ * has been running since 8 s. Nine seconds of a window that looks hung is the
+ * complaint; being told to fix it by doing what you already did is what turns a
+ * slow start into a broken one.
+ *
+ * One module rather than a string in each window, because there are three copy
+ * sites across the two of them and this repo's most expensive recurring defect
+ * is the copy that got the fix and the twin that did not.
+ */
+
+/** True once the socket has been accepted, whatever the tick channel is doing. */
+export function isSocketUp(connection: string | null): boolean {
+  return connection === "Connected";
+}
+
+/**
+ * The line under an empty window.
+ *
+ * Actionable only when there is something to act on. Once the socket is up the
+ * honest answer is that there is nothing to do, so the sentence says what is
+ * happening instead of what to type.
+ */
+export function waitingBody(connection: string | null): string {
+  return isSocketUp(connection)
+    ? "Connected to the arcade. It is loading the session; the first tick follows."
+    : "Waiting for the arcade broadcast. Start a replay with --strategy.";
+}
+
+/** The status bar's version of the same two states, short enough for one line. */
+export function waitingStatus(connection: string | null): string {
+  return isSocketUp(connection)
+    ? "Connected · the arcade is loading its session"
+    : "Waiting for arcade stream…";
+}


### PR DESCRIPTION
## What

An empty PITWALL window now says something different depending on whether the arcade's socket is
up. It used to print one sentence across both states, and that sentence told the reader to start
a replay.

Closes #1004.

## Why

Measured on the real path, cold order (windows first, producer second, reproduced twice):

| moment | seconds from process start |
|---|---|
| host import + `start()` | 0.42 |
| socket accepted | 8.03 |
| first tick on the wire | 10.96 |
| first `get_bulk` returned | 11.12 |

The producer spends that time unpickling a 382 MB session. So a blank window covers two
situations, and the copy described only the first: from 8.03 s the arcade is there and loading,
while the DATA window still read "Waiting for the arcade broadcast. Start a replay with
`--strategy`". Being told to fix a slow start by doing the thing you already did is what turns it
into a broken one.

AGENTS was worse. `get_agents_view` returns None until a tick arrives, so that window has no
connection word at all during the whole startup: null on all 169 samples across 11 s, including
the last 3 s with the socket up. DATA has polled `get_connection` since #982; AGENTS had nothing
to poll it for.

## How

`src/pitwall/ui/src/lib/waitingCopy.ts` holds both strings and the socket test. One module rather
than a literal per window, because there are three copy sites across the two of them.

- `DataWindow.tsx` passes its existing `connection` to `waitingBody` and `waitingStatus`.
- `AgentsWindow.tsx` gains `useConnection`, used only while `view === null`. Once a view exists
  the view's own status line wins: it is host-built and travels with the payload, so it cannot
  disagree with the lap beside it.

The AGENTS smoke's main stub gained `get_connection`. Without it `getConnection` falls back to
`fetch("/api/connection")`, the static server answers 404, and the failure reads as three console
errors with no clue which call made them.

## What this does not do

- **The AGENTS header chip still says "Connecting..." during those 3 s.** Its colour comes from
  `CONNECTION_COLOURS` in `src/pitwall/agents_view/panels.py`, host-side, and the idle view already
  carries a hardcoded copy of one of those hex values. Making the chip track a polled word means
  either forking that map into TypeScript or adding a channel for it, and this repo's most
  expensive recurring defect is a forked constant. Left for the AGENTS layout elevation, which
  rebuilds that header anyway.
- **Warming the radio corpus is not done, because the cost it was filed against is not there.**
  The issue put the first `get_bulk` at 2.1 s with about 1.1 s of lazy radio parquet reading.
  Measured: the first `get_bulk` costs **162 ms** on the real path from a cold process. Cold-process
  `SessionLaps.load` is 140 ms and `RadioCorpus.load` is 37 ms; the whole read is under 1 MB on
  disk, and `RadioPipelineRunner` is a top-level import in `radio_feed.py`, so its module cost is
  paid at host-import time rather than on the first request. Moving 162 ms off a path the user
  reaches at 10.96 s is not worth the code.
- **The 382 MB unpickle is the arcade's.** It is the same pickle #1002 is about and it is the nine
  seconds that actually matter. Attacking `SessionLoader`'s storage format needs its own issue.

## Checks

- `npm run typecheck` clean, `npm run build` clean.
- `node scripts/smoke-data.mjs` 229 checks (was 225), `node scripts/smoke-agents.mjs` 22 (was 19).
- The four new DATA checks were RED against the bundle built from the previous source, which is
  what `dist/` still held when they first ran: both states rendered "Start a replay with
  `--strategy`" and both status bars read the same string.
- Each guard asserts a DIFFERENCE between the two stubbed states rather than one string, so a
  build that hardcoded either sentence fails it. The 1,200 ms wait is deliberate:
  `useConnection` polls at 1 Hz behind `whenBridgeReady`, and a shorter wait reads the
  null-connection frame, which renders the same copy for both stubs.
- **Driven on the real path**, the real host serving the real built bundle over its own loopback
  server, with a socket that accepts and stays silent so the loading phase can be observed rather
  than raced against:

  ```
  t=0.3s  body = "Waiting for the arcade broadcast. Start a replay with --strategy."
          bar  = "Waiting for arcade stream…"
  t=1.5s  body = "Connected to the arcade. It is loading the session; the first tick follows."
          bar  = "Connected · the arcade is loading its session"
  ```

  Held open deliberately because a warm page cache collapses the window: on one run against the
  real producer the window went straight from the first state to the board at 8.7 s, with the
  socket-accepted phase never rendering. Cold, it is the ~3 s between 8.03 s and 10.96 s.
