### PR TITLE
fix(arcade): the discrete telemetry channels stop being interpolated

### DIFF
--- a/src/arcade/config.py
+++ b/src/arcade/config.py
@@ -166,7 +166,14 @@ ARCADE_CACHE_DIR: Final[Path] = get_data_root() / "cache" / "arcade"
 # `RelativeDistance` extraction in the worker intermediate, which nothing
 # had consumed since v10 and which left the cached bytes identical. A
 # maintainer trusting the old sentence would have deleted its readers.)
-CACHE_VERSION: Final[str] = "v12"  # + official classification (SessionData.official_status)
+# **The obvious guard cannot enforce this, and one tried.** `CACHE_VERSION != "v12"` is true
+# forever from the commit that writes it and can never see the NEXT change that forgets to
+# bump. A golden test keyed to the version COULD catch part of it (pin a small rebuilt
+# session's frames against a fixture and require the version to move when they do), and is
+# not written because rebuilding a session costs 254 s. Until it is, the obligation lives
+# here: if the bytes a rebuild would produce differ from the bytes on disk, this string moves
+# in the SAME commit, or the fix reaches nobody who already has a pickle.
+CACHE_VERSION: Final[str] = "v13"  # + the discrete channels stop being interpolated (#1002)
 
 # --- Multiprocessing pool -------------------------------------------------
 # Serial by default — Windows spawn + pickling a loaded session across 8

--- a/src/arcade/data.py
+++ b/src/arcade/data.py
@@ -243,6 +243,84 @@ def _hex_to_rgb(h: str) -> tuple[int, int, int]:
     return int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)
 
 
