### PR TITLE
fix(agents): drop the guardrail line, which no producer can fill

### DIFF
--- a/src/pitwall/agents_view/decision.py
+++ b/src/pitwall/agents_view/decision.py
@@ -43,11 +43,12 @@ from src.arcade.strategy import classify_action
 # point of an alarm colour is pre-attentive triage, and six semantics deny the
 # reader exactly that at the moment they need it.
 #
-# DANGER now belongs to alarm-class facts: the ALERT glyph, the guardrail
-# line, and a dead connection. The dicts stay rather than collapsing into a
-# constant, because a posture the producer has never sent must still fall to
-# TEXT_TERTIARY - which is what says "not reported" as against "reported and
-# unremarkable".
+# DANGER now belongs to alarm-class facts: the ALERT glyph and a dead
+# connection. The guardrail line was the third and it is gone, because nothing
+# could fill it (#974, `build_orchestrator`). The dicts stay rather than
+# collapsing into a constant, because a posture the producer has never sent
+# must still fall to TEXT_TERTIARY - which is what says "not reported" as
+# against "reported and unremarkable".
 _PACE_COLOURS: dict[str, tuple[int, int, int]] = {
     "PUSH": TEXT_SECONDARY,
     "NEUTRAL": TEXT_SECONDARY,
@@ -148,7 +149,38 @@ def _previous_call(latest: dict[str, Any], tail: list[dict[str, Any]] | None) ->
 def build_orchestrator(
     latest: dict[str, Any] | None, history_tail: list[dict[str, Any]] | None = None
 ) -> dict[str, Any]:
-    """The action badge, the confidence bar, the two chips and the plan."""
+    """The action badge, the confidence bar, the two chips and the plan.
+
+    **There is no guardrail line, and that is the fix rather than an omission
+    (#974).** The window used to render `⚠ Guardrail: <reason>` from
+    `latest["guardrail_reason"]`, a field typed, documented, styled and tested
+    on a path that cannot deliver it. The chain, walked end to end:
+
+    - `apply_guard_rails` produces a reason at exactly one production site,
+      `src/strategy/inference/no_llm.py:302`.
+    - `run_lap` hardcodes `guardrail_reason=None` for the `rich` profile
+      (`src/strategy/inference/engine.py:303`), because rich mode puts the
+      bounds in the LLM's prompt instead of applying them after the fact.
+    - `src/arcade/strategy_pipeline.py:48` hardcodes `profile="rich"`, and
+      `src/arcade/app.py` builds its request with a literal `no_llm=False`.
+
+    So on every arcade path the value is None by construction, and the line
+    was permanently blank.
+
+    --- WHERE TO CHANGE IF THE ARCADE LEARNS TO RUN WITHOUT AN LLM ---
+    Restore the field here, the `guardrail` key on `OrchestratorView`
+    (`lib/agents.ts`), the render in `OrchestratorCard.tsx` and the
+    `.orch-guardrail` rule, and give the raw hex back its row in
+    `test_pitwall_tokens.py`.
+
+    **What must NOT be done instead** is calling `apply_guard_rails` post-hoc
+    on the rich path to fill the line. In rich mode the bounds live in the
+    prompt and the model weighed them, so a deterministic check afterwards
+    would report an override that never ran; the prompt and the deterministic
+    mirror have also diverged (#716); and the bounds proscribe a real
+    percentage of professional stops, so the line would wear the alarm colour
+    on correct calls at that rate.
+    """
     if not latest:
         return {
             "action": "--",
@@ -163,7 +195,6 @@ def build_orchestrator(
             "risk": "Risk: --",
             "risk_colour": hex_str(TEXT_TERTIARY),
             "plan": "Pit: -- · Next: -- · UCUT: --",
-            "guardrail": "",
             "changed": "",
         }
 
@@ -171,7 +202,6 @@ def build_orchestrator(
     confidence = float(latest.get("confidence") or 0.0)
     pace_mode = latest.get("pace_mode")
     risk_posture = latest.get("risk_posture")
-    guardrail = latest.get("guardrail_reason")
     badge_colour, badge_label = classify_action(action)
 
     return {
@@ -197,7 +227,6 @@ def build_orchestrator(
         "risk": f"Risk: {risk_posture or '--'}",
         "risk_colour": hex_str(_RISK_COLOURS.get(str(risk_posture or "").upper(), TEXT_TERTIARY)),
         "plan": _plan_line(latest, action),
-        "guardrail": f"⚠ Guardrail: {guardrail}" if guardrail else "",
         "changed": _previous_call(latest, history_tail),
     }
 

--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -67,7 +67,6 @@ const VIEW = {
     risk: "Risk: AGGRESSIVE",
     risk_colour: "#ef4444",
     plan: "Pit: L24 · Next: HARD · UCUT: RUS",
-    guardrail: "",
   },
   scenarios: ["STAY", "PIT", "UCUT", "OCUT"].map((label, index) => ({
     key: label,

--- a/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
@@ -88,7 +88,6 @@ const IDLE_VIEW: AgentsView = {
     risk: "Risk: --",
     risk_colour: "#9ca3af",
     plan: "Pit: — · Next: — · UCUT: —",
-    guardrail: "",
     changed: "",
   },
   scenarios: [

--- a/src/pitwall/ui/src/features/agents/OrchestratorCard.tsx
+++ b/src/pitwall/ui/src/features/agents/OrchestratorCard.tsx
@@ -1,6 +1,6 @@
 /**
- * The N31 decision panel: action badge, confidence, the two regime chips,
- * the plan line and the guardrail.
+ * The N31 decision panel: action badge, confidence, the two regime chips
+ * and the plan line.
  *
  * 1:1 with `orchestrator_card.py`. Every string and colour is decided
  * host side, including the plan line's three branches, so the "stint
@@ -16,7 +16,8 @@ export function OrchestratorCard({ view }: { view: OrchestratorView }) {
       <div className="orch-top">
         {/* The text colour comes from the host too. Fixed to white here it
             measured 2.54:1 on the SUCCESS fill — the primary decision, below
-            AA, in the state where a guardrail has just overruled the plan. */}
+            AA, in the state where the orchestrator has just overruled the
+            Monte Carlo winner. */}
         <div
           className="orch-badge"
           style={{ background: view.action_colour, color: view.action_text_colour }}
@@ -55,7 +56,6 @@ export function OrchestratorCard({ view }: { view: OrchestratorView }) {
           tab panel. Only rendered on the lap the ACTION moved, which is rare
           enough to stay a signal. */}
       {view.changed ? <p className="orch-changed">{view.changed}</p> : null}
-      {view.guardrail ? <p className="orch-guardrail">{view.guardrail}</p> : null}
     </section>
   );
 }

--- a/src/pitwall/ui/src/lib/agents.ts
+++ b/src/pitwall/ui/src/lib/agents.ts
@@ -90,8 +90,6 @@ export interface OrchestratorView {
   risk_colour: string;
   /** Qt rich text: may carry the compound pill. */
   plan: string;
-  /** Empty string when the orchestrator did not override the MC winner. */
-  guardrail: string;
   /** `was STAY OUT (0.58) · L22`, only on the lap the call moved. */
   changed: string;
 }

--- a/src/pitwall/ui/src/styles/agents.css
+++ b/src/pitwall/ui/src/styles/agents.css
@@ -366,12 +366,6 @@
   background: #f59e0b;
   vertical-align: middle;
 }
-.orch-guardrail {
-  margin: 0;
-  color: #ef4444;
-  font-size: 11px;
-  font-weight: 600;
-}
 
 /* --- Scenario bars (scenario_bars.py) ------------------------------------ */
 

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -560,7 +560,6 @@ def test_the_orchestrator_card_is_the_qt_one_field_for_field():
     assert view["risk_colour"] == "#d1d5db"
     assert view["plan"].startswith("Pit: L24 · Next: <span")
     assert view["plan"].endswith("· UCUT: RUS")
-    assert view["guardrail"] == ""
 
 
 def test_the_lap_the_call_moves_says_what_it_moved_from():
@@ -624,9 +623,9 @@ def test_no_posture_wears_the_alarm_colour():
         built = build_orchestrator({"action": "STAY_OUT", "risk_posture": posture})
         assert built["risk_colour"] != danger, f"risk {posture} wears the alarm colour"
 
-    # And the one field that still may: a guardrail is a constraint violation.
-    vetoed = build_orchestrator({"action": "STAY_OUT", "guardrail_reason": "min stint"})
-    assert vetoed["guardrail"].startswith("⚠ Guardrail:")
+    # DANGER is left with two owners on this window, both alarm-class facts:
+    # the ALERT glyph and the dead-producer chip. The guardrail line was the
+    # third until #974.
 
 
 def test_the_confidence_tiers_are_the_three_qt_paints():
@@ -661,13 +660,29 @@ def test_an_empty_plan_on_stay_out_says_the_stint_continues():
     assert idle["action"] == "--"
 
 
-def test_the_guardrail_line_only_exists_when_the_orchestrator_overrode_the_winner():
+def test_the_window_renders_no_guardrail_line_because_nothing_can_fill_it():
+    """#974: a field typed, styled, documented and written by no producer.
+
+    The view used to carry `⚠ Guardrail: <reason>` from
+    `latest["guardrail_reason"]`. `run_lap` hardcodes that to None for the
+    `rich` profile, `strategy_pipeline` hardcodes `profile="rich"`, and
+    `src/arcade/app.py` builds its request with a literal `no_llm=False`, so
+    on every arcade path the line was permanently blank.
+
+    Asserted as the KEY BEING ABSENT while a reason is supplied, not as an
+    empty string. An empty string is what the defect produced for its whole
+    life, so a test pinning `== ""` would have been green throughout and green
+    afterwards, which is the shape of guard this repo keeps paying for. The
+    key's absence is the only thing that changed.
+    """
     from src.pitwall.agents_view.decision import build_orchestrator
 
-    assert build_orchestrator({"guardrail_reason": "min stint"})["guardrail"] == (
-        "⚠ Guardrail: min stint"
-    )
-    assert build_orchestrator({"guardrail_reason": None})["guardrail"] == ""
+    supplied = build_orchestrator({"action": "STAY_OUT", "guardrail_reason": "min stint"})
+    idle = build_orchestrator(None)
+
+    assert "guardrail" not in supplied, "the view must not carry a line no producer can fill"
+    assert "guardrail" not in idle
+    assert "min stint" not in str(supplied), "and nothing may smuggle the reason into another field"
 
 
 def test_the_scenario_bars_normalise_across_scores_that_are_all_negative():

--- a/tests/surfaces/test_pitwall_tokens.py
+++ b/tests/surfaces/test_pitwall_tokens.py
@@ -459,7 +459,10 @@ def test_the_two_raw_hexes_in_the_stylesheet_are_guarded_too():
         f"a new raw hex entered the stylesheet: {raw}. Either use a --qt-* token or add it here "
         "with the palette name it copies."
     )
-    assert "#ef4444" == _rgb_to_hex(palette.DANGER), "the guardrail rule copies DANGER"
+    # `.chip.is-frozen`, the dead-producer chip. It was the guardrail rule too
+    # until #974 deleted a line no producer could fill, and the hex survived
+    # that deletion because the frozen chip is its second copy site.
+    assert "#ef4444" == _rgb_to_hex(palette.DANGER), "the frozen chip copies DANGER"
     assert "#f59e0b" == _rgb_to_hex(palette.WARNING), (
         "the `was <call>` dot copies WARNING - a CHANGE worth noticing, deliberately not the "
         "DANGER one line below it, which means a fault"


### PR DESCRIPTION
## What

The AGENTS window stops rendering a guardrail line. The field, the type, the component branch and
the stylesheet rule are deleted, and `build_orchestrator`'s docstring carries the chain and the
instructions for restoring it.

## Why

`latest.guardrail_reason` is typed, documented, styled, tested and written by nothing on the path
this window is fed from. Walked end to end:

| step | file | what it does |
|---|---|---|
| the only production site that produces a reason | `src/strategy/inference/no_llm.py:302` | `apply_guard_rails` returns `(action, reason)` |
| the rich profile discards it | `src/strategy/inference/engine.py:303` | `guardrail_reason=None,  # rich mode applies rails via the LLM prompt, not post-hoc` |
| the arcade only runs rich | `src/arcade/strategy_pipeline.py:48` | `profile="rich"` hardcoded |
| and its own no-LLM flag is a literal | `src/arcade/app.py` | `no_llm=False`, never read by `_step_once` |

So the value is `None` by construction on every arcade path, and `{view.guardrail ? … : null}`
rendered nothing for the whole life of the feature.

## How

- `build_orchestrator` stops emitting the key in both branches.
- `OrchestratorView.guardrail` gone from `lib/agents.ts`; the render gone from
  `OrchestratorCard.tsx`; `.orch-guardrail` gone from `agents.css`; the boot literal in
  `AgentsWindow.tsx` and the smoke's `VIEW` literal updated in the same commit.
- Two comments that named the deleted line as a live mechanism were corrected: `decision.py`'s
  DANGER-ownership note and `test_pitwall_tokens.py`'s reason for guarding `#ef4444`, which
  survives the deletion because `.chip.is-frozen` is its second copy site.

## Not done, deliberately

Filling the line by calling `apply_guard_rails` post-hoc on the rich path. Three reasons:

1. In rich mode the bounds live in the prompt and the model weighed them, so a deterministic check
   afterwards reports a code override that never ran. `build_scenarios` already refuses that exact
   claim one panel down, which is why its mark reads `NOT TAKEN` rather than `VETOED`.
2. The prompt and the deterministic mirror have diverged (#716): the prompt exempts cases the code
   does not and the code enforces a bound the prompt never states, so the report would flag
   violations of rules that, in the mode that ran, do not exist in that form.
3. The bounds proscribe a real share of professional stops, so the line would wear the alarm
   colour on correct calls at that rate.

The wire field stays. If the arcade ever learns to run without an LLM, the restore list is in
`build_orchestrator`'s docstring.

## Checks

`tests/surfaces/` 247 passed. `npm run typecheck` clean, `npm run build` clean, `smoke-agents` 22
checks against the rebuilt bundle. `ruff check` and `format --check` clean.

The new guard driven red against the code it replaces: the `guardrail` key was put back in
`decision.py` from a scratch copy and the test failed with `assert 'guardrail' not in {'action':
'STAY OUT', …}`; restored from that copy and verified byte-identical with `cmp` before re-running
green. Not with `git checkout`, which would also have reverted the docstring in the same file.

Closes #974
