### PR TITLE
fix(pitwall): every harness measures the client area the window really has

### DIFF
--- a/src/pitwall/config.py
+++ b/src/pitwall/config.py
@@ -86,9 +86,17 @@ class WindowSpec:
         visible and AGENTS' still under the taskbar. So the origin is set
         here rather than left to the toolkit, and `y` is always 0.
 
-        The windows overlap. They always did, and on a 1707-wide desktop a
-        1500 and a 1320 cannot do anything else; the small `x` stagger exists
-        so both title bars stay grabbable.
+        The windows overlap. They always did, and on a 1707-wide desktop two
+        1500s cannot do anything else; the small `x` stagger exists so both
+        title bars stay grabbable.
+
+        **The origin is chosen before the width, and the window narrows to
+        what is left.** Clamping `x` against the window's own size instead
+        collapsed the stagger to zero the moment both windows hit the screen
+        width - on a 1366 laptop the top window landed exactly over the
+        bottom one's title bar. That was invisible while the two specs had
+        different widths, so the guard only sees it when run on more than one
+        screen.
 
         Pure, and takes the screen rather than reading it, so this module
         still imports on a machine with no system webview and so the rule can
@@ -96,18 +104,24 @@ class WindowSpec:
         layout decision and a big monitor is not a reason to override it.
         """
         usable_height = max(1, screen_height - _OS_CHROME_ALLOWANCE_PX)
-        width = min(self.width, screen_width)
         height = min(self.height, usable_height)
-        x = min(index * _WINDOW_STAGGER_PX, max(0, screen_width - width))
+        x = index * _WINDOW_STAGGER_PX
+        width = min(self.width, max(1, screen_width - x))
         return x, 0, width, height
 
 
-# DATA is the wider of the two: it holds a full timing tower plus traces.
-# AGENTS mirrors the Qt window it replaces (540 + 740 px columns, plus the
-# frame), so the layout ports across without being redesigned.
+# Both windows are the same size, so both hand their page the same client area
+# and the two harness families have one number to point at rather than two to
+# drift apart.
+#
+# AGENTS was 1320 x 900 until sprint 10, and the number had an argument behind
+# it: it mirrored the Qt strategy window's 540 + 740 px columns plus the frame.
+# The layout elevation deletes that split, so the argument went with it, and
+# what was left was a decision band budgeted 180 px wider than the window it
+# renders in.
 WINDOWS: Final[tuple[WindowSpec, ...]] = (
     WindowSpec("data", "PITWALL · DATA", "data.html", 1500, 950),
-    WindowSpec("agents", "PITWALL · AGENTS", "agents.html", 1320, 900),
+    WindowSpec("agents", "PITWALL · AGENTS", "agents.html", 1500, 950),
 )
 
 

--- a/src/pitwall/ui/scripts/shot-agents.mjs
+++ b/src/pitwall/ui/scripts/shot-agents.mjs
@@ -78,7 +78,16 @@ function serveDist(root) {
 }
 
 const UI_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const [viewPath, out, width = "1320", height = "900"] = process.argv.slice(2);
+
+// The client area the product really hands this page, NOT the `WindowSpec`
+// size. `place()` opens AGENTS at 1500x870 on the reference desktop and the OS
+// keeps 14 px of frame and 37 px of title bar, so the page gets 1486x833.
+// Shooting the outer size instead means every capture is 67 px taller than the
+// window, which is where a vertical overflow would show.
+const CLIENT = { width: 1486, height: 833 };
+
+const [viewPath, out, width = String(CLIENT.width), height = String(CLIENT.height)] =
+  process.argv.slice(2);
 
 if (!viewPath || !out) {
   console.error("usage: node scripts/shot-agents.mjs <view.json> <out.png> [w] [h]");

--- a/src/pitwall/ui/scripts/shot-data.mjs
+++ b/src/pitwall/ui/scripts/shot-data.mjs
@@ -34,8 +34,15 @@ import { serveDist } from "./serve-dist.mjs";
 const UI_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const TICKS = JSON.parse(readFileSync(process.argv[2], "utf-8"));
 const OUT = resolve(process.argv[3] ?? resolve(UI_DIR, "data.png"));
-const WIDTH = Number(process.argv[4] ?? 1500);
-const HEIGHT = Number(process.argv[5] ?? 950);
+// The client area the product really hands this page, NOT the `WindowSpec`
+// size. `place()` opens DATA at 1500x870 on the reference desktop and the OS
+// keeps 14 px of frame and 37 px of title bar, so the page gets 1486x833. The
+// defaults were the outer size, so every capture was 117 px taller and 14 px
+// wider than the window it claimed to show. `smoke-data.mjs` was already close
+// to the real client, which is how the two disagreed.
+const CLIENT = { width: 1486, height: 833 };
+const WIDTH = Number(process.argv[4] ?? CLIENT.width);
+const HEIGHT = Number(process.argv[5] ?? CLIENT.height);
 
 const ticks = Array.isArray(TICKS) ? TICKS : [TICKS];
 const server = await serveDist(resolve(UI_DIR, "dist"));

--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -28,6 +28,14 @@ const UI_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 // deliberately broken copy without touching the real one.
 const DIST = resolve(process.argv[2] ?? resolve(UI_DIR, "dist"));
 
+// The client area the product really hands this page, NOT the `WindowSpec`
+// size. `place()` opens AGENTS at 1500x870 on the reference desktop and the
+// OS keeps 14 px of frame and 37 px of title bar, so the page gets 1486x833.
+// Measuring the outer size instead hid 67 px of vertical overflow from every
+// assertion in this file; `tests/surfaces/test_pitwall_host.py` now refuses a
+// harness viewport larger than the real client.
+const CLIENT = { width: 1486, height: 833 };
+
 /**
  * Enough of a view to render every panel.
  *
@@ -193,7 +201,7 @@ const check = (ok, what) => {
 
 const server = await serveDist(DIST);
 const browser = await chromium.launch();
-const ctx = await browser.newContext({ viewport: { width: 1320, height: 900 } });
+const ctx = await browser.newContext({ viewport: CLIENT });
 const page = await ctx.newPage();
 page.on("pageerror", (error) => failures.push(`pageerror: ${error.message}`));
 page.on("console", (message) => {
@@ -350,7 +358,7 @@ await ctx.close();
 // re-armed once per LAP, and the bar sat blank for the other eighty
 // seconds of it. The settled stub above cannot see that: it is the dead
 // producer, the case that already worked.
-const live = await browser.newContext({ viewport: { width: 1320, height: 900 } });
+const live = await browser.newContext({ viewport: CLIENT });
 const livePage = await live.newPage();
 await livePage.addInitScript((view) => {
   let seq = 0;
@@ -413,7 +421,7 @@ await live.close();
 // states must be TELLABLE APART from the rendered bar. Reading one of them would
 // pass on a build that hardcoded the string.
 async function idleStatusBar(connection) {
-  const context = await browser.newContext({ viewport: { width: 1320, height: 900 } });
+  const context = await browser.newContext({ viewport: CLIENT });
   const idlePage = await context.newPage();
   idlePage.on("pageerror", (error) =>
     failures.push(`pageerror(idle/${connection}): ${error.message}`),
@@ -456,7 +464,7 @@ check(
 // with a DISAGREEING connection, or a bar that ignored the poll entirely would
 // pass this too.
 const servedBar = await (async () => {
-  const context = await browser.newContext({ viewport: { width: 1320, height: 900 } });
+  const context = await browser.newContext({ viewport: CLIENT });
   const viewPage = await context.newPage();
   await viewPage.addInitScript(
     ([view, state]) => {

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -164,6 +164,14 @@ const EXTENTS = (index) => `
   })()
 `;
 
+// The client area the product really hands this page, NOT the `WindowSpec`
+// size. `place()` opens DATA at 1500x870 on the reference desktop and the OS
+// keeps 14 px of frame and 37 px of title bar, so the page gets 1486x833.
+// Most scenarios below already used the real client; scenario A used the outer
+// size and was therefore measuring a surface 117 px taller than the window.
+// `tests/surfaces/test_pitwall_host.py` now refuses a viewport larger than it.
+const CLIENT = { width: 1486, height: 833 };
+
 const server = await serveDist(DIST);
 const browser = await chromium.launch();
 const url = `http://127.0.0.1:${server.address().port}/data.html`;
@@ -171,7 +179,7 @@ const url = `http://127.0.0.1:${server.address().port}/data.html`;
 // --- Scenario A: two drivers, a real span -----------------------------------
 
 const ctx = await browser.newContext({
-  viewport: { width: 1500, height: 950 },
+  viewport: CLIENT,
 });
 const page = await ctx.newPage();
 page.on("pageerror", (error) => failures.push(`pageerror: ${error.message}`));
@@ -658,7 +666,7 @@ await ctx.close();
 // --- Scenario B: single driver, and a car the telemetry never placed --------
 
 const solo = await browser.newContext({
-  viewport: { width: 1500, height: 950 },
+  viewport: CLIENT,
 });
 const soloPage = await solo.newPage();
 soloPage.on("pageerror", (error) =>
@@ -753,7 +761,7 @@ const FIELD = {
 };
 
 const ring = await browser.newContext({
-  viewport: { width: 1500, height: 950 },
+  viewport: CLIENT,
 });
 const ringPage = await ring.newPage();
 ringPage.on("pageerror", (error) =>
@@ -944,7 +952,7 @@ await ring.close();
 // deleting that line would have been invisible. Its twin in the AGENTS charts
 // shipped the same defect a sprint later and Víctor is the one who saw it.
 const stillCtx = await browser.newContext({
-  viewport: { width: 1500, height: 950 },
+  viewport: CLIENT,
 });
 const stillPage = await stillCtx.newPage();
 await stillPage.addInitScript((payload) => {
@@ -990,7 +998,7 @@ const RETIRED = {
 
 async function provisionalChips(field) {
   const context = await browser.newContext({
-    viewport: { width: 1500, height: 950 },
+    viewport: CLIENT,
   });
   const scenarioPage = await context.newPage();
   scenarioPage.on("pageerror", (error) =>
@@ -1221,7 +1229,7 @@ function towerLive() {
 }
 
 const towerCtx = await browser.newContext({
-  viewport: { width: 1485, height: 833 },
+  viewport: CLIENT,
 });
 const towerPage = await towerCtx.newPage();
 towerPage.on("pageerror", (error) =>
@@ -1574,7 +1582,7 @@ const RADIO_EVENTS = [
 
 async function radioPage(radio) {
   const context = await browser.newContext({
-    viewport: { width: 1485, height: 833 },
+    viewport: CLIENT,
   });
   const rPage = await context.newPage();
   rPage.on("pageerror", (error) =>
@@ -2287,7 +2295,7 @@ function paceField() {
 }
 
 const paceCtx = await browser.newContext({
-  viewport: { width: 1485, height: 833 },
+  viewport: CLIENT,
 });
 const pacePage = await paceCtx.newPage();
 pacePage.on("pageerror", (error) =>
@@ -2806,7 +2814,7 @@ check(
 // guard above had to learn the hard way.
 {
   const partialCtx = await browser.newContext({
-    viewport: { width: 1485, height: 833 },
+    viewport: CLIENT,
   });
   const partial = await partialCtx.newPage();
   partial.on("pageerror", (error) =>
@@ -3182,7 +3190,7 @@ for (const [width, height] of [
   [1265, 650],
   [1350, 660],
   [1350, 673],
-  [1485, 833],
+  [CLIENT.width, CLIENT.height],
 ]) {
   const ctx = await browser.newContext({ viewport: { width, height } });
   const page = await ctx.newPage();
@@ -3522,7 +3530,7 @@ if (bands === null) {
 // a window that never had data cannot demonstrate a window whose data went stale.
 {
   const deadCtx = await browser.newContext({
-    viewport: { width: 1485, height: 833 },
+    viewport: CLIENT,
   });
   const dead = await deadCtx.newPage();
   dead.on("pageerror", (error) =>
@@ -3831,7 +3839,7 @@ await paceCtx.close();
 // Asserted as an EFFECT and as a DIFFERENCE. Reading one string would pass on a
 // build that hardcoded it; requiring the two to differ cannot.
 async function waitingCopy(connection) {
-  const context = await browser.newContext({ viewport: { width: 1500, height: 950 } });
+  const context = await browser.newContext({ viewport: CLIENT });
   const emptyPage = await context.newPage();
   emptyPage.on("pageerror", (error) =>
     failures.push(`pageerror(waiting/${connection}): ${error.message}`),

--- a/tests/surfaces/test_pitwall_host.py
+++ b/tests/surfaces/test_pitwall_host.py
@@ -11,9 +11,11 @@ so a machine with no system webview still runs the suite.
 from __future__ import annotations
 
 import json
+import re
 import socket
 import threading
 import time
+from pathlib import Path
 
 import pytest
 
@@ -323,13 +325,107 @@ def test_every_shipped_window_fits_a_small_laptop():
         )
 
 
-def test_the_second_window_is_still_grabbable():
+@pytest.mark.parametrize("screen", [(1707, 960), (1366, 768), (3840, 2160)])
+def test_the_second_window_is_still_grabbable(screen):
     """The two windows overlap - they must, at these sizes - so the one