+def _nearest_sample(t: np.ndarray, timeline: np.ndarray) -> np.ndarray:
+    """For each timeline instant, the index of the closest raw sample (#1002).
+
+    The resampler used to run `np.interp` over channels whose values are LABELS,
+    which manufactures labels nobody measured. Melbourne 2025, 2,491,006 served
+    frames: **1,775 DRS frames** carried 4, 5, 6, 7, 9, 11 or 13, codes the raw
+    stream never contains and `DRS_OPEN_CODES` reads as closed, so an open wing
+    drew as a flicker; and **86,925 brake frames (3.49 %)** sat strictly between
+    2 and 98 on a channel whose raw form is BOOLEAN. Both go to zero here.
+
+    `fastf1.core.Telemetry._CHANNELS` marks `DRS`, `nGear` and `Brake` as
+    `{'type': 'discrete'}` and fills them rather than interpolating. This is that
+    distinction, which the arcade had inverted for `brake`.
+
+    Ties go to the EARLIER sample, which matters because the raw stream carries
+    907 duplicate-`t` pairs on this race: `<=` makes the pick deterministic
+    instead of dependent on floating-point noise.
+
+    Leans on `len(t) >= 2`, which `_process_driver_data` guarantees - it skips
+    any lap with fewer than two samples and returns None when a driver has no
+    laps at all, so the shortest array reaching here is 862 samples long.
+    """
+    right = np.searchsorted(t, timeline).clip(1, len(t) - 1)
+    closer_to_left = timeline - t[right - 1] <= t[right] - timeline
+    return np.where(closer_to_left, right - 1, right)
+
+
+# The eight forward gears plus neutral. 0 is a REAL reading - 1,400 raw samples
+# on Melbourne 2025, and the PITWALL GEAR lane's [0, 9] range renders it - so the
+# validity test is one-sided.
+_MAX_GEAR = 8
+
+
+def _drop_impossible_gears(gears: np.ndarray) -> np.ndarray:
+    """Replace a gear no car has with the last one it really was in (#1002).
+
+    The F1 live-timing feed publishes `nGear` values that do not exist. Read from
+    `session.car_data` for Melbourne 2025, before any resampling this repo does:
+    **151 samples at 128**, plus one or two each of almost every value between 10
+    and 127. FastF1's own two resampling stages carry that to 310 and then 570,
+    and the arcade's carried it to 967 frames at 128. PITWALL's GEAR lane is
+    locked to [0, 9], so each one is a full-height spike.
+
+    Nearest-neighbour resampling does NOT fix this: measured, it moves the count
+    from 1,840 frames above 8 to 1,836. The sentinel is upstream of the
+    interpolation, so it has to be rejected as data rather than smoothed.
+
+    The repair is FastF1's own discrete-channel fill idiom (`.ffill()` then
+    `.bfill()`) applied to a validity check FastF1 does not itself perform: it
+    fills gaps in the merge, it does not judge whether a published gear is
+    possible. The `bfill` tail is for a driver whose FIRST sample is invalid,
+    where there is nothing behind to carry forward.
+
+    A dropout longer than a blink therefore renders as a frozen gear rather than
+    a spike. PIA's lap 44 is the worst case on this race and freezes at gear 8
+    for about 75 s at 0 km/h. That is a visible artefact and the intended one:
+    the alternative is a gear the car cannot select.
+    """
+    impossible = gears > _MAX_GEAR
+    if not impossible.any():
+        return gears
+    if impossible.all():
+        # Nothing to carry from in either direction, so the fill would return a
+        # column of NaN and `int(...)` on the frame would raise. Unreachable on
+        # real telemetry, where the sentinel is a handful of samples in tens of
+        # thousands, and handled rather than left because the alternative failure
+        # is the whole session load, not one frame.
+        logger.warning("Every nGear sample is out of range; leaving the channel as published")
+        return gears
+    # The fill also closes any pre-existing NaN in the channel, because `ffill` does not
+    # distinguish the ones this mask made from the ones it found. That is inconsistent
+    # with the no-invalid-samples path above, which returns such an array untouched for
+    # `int()` to raise on. Left as it is: no raw channel on any race measured carries a
+    # NaN, and the raising half is what the interpolating resampler did too.
+    repaired = pd.Series(gears).mask(impossible)
+    return repaired.ffill().bfill().to_numpy()
+
+
 def _process_driver_data(args: tuple) -> dict | None:
     """Module-level worker: iterate a driver's laps and flatten telemetry.
 
@@ -333,6 +411,10 @@ def _process_driver_data(args: tuple) -> dict | None:
     order = np.argsort(concat["t"])
     for k in concat:
         concat[k] = concat[k][order]
+    # After the sort, because the fill carries a gear FORWARD in time and the
+    # per-lap arrays are concatenated in lap order but the samples inside them
+    # are only sorted here.
+    concat["gear"] = _drop_impossible_gears(concat["gear"])
 
     return {
         "code": driver_code,
@@ -512,17 +594,22 @@ class SessionLoader:
         pedal_multipliers: dict[str, float],
         circuit_length_m: float,
     ) -> list[FrameData]:
-        cont = {
-            k: np.interp(timeline, t, data[k])
-            for k in ("x", "y", "speed", "throttle", "brake", "dist", "tyre_life")
-        }
-        disc = {k: np.interp(timeline, t, data[k]) for k in ("gear", "drs", "lap", "tyre")}
-        for name, multiplier in pedal_multipliers.items():
-            cont[name] = np.clip(cont[name] * multiplier, 0.0, 100.0)
+        cont = {k: np.interp(timeline, t, data[k]) for k in ("x", "y", "speed", "throttle", "dist")}
+        nearest = _nearest_sample(t, timeline)
+        disc = {k: data[k][nearest] for k in ("gear", "drs", "lap", "tyre", "brake", "tyre_life")}
+        # The two pedals are scaled the same way and no longer live in the same dict, so
+        # they are applied one by one rather than by iterating `pedal_multipliers`. The
+        # shape being avoided is not the loop, which would raise `KeyError: 'brake'` and
+        # be loud: it is brake ADDED to the discrete set and left in `cont` as well, where
+        # the loop would keep scaling a copy nothing reads while the wire served the
+        # unscaled one. Naming each pedal beside the dict it lives in makes that
+        # impossible to write.
+        cont["throttle"] = np.clip(cont["throttle"] * pedal_multipliers["throttle"], 0.0, 100.0)
+        disc["brake"] = np.clip(disc["brake"] * pedal_multipliers["brake"], 0.0, 100.0)
         # Race distance cannot decrease; the per-lap accumulator leaves float
         # seams at lap boundaries (measured worst 0.11 m on Melbourne 2025).
         cont["dist"] = np.maximum.accumulate(cont["dist"])
-        lap_numbers = np.maximum(1, np.rint(disc["lap"]).astype(int))
+        lap_numbers = np.maximum(1, disc["lap"].astype(int))
         rel_dist = _lap_fraction_from_distance(cont["dist"], lap_numbers, circuit_length_m)
         frames: list[FrameData] = []
         for i, ti in enumerate(timeline):
@@ -533,15 +620,15 @@ class SessionLoader:
                     x=float(cont["x"][i]),
                     y=float(cont["y"][i]),
                     speed=float(cont["speed"][i]),
-                    gear=int(round(disc["gear"][i])),
-                    drs=int(round(disc["drs"][i])),
+                    gear=int(disc["gear"][i]),
+                    drs=int(disc["drs"][i]),
                     throttle=float(cont["throttle"][i]),
-                    brake=float(cont["brake"][i]),
+                    brake=float(disc["brake"][i]),
                     lap=int(lap_numbers[i]),
                     dist=float(cont["dist"][i]),
                     rel_dist=float(rel_dist[i]),
-                    tyre=int(round(disc["tyre"][i])),
-                    tyre_life=float(cont["tyre_life"][i]),
+                    tyre=int(disc["tyre"][i]),
+                    tyre_life=float(disc["tyre_life"][i]),
                     active=active,
                 )
             )

--- a/src/arcade/gaps.py
+++ b/src/arcade/gaps.py
@@ -79,9 +79,13 @@ That row is 7,017 distinct pairs. Three honest caveats on it:
    against an official 8.481 s.
 2. **The error budget is not "one frame".** Per crossing (n=921) the error
    is median 22 ms, p95 67 ms and worst 486 ms, and **9.8 % land more than
-   one 40 ms frame from the parquet time**, because the `lap` field is
-   `np.interp` plus `round` over a step function rather than a true line
-   detector.
+   one 40 ms frame from the parquet time**, because the `lap` field is a
+   resampled step function rather than a true line detector: the crossing
+   lands on whichever resampled frame first carries the new lap, never on
+   the moment the car crossed. #1002 moved that resampling from
+   `np.interp` plus `round` to nearest-neighbour, which for a one-step
+   change switches at the same instant (both pick the midpoint between the
+   two raw samples), so these numbers are unchanged.
 3. **The tail moved when the keying did.** Keying on the LAST frame of an
    increment measured p95 101 ms / p99 160 ms, and the first-frame keying
    this module ships improves the per-crossing error while making the pair

--- a/tests/infra/test_dep_imports.py
+++ b/tests/infra/test_dep_imports.py
@@ -73,10 +73,17 @@ def test_pandas_parquet_roundtrip():
 
 
 def test_scipy_signal_resample():
-    """scipy.signal.resample stays usable for arcade telemetry interp.
+    """scipy.signal.resample stays importable and keeps its signature.
 
-    SessionLoader resamples per-driver telemetry on this call path; a
-    signature change would silently corrupt arcade playback timing.
+    **It is NOT on any arcade call path.** The sentence that stood here said
+    "SessionLoader resamples per-driver telemetry on this call path", and there
+    is no scipy anywhere in `src/arcade`: the resampler is `np.interp` for the
+    continuous channels and a `searchsorted` nearest-neighbour pick for the
+    discrete ones (#1002). A guard whose docstring names a caller that does not
+    exist is how the next reader concludes the wrong module is covered.
+
+    Kept because scipy is a declared dependency and this is the environment
+    suite, whose job is that the declared stack imports and behaves.
     """
     pytest.importorskip("scipy")
     import numpy as np

