### PR TITLE
fix(pitwall): every harness page reports its own console, and four stubs stop 404ing

### DIFF
--- a/src/pitwall/ui/scripts/page-guard.mjs
+++ b/src/pitwall/ui/scripts/page-guard.mjs
@@ -1,0 +1,38 @@
+/**
+ * Watch a Playwright page for the failures a harness cannot see any other way.
+ *
+ * **The class this exists for is a 404, not an exception.** `bridge.ts` calls
+ * `window.pywebview.api.<method>` when the shell provides one and falls back to
+ * `fetch("/api/…")` when it does not - and the fallback swallows a bad status
+ * (`if (!response.ok) return null`), because in the product that is a server
+ * restarting and null already means "keep what you have". So a harness stub
+ * missing a method does not throw and does not fail an assertion: the window
+ * quietly renders the unknown state and chromium logs one console error.
+ *
+ * Four stubs had drifted that way by sprint 10 - `smoke-agents.mjs`'s live
+ * page and `shot-agents.mjs` had never gained `get_connection` after #1004
+ * wired `useConnection` into the AGENTS window, and `shot-data.mjs` and one
+ * `smoke-data.mjs` page carried `get_tick` alone. Only one page per file was
+ * listening to the console, so 18 of the 22 pages across the four harnesses
+ * could not have reported it.
+ *
+ * `pageerror` alone is not enough and never was: a failed `fetch` is not a
+ * page error.
+ */
+
+/**
+ * Attach the two listeners every page in a harness needs.
+ *
+ * @param {import("@playwright/test").Page} page
+ * @param {string[]} failures - the harness's own list; a smoke fails on it,
+ *   a screenshot script exits non-zero on it.
+ * @param {string} [label] - which page this is, for a legible message when a
+ *   harness drives a dozen of them.
+ */
+export function watchPage(page, failures, label = "") {
+  const where = label ? `(${label})` : "";
+  page.on("pageerror", (error) => failures.push(`pageerror${where}: ${error.message}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") failures.push(`console${where}: ${message.text()}`);
+  });
+}

--- a/src/pitwall/ui/scripts/shot-agents.mjs
+++ b/src/pitwall/ui/scripts/shot-agents.mjs
@@ -25,6 +25,7 @@ import { createServer } from "node:http";
 import { dirname, extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium } from "@playwright/test";
+import { watchPage } from "./page-guard.mjs";
 
 const MIME = {
   ".html": "text/html",
@@ -101,8 +102,11 @@ const bundle = `http://127.0.0.1:${server.address().port}/agents.html`;
 const browser = await chromium.launch();
 const ctx = await browser.newContext({ viewport: { width: +width, height: +height } });
 const page = await ctx.newPage();
-page.on("console", (m) => console.log(`[console:${m.type()}] ${m.text()}`));
-page.on("pageerror", (e) => console.log(`[pageerror] ${e.message}`));
+// A capture with a console error is not a capture of the product. This used to
+// print and carry on, which is how every AGENTS shot since #1004 was taken with
+// `useConnection` falling through to `fetch("/api/connection")` and a 404.
+const failures = [];
+watchPage(page, failures);
 
 await page.addInitScript((payload) => {
   window.pywebview = {
@@ -112,6 +116,10 @@ await page.addInitScript((payload) => {
       // under the screenshot.
       get_agents_view: async (sinceSeq) => (sinceSeq >= payload.seq ? null : payload),
       get_tick: async () => null,
+      // Polled by `useConnection` while there is no view. Without it the
+      // bridge falls back to `fetch("/api/connection")`, the static server
+      // answers 404, and the window renders an unknown connection.
+      get_connection: async () => "Connected",
     },
   };
 }, view);
@@ -124,4 +132,10 @@ await page.screenshot({ path: resolve(out), fullPage: false });
 await ctx.close();
 await browser.close();
 server.close();
+
+if (failures.length) {
+  console.error(`shot-agents FAILED (${failures.length}):`);
+  for (const failure of failures) console.error(`  - ${failure}`);
+  process.exit(1);
+}
 console.log(`saved ${out}`);

--- a/src/pitwall/ui/scripts/shot-data.mjs
+++ b/src/pitwall/ui/scripts/shot-data.mjs
@@ -30,6 +30,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium } from "@playwright/test";
 import { serveDist } from "./serve-dist.mjs";
+import { watchPage } from "./page-guard.mjs";
 
 const UI_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const TICKS = JSON.parse(readFileSync(process.argv[2], "utf-8"));
@@ -49,8 +50,11 @@ const server = await serveDist(resolve(UI_DIR, "dist"));
 const browser = await chromium.launch();
 const context = await browser.newContext({ viewport: { width: WIDTH, height: HEIGHT } });
 const page = await context.newPage();
-page.on("console", (message) => console.log(`[page:${message.type()}] ${message.text()}`));
-page.on("pageerror", (error) => console.error(`[pageerror] ${error.message}`));
+// A capture with a console error is not a capture of the product. This used to
+// print and carry on, which is how every DATA shot since #982 was taken with
+// `useConnection` falling through to `fetch("/api/connection")` and a 404.
+const failures = [];
+watchPage(page, failures);
 
 // Monotone, exactly like the smoke's stub: hand back the current tick until
 // the window has rendered it, then advance. A stub that returns "anything you
@@ -60,6 +64,11 @@ await page.addInitScript((payloads) => {
   window.__cursor = 0;
   window.pywebview = {
     api: {
+      // The four the DATA window polls. Three were missing, so the bridge fell
+      // back to `fetch("/api/…")` and the static server answered 404 on each.
+      get_bulk: async () => null,
+      get_live_lap: async () => null,
+      get_connection: async () => "Connected",
       get_tick: async (sinceSeq) => {
         if (window.__ticks[window.__cursor].seq === sinceSeq) {
           if (window.__cursor + 1 >= window.__ticks.length) return null;
@@ -92,3 +101,9 @@ console.log(`shot-data: ${consumed}/${ticks.length} ticks replayed -> ${OUT}`);
 await context.close();
 await browser.close();
 server.close();
+
+if (failures.length) {
+  console.error(`shot-data FAILED (${failures.length}):`);
+  for (const failure of failures) console.error(`  - ${failure}`);
+  process.exit(1);
+}

--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -21,6 +21,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium } from "@playwright/test";
 import { serveDist } from "./serve-dist.mjs";
+import { watchPage } from "./page-guard.mjs";
 import { staysStill } from "./settle.mjs";
 
 const UI_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -202,10 +203,7 @@ const server = await serveDist(DIST);
 const browser = await chromium.launch();
 const ctx = await browser.newContext({ viewport: CLIENT });
 const page = await ctx.newPage();
-page.on("pageerror", (error) => failures.push(`pageerror: ${error.message}`));
-page.on("console", (message) => {
-  if (message.type() === "error") failures.push(`console: ${message.text()}`);
-});
+watchPage(page, failures);
 
 await page.addInitScript((view) => {
   window.pywebview = {
@@ -359,6 +357,7 @@ await ctx.close();
 // producer, the case that already worked.
 const live = await browser.newContext({ viewport: CLIENT });
 const livePage = await live.newPage();
+watchPage(livePage, failures, "live");
 await livePage.addInitScript((view) => {
   let seq = 0;
   window.pywebview = {
@@ -376,6 +375,7 @@ await livePage.addInitScript((view) => {
       // until this line changed.
       get_agents_view: async () => ({ ...structuredClone(view), seq: ++seq }),
       get_tick: async () => null,
+      get_connection: async () => "Connected",
     },
   };
 }, VIEW);
@@ -422,9 +422,7 @@ await live.close();
 async function idleStatusBar(connection) {
   const context = await browser.newContext({ viewport: CLIENT });
   const idlePage = await context.newPage();
-  idlePage.on("pageerror", (error) =>
-    failures.push(`pageerror(idle/${connection}): ${error.message}`),
-  );
+  watchPage(idlePage, failures, "idle/${connection}");
   await idlePage.addInitScript((state) => {
     window.pywebview = {
       api: {
@@ -465,6 +463,7 @@ check(
 const servedBar = await (async () => {
   const context = await browser.newContext({ viewport: CLIENT });
   const viewPage = await context.newPage();
+watchPage(viewPage, failures, "frozen");
   await viewPage.addInitScript(
     ([view, state]) => {
       window.pywebview = {

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -28,6 +28,8 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium } from "@playwright/test";
 import { serveDist } from "./serve-dist.mjs";
+import { watchPage } from "./page-guard.mjs";
+import ts from "typescript";
 import { staysStill } from "./settle.mjs";
 
 const UI_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -182,10 +184,7 @@ const ctx = await browser.newContext({
   viewport: CLIENT,
 });
 const page = await ctx.newPage();
-page.on("pageerror", (error) => failures.push(`pageerror: ${error.message}`));
-page.on("console", (message) => {
-  if (message.type() === "error") failures.push(`console: ${message.text()}`);
-});
+watchPage(page, failures);
 
 // A MONOTONE script, never "return whatever the caller has not seen". The
 // first version of this stub returned the first tick whose seq differed, so
@@ -669,9 +668,7 @@ const solo = await browser.newContext({
   viewport: CLIENT,
 });
 const soloPage = await solo.newPage();
-soloPage.on("pageerror", (error) =>
-  failures.push(`pageerror(solo): ${error.message}`),
-);
+watchPage(soloPage, failures, "solo");
 
 await soloPage.addInitScript(
   (payload) => {
@@ -764,9 +761,7 @@ const ring = await browser.newContext({
   viewport: CLIENT,
 });
 const ringPage = await ring.newPage();
-ringPage.on("pageerror", (error) =>
-  failures.push(`pageerror(ring): ${error.message}`),
-);
+watchPage(ringPage, failures, "ring");
 
 await ringPage.addInitScript(
   (payload) => {
@@ -774,6 +769,12 @@ await ringPage.addInitScript(
       api: {
         get_tick: async (sinceSeq) =>
           sinceSeq === payload.seq ? null : payload,
+        // The other three the DATA window polls. Without them the bridge
+        // falls back to `fetch("/api/...")` and the static server answers
+        // 404 four times, which nothing on this page was listening for.
+        get_bulk: async () => null,
+        get_live_lap: async () => null,
+        get_connection: async () => "Connected",
       },
     };
   },
@@ -955,6 +956,7 @@ const stillCtx = await browser.newContext({
   viewport: CLIENT,
 });
 const stillPage = await stillCtx.newPage();
+watchPage(stillPage, failures, "still");
 await stillPage.addInitScript((payload) => {
   let seq = payload.seq;
   window.pywebview = {
@@ -1001,9 +1003,7 @@ async function provisionalChips(field) {
     viewport: CLIENT,
   });
   const scenarioPage = await context.newPage();
-  scenarioPage.on("pageerror", (error) =>
-    failures.push(`pageerror(provisional): ${error.message}`),
-  );
+  watchPage(scenarioPage, failures, "provisional");
   await scenarioPage.addInitScript(
     (payload) => {
       window.pywebview = {
@@ -1011,7 +1011,6 @@ async function provisionalChips(field) {
           get_tick: async (sinceSeq) =>
             sinceSeq === payload.seq ? null : payload,
           get_bulk: async () => null,
-          get_live_lap: async () => null,
           get_live_lap: async () => null,
           get_connection: async () => "Connected",
         },
@@ -1232,9 +1231,7 @@ const towerCtx = await browser.newContext({
   viewport: CLIENT,
 });
 const towerPage = await towerCtx.newPage();
-towerPage.on("pageerror", (error) =>
-  failures.push(`pageerror(tower): ${error.message}`),
-);
+watchPage(towerPage, failures, "tower");
 await towerPage.addInitScript(
   ([payload, bulk, live]) => {
     window.pywebview = {
@@ -1585,9 +1582,7 @@ async function radioPage(radio) {
     viewport: CLIENT,
   });
   const rPage = await context.newPage();
-  rPage.on("pageerror", (error) =>
-    failures.push(`pageerror(radio): ${error.message}`),
-  );
+  watchPage(rPage, failures, "radio");
   await rPage.addInitScript(
     ([payload, bulk, live]) => {
       window.pywebview = {
@@ -1656,25 +1651,33 @@ check(
 );
 
 // The minute boundary `paceLabel` documented and its two siblings did not have.
-// Evaluated against the SHIPPED module rather than a copy of its arithmetic.
-const boundary = await feedPage.evaluate(async () => {
-  const mod = await import("/src/lib/format.ts").catch(() => null);
-  return mod === null
-    ? null
-    : [
-        mod.formatSeconds(119.9996, 3),
-        mod.formatSeconds(59.9996, 3),
-        mod.formatSeconds(29.412, 3),
-        mod.formatSeconds(119.96, 1, true),
-      ];
+// Evaluated against the real module rather than a copy of its arithmetic.
+//
+// **This ran in the browser until sprint 10 and it never executed once.** It
+// asked for `/src/lib/format.ts` from a server that holds the BUILT bundle, so
+// the import 404'd, `.catch(() => null)` turned that into `null`, and the `if`
+// below skipped the whole assertion - a guard about the empty set, and the one
+// page in this file with nothing watching its console, so the 404 was silent
+// too. Transpiled here instead, with the `typescript` this project already
+// depends on: same source the bundle is built from, no browser needed for a
+// pure function, and no way left for it to skip itself.
+const formatSource = readFileSync(resolve(UI_DIR, "src/lib/format.ts"), "utf-8");
+const { outputText } = ts.transpileModule(formatSource, {
+  compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 },
 });
-if (boundary !== null) {
-  check(
-    JSON.stringify(boundary) ===
-      JSON.stringify(["2:00.000", "1:00.000", "29.412", "2:00.0"]),
-    `the shared formatter rounds before it splits (${JSON.stringify(boundary)})`,
-  );
-}
+const format = await import(
+  `data:text/javascript;base64,${Buffer.from(outputText).toString("base64")}`
+);
+const boundary = [
+  format.formatSeconds(119.9996, 3),
+  format.formatSeconds(59.9996, 3),
+  format.formatSeconds(29.412, 3),
+  format.formatSeconds(119.96, 1, true),
+];
+check(
+  JSON.stringify(boundary) === JSON.stringify(["2:00.000", "1:00.000", "29.412", "2:00.0"]),
+  `the shared formatter rounds before it splits (${JSON.stringify(boundary)})`,
+);
 
 // --- The history a reader could not reach ---------------------------------
 //
@@ -2298,9 +2301,7 @@ const paceCtx = await browser.newContext({
   viewport: CLIENT,
 });
 const pacePage = await paceCtx.newPage();
-pacePage.on("pageerror", (error) =>
-  failures.push(`pageerror(pace): ${error.message}`),
-);
+watchPage(pacePage, failures, "pace");
 await pacePage.addInitScript(
   ([payload, bulk, live]) => {
     window.pywebview = {
@@ -2683,9 +2684,7 @@ check(
     viewport: { width: 1265, height: 593 },
   });
   const narrow = await narrowCtx.newPage();
-  narrow.on("pageerror", (error) =>
-    failures.push(`pageerror(pace-narrow): ${error.message}`),
-  );
+  watchPage(narrow, failures, "pace-narrow");
   await narrow.addInitScript(
     ([payload, bulk, live]) => {
       window.pywebview = {
@@ -2817,9 +2816,7 @@ check(
     viewport: CLIENT,
   });
   const partial = await partialCtx.newPage();
-  partial.on("pageerror", (error) =>
-    failures.push(`pageerror(skeleton): ${error.message}`),
-  );
+  watchPage(partial, failures, "skeleton");
   const REVEALED_TO = 30;
   await partial.addInitScript(
     ([payload, bulk, live, cap]) => {
@@ -2961,9 +2958,7 @@ for (const [width, height] of [
 ]) {
   const ctx = await browser.newContext({ viewport: { width, height } });
   const page = await ctx.newPage();
-  page.on("pageerror", (error) =>
-    failures.push(`pageerror(bests ${height}): ${error.message}`),
-  );
+  watchPage(page, failures, "bests ${height}");
   // **Withheld at the STUB, not with `page.route`.** `bridge.ts` uses
   // `window.pywebview` whenever it exists and only falls back to `fetch`, so the
   // smoke's injected api is the transport and an HTTP route intercepts nothing -
@@ -3047,9 +3042,7 @@ for (const [width, height] of [
     viewport: { width: 1265, height: 593 },
   });
   const page = await ctx.newPage();
-  page.on("pageerror", (error) =>
-    failures.push(`pageerror(wheel): ${error.message}`),
-  );
+  watchPage(page, failures, "wheel");
   // **Capped at lap 30, like the skeleton block one section down.** `paceBulk()` reveals
   // all 57 laps, so on it there are no future rows at all, the pin target IS the bottom of
   // the scroller, and the reader can never be "away from" it - the first version of this
@@ -3194,9 +3187,7 @@ for (const [width, height] of [
 ]) {
   const ctx = await browser.newContext({ viewport: { width, height } });
   const page = await ctx.newPage();
-  page.on("pageerror", (error) =>
-    failures.push(`pageerror(lanes ${width}): ${error.message}`),
-  );
+  watchPage(page, failures, "lanes ${width}");
   await page.addInitScript(
     ([payload, bulk, live]) => {
       window.pywebview = {
@@ -3457,9 +3448,7 @@ if (bands === null) {
     viewport: { width: 1265, height: 593 },
   });
   const narrow = await narrowCtx.newPage();
-  narrow.on("pageerror", (error) =>
-    failures.push(`pageerror(axis): ${error.message}`),
-  );
+  watchPage(narrow, failures, "axis");
   await narrow.addInitScript(
     ([payload, bulk, live]) => {
       window.pywebview = {
@@ -3533,9 +3522,7 @@ if (bands === null) {
     viewport: CLIENT,
   });
   const dead = await deadCtx.newPage();
-  dead.on("pageerror", (error) =>
-    failures.push(`pageerror(dead): ${error.message}`),
-  );
+  watchPage(dead, failures, "dead");
   await dead.addInitScript(
     ([payload, bulk, live]) => {
       window.__alive = true;
@@ -3841,9 +3828,7 @@ await paceCtx.close();
 async function waitingCopy(connection) {
   const context = await browser.newContext({ viewport: CLIENT });
   const emptyPage = await context.newPage();
-  emptyPage.on("pageerror", (error) =>
-    failures.push(`pageerror(waiting/${connection}): ${error.message}`),
-  );
+  watchPage(emptyPage, failures, "waiting/${connection}");
   await emptyPage.addInitScript((state) => {
     window.pywebview = {
       api: {

--- a/tests/surfaces/test_pitwall_host.py
+++ b/tests/surfaces/test_pitwall_host.py
@@ -414,6 +414,44 @@ def test_no_harness_measures_a_surface_larger_than_the_product_has():
     assert seen >= len(_HARNESSES), f"only {seen} viewport literals found across {_HARNESSES}"
 
 
+_NEW_PAGE = re.compile(r"(?:const|let)\s+(\w+)\s*=\s*await\s+\w+\.newPage\(\)")
+_WATCHED = re.compile(r"watchPage\((\w+),")
+
+
+def test_every_harness_page_is_watched_for_console_errors():
+    """The invariant that makes a missing bridge stub visible at all.
+
+    `bridge.ts` calls `window.pywebview.api.<method>` when the shell provides
+    one and falls back to `fetch("/api/...")` when it does not, and the
+    fallback swallows a bad status on purpose (`if (!response.ok) return
+    null`) because in the product that is a server restarting. So a stub
+    missing a method throws nothing and fails no assertion: the window renders
+    the unknown state and chromium logs one console error.
+
+    By sprint 10 four stubs had drifted that way and **18 of the 22 pages
+    across the four harnesses had no console listener**, so none of them could
+    have reported it. Watching every page is what turns the whole class from
+    silent into loud, which is why this asserts the listener rather than any
+    particular method: the next hook to be wired will be some other method.
+
+    Counts the pages first, so it cannot pass by finding none.
+    """
+    scripts = Path(__file__).resolve().parents[2] / "src" / "pitwall" / "ui" / "scripts"
+
+    pages = 0
+    unwatched: list[str] = []
+    for name in _HARNESSES:
+        source = (scripts / name).read_text(encoding="utf-8")
+        watched = set(_WATCHED.findall(source))
+        for variable in _NEW_PAGE.findall(source):
+            pages += 1
+            if variable not in watched:
+                unwatched.append(f"{name}:{variable}")
+
+    assert pages >= len(_HARNESSES), f"only {pages} pages found across {_HARNESSES}"
+    assert not unwatched, f"pages with no console listener: {unwatched}"
+
+
 def test_both_windows_hand_the_page_the_same_client_area():
     """One surface, one number for the harnesses to point at.
 


### PR DESCRIPTION
Four of the 22 bridge stubs across the PITWALL UI harnesses had drifted from the api the windows
call, and 18 of the 22 pages had nothing listening for the failure, so none of it could be seen.

## Why it is silent

`bridge.ts` calls `window.pywebview.api.<method>` when the shell provides one and falls back to
`fetch("/api/…")` when it does not. The fallback swallows a bad status on purpose:

```ts
const response = await fetch("/api/connection", { cache: "no-store" });
if (!response.ok) return null;
```

In the product that is a server restarting, and `null` already means "keep what you have". In a
harness it means a missing stub method throws nothing, fails no assertion, and renders the unknown
state while chromium logs one console error.

`pageerror` does not fire for it. A failed `fetch` is not a page error.

## The census

| harness | stubs | pages | pages with a console listener |
|---|---|---|---|
| `smoke-agents.mjs` | 4 | 4 | 1 |
| `smoke-data.mjs` | 16 | 16 | 1 |
| `shot-agents.mjs` | 1 | 1 | 1 (printed, never failed) |
| `shot-data.mjs` | 1 | 1 | 1 (printed, never failed) |

Incomplete stubs, each producing a 404 per poll:

- `smoke-agents.mjs` live page: no `get_connection`. Added when #1004 wired `useConnection` into
  the AGENTS window; the stub beside it got the method and this one did not.
- `smoke-data.mjs` ring page: `get_tick` alone, so `get_bulk`, `get_live_lap` and `get_connection`
  all fell through. Four 404s on that page.
- `shot-agents.mjs`: no `get_connection`, so every AGENTS capture since #1004 was taken with the
  window's connection state unknown.
- `shot-data.mjs`: `get_tick` alone, same for every DATA capture since #982.

Both shot scripts printed console output and carried on, so a capture with a 404 in it looked
exactly like a clean one.

Also found: two duplicated keys in `smoke-data.mjs` stubs (`get_live_lap` twice on the scenario
page). Harmless in JS, last wins, but they are the same drift.

## The guard that never ran

Watching every page immediately surfaced a fifth 404 that has nothing to do with a stub:

```js
const mod = await import("/src/lib/format.ts").catch(() => null);
return mod === null ? null : [ … ];
```

`smoke-data.mjs` asked a server that holds the BUILT bundle for a TypeScript source file. The
import 404'd, the `.catch` turned it into `null`, and the `if (boundary !== null)` below skipped
the assertion entirely. It is the check whose own comment says it exists to run "against the
SHIPPED module rather than a copy of its arithmetic", and it had never executed once. Its page was
also the one with no console listener, so the 404 was invisible too.

## Fix

- `scripts/page-guard.mjs`: one `watchPage(page, failures, label)` attaching both `pageerror` and
  `console`. Every page in all four harnesses uses it; the ad-hoc per-page handlers are gone.
- Both shot scripts collect into the same list and `process.exit(1)` on it. A capture with a
  console error is not a capture of the product.
- The four incomplete stubs completed, the two duplicate keys removed.
- The formatter check is transpiled with the `typescript` this project already depends on and
  imported as a data URL in Node, so it runs against the same source the bundle is built from and
  cannot skip itself. `smoke-data` goes from 229 checks to **230**, which is the measurement that
  it was dead.
- `tests/surfaces/test_pitwall_host.py` gains a guard that every `newPage()` in the four harnesses
  is watched. It asserts the listener rather than any particular api method, because the next hook
  to be wired will be some other method; counting the pages first so it cannot pass by finding
  none.

## Checks

`tests/surfaces/` 248 passed. `smoke-agents` 22 checks, `smoke-data` **230**. `ruff check .` and
`ruff format --check .` clean over the whole repo.

Driven red twice, each time restored from a scratch copy and verified byte-identical with `cmp`
rather than with `git checkout`:

- `get_connection` removed from `shot-agents.mjs`'s stub: `shot-agents FAILED (1): console: Failed
  to load resource: the server responded with a status of 404 (Not Found)`, exit 1. Before this
  PR the same run printed the same line and exited 0.
- `format.ts` mutated to split the minutes off before rounding, which is the historical bug its
  own docstring documents: `the shared formatter rounds before it splits
  (["1:60.000","60.000","29.412","1:60.0"])`. That is the first time that guard has ever failed,
  because it is the first time it has ever run.


Closes #1012