-    underneath needs its title bar reachable. A zero stagger would bury it."""
+    underneath needs its title bar reachable. A zero stagger would bury it.
+
+    Run over three screens rather than one. Pinned to 1707x960 alone this was
+    green through the whole life of the defect it names: on a 1366 laptop both
+    windows are clamped to the screen width, and an `x` that clamps against
+    the FULL window width collapses the stagger to zero, putting the top
+    window exactly over the bottom one's title bar. `place` narrows the
+    staggered window instead.
+    """
     from src.pitwall.config import WINDOWS
 
-    origins = [spec.place(index, 1707, 960)[0] for index, spec in enumerate(WINDOWS)]
-    assert len(set(origins)) == len(origins), f"two windows share an origin: {origins}"
+    origins = [spec.place(index, *screen)[0] for index, spec in enumerate(WINDOWS)]
+    assert len(set(origins)) == len(origins), (
+        f"two windows share an origin on {screen[0]}x{screen[1]}: {origins}"
+    )
+
+
+# The desktop every placement number in this section is measured on: a 2560x1440
+# panel at 150 %, which is 1707x960 logical.
+_REFERENCE_SCREEN = (1707, 960)
+
+# What the OS keeps for itself BETWEEN a placed window and the page inside it,
+# as opposed to `_OS_CHROME_ALLOWANCE_PX`, which is what it keeps around the
+# window. The 37 is the title bar `config.py` already names; the 14 is the
+# frame either side.
+#
+# **Measured, not remembered.** Both windows were opened on the reference
+# desktop and asked with `evaluate_js`: `innerWidth`, `documentElement
+# .clientWidth` and `body.clientWidth` all report **1486x833** from a placed
+# 1500x870, twice, at `devicePixelRatio` 1.5 and with no overflow in either
+# axis. The figure carried in this programme's notes since sprint 9 was
+# 1485 - one pixel short, and short in the direction that hides a clip.
+_WINDOW_FRAME_PX = 14
+_TITLE_BAR_PX = 37
+
+# Catches both `viewport: { width: N, height: M }` and a harness's own declared
+# client constant, which is the only other place these numbers may appear.
+_SIZE_LITERAL = re.compile(r"width:\s*(\d+),\s*height:\s*(\d+)")
+
+_HARNESSES = (
+    "smoke-agents.mjs",
+    "shot-agents.mjs",
+    "smoke-data.mjs",
+    "shot-data.mjs",
+)
+
+
+def _reference_client(index: int, spec) -> tuple[int, int]:
+    _, _, width, height = spec.place(index, *_REFERENCE_SCREEN)
+    return width - _WINDOW_FRAME_PX, height - _TITLE_BAR_PX
+
+
+def test_no_harness_measures_a_surface_larger_than_the_product_has():
+    """A viewport wider or taller than the real client cannot see a clip.
+
+    This is the shape of defect the programme keeps paying for: a check that
+    sits at the only size where the thing it guards cannot happen. Three of
+    the four harnesses were sized from the OUTER `WindowSpec` rather than from
+    the client the page actually receives - `smoke-agents.mjs` measured
+    1320x900 against a real 833, so **67 px of vertical overflow was invisible
+    to every assertion in it**, and `smoke-data.mjs` was the only one already
+    right.
+
+    Asserted as an inequality, not an equality, because a harness may
+    deliberately drive a SMALLER client (`smoke-data.mjs` sweeps a list of
+    them). Measuring bigger is the defect; measuring smaller is a test.
+    """
+    from src.pitwall.config import WINDOWS
+
+    scripts = Path(__file__).resolve().parents[2] / "src" / "pitwall" / "ui" / "scripts"
+    clients = [_reference_client(index, spec) for index, spec in enumerate(WINDOWS)]
+    widest = max(width for width, _ in clients)
+    tallest = max(height for _, height in clients)
+
+    seen = 0
+    for name in _HARNESSES:
+        source = (scripts / name).read_text(encoding="utf-8")
+        for width, height in _SIZE_LITERAL.findall(source):
+            seen += 1
+            assert int(width) <= widest and int(height) <= tallest, (
+                f"{name} measures {width}x{height}, larger than the real client {widest}x{tallest}"
+            )
+    # The enumeration itself, so this cannot pass by finding nothing.
+    assert seen >= len(_HARNESSES), f"only {seen} viewport literals found across {_HARNESSES}"
+
+
+def test_both_windows_hand_the_page_the_same_client_area():
+    """One surface, one number for the harnesses to point at.
+
+    The two windows used to differ: AGENTS was 1320 wide because it mirrored
+    the Qt strategy window's 540 + 740 columns plus the frame. That split is
+    gone, so the width had no argument behind it and the two harness families
+    had two numbers to drift apart.
+    """
+    from src.pitwall.config import WINDOWS
+
+    clients = {spec.key: _reference_client(index, spec) for index, spec in enumerate(WINDOWS)}
+    assert len(set(clients.values())) == 1, f"windows disagree about the client area: {clients}"
 
 
 # --- The connection label, which band 1 renders ------------------------------