--- a/tests/surfaces/test_arcade_telemetry_span.py
+++ b/tests/surfaces/test_arcade_telemetry_span.py
@@ -416,3 +416,213 @@ def test_eligible_is_not_open_at_every_site_that_decodes_it():
     for code in DRS_OPEN_CODES:
         assert DriverInfoPanel._drs_label(code) == "ON", f"code {code} is documented as On"
         assert DriverInfoPanel._drs_color(code) == open_colour
+
+
+# --- #1002: the discrete channels stop being interpolated ----------------------
+
+
+def _melbourne_or_skip():
+    """The cached arcade session, or a skip. The pickle is not in git."""
+    from src.arcade.config import ARCADE_CACHE_DIR, CACHE_VERSION
+
+    cached = ARCADE_CACHE_DIR / "Melbourne_2025_race.pkl"
+    if not cached.exists():
+        pytest.skip("the Melbourne 2025 arcade pickle is not on this install")
+    import pickle
+
+    with cached.open("rb") as handle:
+        session = pickle.load(handle)
+    if session.version != CACHE_VERSION:
+        pytest.skip(f"the cached pickle is {session.version}, not {CACHE_VERSION}")
+    return session
+
+
+def _active_frames(session) -> list:
+    frames = [
+        frame for driver in session.frames_by_driver.values() for frame in driver if frame.active
+    ]
+    # The set is DISCOVERED, so its size is asserted before anything reads it: an
+    # empty list would make every assertion below vacuously true, which is the
+    # exact shape of the green-on-nothing guard this repo has already shipped once.
+    assert len(frames) > 1_000_000, f"only {len(frames)} active frames"
+    return frames
+
+
+def test_no_served_frame_carries_a_gear_the_car_cannot_select():
+    """The EFFECT of #1002, on the frames the arcade actually broadcasts.
+
+    Not "the resampler is nearest-neighbour" - that is the mechanism, and measured,
+    the mechanism alone changes this number by four. The F1 live-timing feed itself
+    publishes `nGear` of 128 (151 raw samples on this race) and every value between
+    10 and 127, and three resampling stages carried it to **967 served frames at
+    128 and 1,840 above gear 8**. PITWALL's GEAR lane is locked to [0, 9], so each
+    is a full-height spike.
+
+    Gear 0 is asserted PRESENT in the same breath. It is a real reading, and a
+    validity predicate written `g < 1 or g > 8` would erase 4,773 frames of a
+    stationary car while making the first assertion pass.
+    """
+    frames = _active_frames(_melbourne_or_skip())
+    gears = {frame.gear for frame in frames}
+    assert max(gears) <= 8, f"gears above 8 are served: {sorted(g for g in gears if g > 8)}"
+    assert min(gears) >= 0
+    neutral = sum(1 for frame in frames if frame.gear == 0)
+    assert neutral > 1000, f"only {neutral} neutral frames: is 0 being filtered as invalid?"
+
+
+def test_no_served_frame_carries_a_drs_code_the_feed_never_emits():
+    """The raw channel holds {0, 1, 2, 3, 8, 10, 12, 14}; the wire used to hold more.
+
+    Linear interpolation between two real codes manufactures the ones in between,
+    and 9, 11 and 13 are read as CLOSED by `DRS_OPEN_CODES` while sitting between
+    two open frames - so an open wing drew as a flicker. Measured before the fix:
+    **1,775 served frames** on 4, 5, 6, 7, 9, 11 or 13.
+    """
+    frames = _active_frames(_melbourne_or_skip())
+    served = {frame.drs for frame in frames}
+    manufactured = served - {0, 1, 2, 3, 8, 10, 12, 14}
+    assert not manufactured, f"codes FastF1 never emits are on the wire: {sorted(manufactured)}"
+    # The open codes must still be REACHED, or a channel stuck at 0 would pass.
+    assert served & DRS_OPEN_CODES, "no open-wing frame survives at all"
+
+
+def test_the_brake_channel_is_the_boolean_it_was_measured_as():
+    """`Brake` is `{'type': 'discrete'}` to FastF1 and False/True in the raw stream.
+
+    It lived in the resampler's CONTINUOUS set and was multiplied by 100, so
+    **86,925 served frames (3.49 %) sat strictly between 2 and 98** across 10,976
+    distinct values, none of which any car ever published.
+    """
+    frames = _active_frames(_melbourne_or_skip())
+    served = {round(frame.brake, 6) for frame in frames}
+    assert served <= {0.0, 100.0}, f"interpolated brake pressures are served: {sorted(served)[:8]}"
+    assert served == {0.0, 100.0}, "both states must occur, or the channel is stuck"
+
+
+def test_a_tyre_age_is_a_whole_number_of_laps():
+    """`tyre_life` is a per-lap count with a reset at every stop, not a ramp.
+
+    It was in the continuous set beside `brake`, so it interpolated ACROSS the reset:
+    758 served frames carried a fractional age and **25 sat more than half a lap from
+    either neighbouring value, the worst 16.4 laps out**. The TimingTower renders this
+    number, and a pit exit is exactly where it was wrong.
+    """
+    frames = _active_frames(_melbourne_or_skip())
+    fractional = [f.tyre_life for f in frames if abs(f.tyre_life - round(f.tyre_life)) > 1e-9]
+    assert not fractional, f"{len(fractional)} frames carry a fractional tyre age"
+
+
+# --- the same rules on a hand-built driver, so CI can see them ------------------
+#
+# Every guard above reads the cached 382 MB pickle, which no CI runner has, so all of
+# them SKIP there. Worse, on a machine that HAS a current pickle they pass against the
+# artefact rather than the code: reverting `_resample_driver` to `np.interp` leaves the
+# already-built v13 frames untouched and every one of them stays green. The tests below
+# run the resampler itself on four samples and are the ones that go red for that.
+
+
+def _one_driver_two_samples() -> dict:
+    """Two raw samples a second apart, chosen so linear interpolation is VISIBLE.
+
+    At the midpoint every discrete channel would take a value that is not in the raw
+    array: gear 5 between 2 and 8, DRS 6 between 0 and 12 (a code FastF1 never emits),
+    brake 0.5 on a boolean channel, tyre 2 (MEDIUM) between SOFT and HARD, and a tyre age
+    of 2.5 on a channel counted in whole laps.
+    """
+    import numpy as np
+
+    return {
+        "t": np.array([0.0, 1.0]),
+        "x": np.array([0.0, 100.0]),
+        "y": np.array([0.0, 50.0]),
+        "speed": np.array([100.0, 200.0]),
+        "throttle": np.array([0.0, 100.0]),
+        "brake": np.array([0.0, 1.0]),
+        "dist": np.array([0.0, 200.0]),
+        "tyre_life": np.array([4.0, 1.0]),
+        "gear": np.array([2.0, 8.0]),
+        "drs": np.array([0.0, 12.0]),
+        "lap": np.array([1.0, 2.0]),
+        "tyre": np.array([1.0, 3.0]),
+    }
+
+
+def _resampled_midpoint():
+    """The frame the resampler builds exactly half way between the two samples."""
+    import numpy as np
+
+    from src.arcade.data import SessionLoader
+
+    data = _one_driver_two_samples()
+    timeline = np.array([0.0, 0.5, 1.0])
+    frames = SessionLoader()._resample_driver(
+        data, data["t"], timeline, 1.0, {"throttle": 1.0, "brake": 100.0}, 5000.0
+    )
+    assert len(frames) == 3, "the fixture must produce the midpoint frame it is about"
+    return frames[1]
+
+
+def test_a_discrete_channel_only_ever_takes_a_value_the_car_published():
+    """The mechanism, on four samples, without the 382 MB artefact.
+
+    This is the guard that goes red on a revert to `np.interp`, which the pickle-backed
+    guards above cannot: they would still be reading frames built by the fixed code.
+    """
+    midpoint = _resampled_midpoint()
+    assert midpoint.gear == 2, "gear 5 is what linear interpolation invents here"
+    assert midpoint.drs == 0, "DRS 6 is a code FastF1 never emits"
+    assert midpoint.brake == 0.0, "brake is boolean; 50.0 is a pressure nobody published"
+    assert midpoint.tyre == 1, "tyre 2 is MEDIUM, invented between SOFT and HARD"
+    assert midpoint.tyre_life == 4.0, "an age is a whole number of laps"
+    assert midpoint.lap == 1, "the lap does not advance until the sample that carries it"
+
+
+def test_a_continuous_channel_still_interpolates():
+    """The other half, or the fix could be 'resample nothing' and pass.
+
+    Speed, throttle and position are genuinely continuous and must still take the value
+    between two samples: a stepped speed trace is the defect this change must not create.
+    """
+    midpoint = _resampled_midpoint()
+    assert midpoint.speed == 150.0
+    assert midpoint.throttle == 50.0
+    assert (midpoint.x, midpoint.y) == (50.0, 25.0)
+
+
+def test_the_nearest_sample_pick_is_correct_at_both_ends_and_on_a_tie():
+    """Exact hits, extrapolation past either end, and a deterministic tie.
+
+    The tie matters on real data: Melbourne 2025 carries 907 duplicate-`t` pairs, and a
+    pick that depended on floating-point noise would resample the same race differently
+    on two machines.
+    """
+    import numpy as np
+
+    from src.arcade.data import _nearest_sample
+
+    t = np.array([0.0, 1.0, 2.0])
+    picked = _nearest_sample(t, np.array([-5.0, 0.0, 0.4, 0.5, 0.6, 1.0, 2.0, 9.0]))
+    assert list(picked) == [0, 0, 0, 0, 1, 1, 2, 2]
+
+
+def test_an_impossible_gear_is_replaced_by_the_last_real_one():
+    """`> 8` only, a leading invalid filled backwards, and neutral left alone."""
+    import numpy as np
+
+    from src.arcade.data import _drop_impossible_gears
+
+    assert list(_drop_impossible_gears(np.array([3.0, 128.0, 128.0, 5.0]))) == [3.0, 3.0, 3.0, 5.0]
+    assert list(_drop_impossible_gears(np.array([128.0, 12.0, 3.0, 4.0]))) == [3.0, 3.0, 3.0, 4.0]
+    # Neutral is a real reading, so a two-sided predicate would erase these.
+    untouched = np.array([0.0, 0.0, 2.0, 8.0])
+    assert list(_drop_impossible_gears(untouched)) == [0.0, 0.0, 2.0, 8.0]
+
+
+def test_a_channel_that_is_entirely_impossible_is_left_as_published():
+    """There is nothing to fill from, and a NaN column would raise at frame build."""
+    import numpy as np
+
+    from src.arcade.data import _drop_impossible_gears
+
+    published = np.array([128.0, 128.0])
+    assert list(_drop_impossible_gears(published)) == [128.0, 128.0]

--- a/tests/surfaces/test_arcade_wire_contract.py
+++ b/tests/surfaces/test_arcade_wire_contract.py
@@ -69,7 +69,11 @@ def _frames(n: int) -> list[FrameData]:
             gear=7,
             drs=8,
             throttle=90.0,
-            brake=5.0,
+            # 100.0, not the 5.0 that stood here: since #1002 `brake` is resampled
+            # nearest-neighbour off a BOOLEAN raw channel, so the only values the
+            # producer can put on the wire are 0.0 and 100.0. A fixture outside that
+            # set describes a payload the arcade cannot build.
+            brake=100.0,
             lap=1 + i // 10,
             dist=float(i) * 10.0,
             rel_dist=(i % 10) / 10.0,


### PR DESCRIPTION
## What

The arcade's `disc` channels are resampled nearest-neighbour instead of linearly, `brake` and
`tyre_life` move into that set, `nGear` values no car can select are rejected at extraction, and
`CACHE_VERSION` goes to v13.

Closes #1002.

## Why

`SessionLoader._resample_driver` built a dict called `disc` and ran `np.interp` over it, so
channels whose values are labels got values nobody measured. `brake` and `tyre_life` were not even
in that dict; they sat in `cont`.

`fastf1.core.Telemetry._CHANNELS`, read from the installed FastF1 3.7.0, marks `DRS`, `nGear` and
`Brake` as `{'type': 'discrete'}` and fills them rather than interpolating. The arcade had that
distinction inverted for `brake`.