### PR DESCRIPTION
Three of the four PITWALL UI harnesses size their viewport from the `WindowSpec` rather than from
the client area the window hands the page, so they measure a surface the product never has. The
AGENTS window is also 180 px narrower than the layout work about to land assumes.

## The numbers

`place()` on the reference desktop (2560x1440 at 150 %, i.e. 1707x960 logical) opens DATA at
1500x870 and AGENTS at 1320x870. Asked directly, with `evaluate_js` inside the real windows:
`innerWidth`, `documentElement.clientWidth` and `body.clientWidth` all report the same thing, so
the OS keeps 14 px of frame and 37 px of title bar.

| surface | outer | real client | what the harness used |
|---|---|---|---|
| DATA | 1500x870 | 1486x833 | `smoke-data.mjs` 1500x950 in six contexts, 1485x833 in five |
| DATA | | | `shot-data.mjs` defaults 1500x950 |
| AGENTS | 1320x870 | 1306x833 (derived) | `smoke-agents.mjs` 1320x900 in four contexts |
| AGENTS | | | `shot-agents.mjs` defaults 1320x900 |

The AGENTS row is derived from the same 14 px frame rather than measured, because the window was
already 1500 wide by the time it was probed. The height, 833, is measured on both.

So `smoke-agents.mjs` ran 67 px taller than the window: any vertical overflow in the AGENTS window
was outside every assertion in that file by construction. `smoke-data.mjs`'s scenario A, which
carries the bulk of its 229 checks, ran 117 px taller.