Measured on Melbourne 2025, 2,491,006 active frames, by rebuilding the pickle through the real
loader:

| channel | before | after |
|---|---|---|
| drs | 14 codes; 1,775 frames on 4, 5, 6, 7, 9, 11, 13 | 8 codes, exactly the raw set |
| brake | 86,925 frames (3.49%) strictly in (2, 98), 10,976 distinct values | 0 frames, 2 distinct |
| gear | 967 frames at 128, 1,840 above gear 8 | 0 above gear 8 |
| tyre_life | 758 fractional frames, 25 more than half a lap out, worst 16.41 | 0 fractional |
| tyre | {1: 236348, 2: 272269, 3: 1982389} | {1: 236350, 2: 272264, 3: 1982392} |

The DRS codes matter because 9, 11 and 13 are read as closed by `DRS_OPEN_CODES` while sitting
between two open frames, so an open wing drew as a flicker. The raw stream holds only
{0, 1, 2, 3, 8, 10, 12, 14}, so every one of those 1,775 frames was manufactured here. Raw `Brake`
is boolean ({False: 581877, True: 169995}) and gets multiplied by 100, so every fractional value
was a fabricated pressure. `tyre_life` is a per-lap count that resets at a stop, and the
TimingTower renders it, so a pit exit was exactly where it was wrong.

**The gear spike is not this repo's, and nearest-neighbour does not fix it.** `session.car_data`,
the rawest form FastF1 exposes, already holds 151 samples at nGear 128 plus one or two each of
almost every value between 10 and 127. FastF1's own two resampling stages carry that to 310 and
570; the arcade's carried it to 967. Measured, switching to nearest-neighbour moves the count above
gear 8 from 1,840 to 1,836. So the sentinel has to be rejected as data. PITWALL's GEAR lane is
locked to [0, 9], which is why each one is a full-height spike.

## How

- `_nearest_sample` is a `searchsorted` pick with ties going to the earlier sample, which matters
  because this race carries 907 duplicate-`t` pairs. No new dependency.
- `disc` becomes `("gear", "drs", "lap", "tyre", "brake", "tyre_life")`. The two pedals no longer
  share a dict, so the multiplier is applied to each by name rather than by iterating
  `pedal_multipliers`: a loop over that dict would now silently skip whichever pedal moved.
- `_drop_impossible_gears` masks `nGear > 8` and fills with FastF1's own discrete-channel idiom
  (ffill then bfill), applied to a validity check FastF1 does not itself perform. The predicate is
  one-sided: **gear 0 is real**, 1,400 raw samples and 4,773 served frames, and the PITWALL lane's
  range renders it.