## The AGENTS width

`WindowSpec("agents", ...)` was 1320 because it mirrored the Qt strategy window's 540 + 740 px
columns plus the frame. The layout elevation deletes that split, so the number has no argument
behind it any more, and the design spec written for the elevation budgeted its decision band at
1485 - the DATA window's client - which would have left the PLAN module 301 px instead of 480.

Both specs go to 1500x950. One client area, one number for the harnesses.

## The stagger, found while making that change

`place()` chose `x = min(index * 40, max(0, screen_width - width))`, clamping the origin against
the window's own width. With two windows of different widths that never bit. With both at 1500 a
1366-wide laptop clamps both to the screen and the second origin drops to 0, putting the top
window exactly over the bottom one's title bar, which is the thing the stagger exists to prevent.
`test_the_second_window_is_still_grabbable` ran on one screen and was green through all of it.

## Fix

- Both `WindowSpec`s at 1500x950.
- `place()` picks the origin first and narrows the window to the room left, so the stagger
  survives a screen too small for two full-width windows.
- All four harnesses take a named `CLIENT` constant with the derivation in a comment.
- Two new guards in `tests/surfaces/test_pitwall_host.py`: no harness viewport may exceed the real
  client (an inequality, since a harness may deliberately drive a smaller one), and both windows
  must hand the page the same client area. Both assert their visited count first.
- `test_the_second_window_is_still_grabbable` is parametrised over 1707x960, 1366x768 and
  3840x2160.

## Checks

`tests/surfaces/` 247 passed. `smoke-agents` 22 checks and `smoke-data` 229 checks, both at the
measured client size, counts unchanged. `ruff check` and `ruff format --check` clean on the
touched files. Both guards driven red first: `smoke-agents.mjs measures 1320x900, larger than the
real client 1486x833` and `windows disagree about the client area: {'data': (1485, 833),
'agents': (1305, 833)}`. And the two real windows were opened and probed, twice.


Closes #1009