- `int(round(...))` becomes `int(...)` on the four discrete fields, since a nearest-neighbour pick
  returns the raw sample rather than a value between two of them.
- `CACHE_VERSION` v12 to v13. Without it `SessionLoader.load` reuses any pickle whose version
  matches, so the 382 MB file already on disk keeps serving the interpolated frames and the fix
  reaches nobody.

Three claims elsewhere in the tree described the old mechanism and are corrected with it:
`gaps.py`'s error-budget note ("np.interp plus round"; its numbers are unchanged, because for a
one-step change both schemes switch at the midpoint between the two raw samples),
`tests/infra/test_dep_imports.py`'s docstring (it said SessionLoader resamples through
`scipy.signal.resample`; there is no scipy anywhere in `src/arcade`), and the wire-contract
fixture's `brake=5.0`, a value the fixed producer cannot emit.

## Known artefact, stated rather than discovered later

A telemetry dropout longer than a blink now renders as a frozen gear rather than a spike. PIA's
lap 44 is the worst case on this race and holds gear 8 for about 75 s at 0 km/h. That is the
intended trade: the alternative is a gear the car cannot select.

## Out of scope

- **The twin in the telemetry submodule.**
  `src/telemetry/backend/services/comparison_service.py:166,176` interpolates the same boolean
  `brake` channel onto its comparison grid. It is behind a git submodule boundary and needs its
  own issue in F1_Telemetry_Manager.
- **The 382 MB unpickle itself.** Rebuilding the pickle costs 254 s cold and loading it is the
  nine seconds #1004 measured. Changing `SessionLoader`'s storage format is a separate issue.

## Checks

- Pickle rebuilt through the real `SessionLoader` (254 s, version v13 on the object) and the
  served frames censused: the table above is that census, not a simulation.
- `tests/surfaces/` 234 passed plus 5 new, `uvx ruff check src/ tests/` clean.
- The four effect guards were driven RED by restoring `dev`'s resampler, rebuilding the pickle with
  it, and running them against the real v12 file, then the fix restored, the revert verified by
  re-reading the file, and the pickle rebuilt again.
- Each of those asserts the effect and also asserts the channel is not merely stuck: gear must still
  serve neutral frames, DRS must still reach an open code, brake must still show both states.
- **Those four all SKIP in CI, which has no data at all**, and on a machine with a current pickle
  they would pass against the artefact rather than the code: reverting `_resample_driver` to
  `np.interp` leaves the already-built v13 frames untouched and every one of them stays green.
  So five more guards run the resampler itself on a four-sample driver and need nothing on disk.
  Reverting `disc` to `np.interp` fails exactly one test, and its message is the whole defect:
  `gear=5, drs=6, brake=50.0, tyre=2, tyre_life=2.5` at a midpoint where the raw samples are
  2/8, 0/12, 0/1, SOFT/HARD and 4/1. Disabling the gear predicate fails the gear fixture.
- A test asserting `CACHE_VERSION != "v12"` was removed rather than kept: it is true forever from
  this commit and can never see the next unbumped change. The obligation is a comment on the
  constant instead.
- The whole suite: 935 passed, 9 pre-existing failures that reproduce with this change disabled.
