### PR TITLE
feat(agents): a decision band over six consoles, not a column beside a grid

### DIFF
--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -4,8 +4,8 @@
  * **The gap this closes was named by the sprint-3 exit gate**: every one
  * of its render-layer findings sailed through 35 green Python tests,
  * because those pin the view DICT and nothing loaded the bundle. Deleting
- * `<PaceChart/>` from `AgentsWindow.tsx`, or the whole `.agents-split`
- * rule from the stylesheet, left the suite entirely green.
+ * `<PaceChart/>` from `AgentsWindow.tsx`, or the whole layout rule from
+ * the stylesheet, left the suite entirely green.
  *
  * So this asserts EFFECTS in a real engine: the elements exist, the
  * layout the port claims is frozen actually computes to Qt's numbers, and
@@ -248,12 +248,110 @@ const barWidths = await page.evaluate(() =>
 check(barWidths[1] > barWidths[0] && barWidths[0] > 0, `the bars carry their fill (${barWidths})`);
 check(await page.locator(".orchestrator").isVisible(), "the orchestrator card");
 
-// Qt pins the left panel at 540 px and sends every extra pixel right
-// (`setStretchFactor(0, 0)`). A proportional split grew it to 807 at 1920.
-const columns = await page.evaluate(
-  () => getComputedStyle(document.querySelector(".agents-split")).gridTemplateColumns,
+// --- The four strata -------------------------------------------------------
+//
+// The 540 px left column is gone with the Qt split it came from, and so is the
+// check that pinned it. What replaces it asserts the SHAPE the band claims: one
+// row of four modules, in the reader's question order, and six consoles placed
+// by name underneath.
+const band = await page.evaluate(() => {
+  const modules = [...document.querySelectorAll(".agents-band > *")];
+  const box = (el) => el.getBoundingClientRect();
+  return {
+    count: modules.length,
+    tops: modules.map((el) => Math.round(box(el).top)),
+    lefts: modules.map((el) => Math.round(box(el).left)),
+    widths: modules.map((el) => Math.round(box(el).width)),
+  };
+});
+check(band.count === 4, `the band carries four modules (${band.count})`);
+check(new Set(band.tops).size === 1, `all four sit on one row (${band.tops})`);
+check(
+  band.lefts.every((left, i) => i === 0 || left > band.lefts[i - 1]),
+  `and in reading order (${band.lefts})`,
 );
-check(columns.startsWith("540px"), `left column is 540px (got ${columns})`);
+// PLAN is the `1fr`: it must be the widest, and it must actually absorb the
+// slack rather than sitting at some fixed budget. The three fixed columns are
+// 340 / 290 / 330 against a 1466 px inner width.
+check(
+  band.widths[3] > Math.max(band.widths[0], band.widths[1], band.widths[2]),
+  `PLAN absorbs the width (${band.widths})`,
+);
+
+// The consoles, by rendered geometry rather than by class name: a card can
+// carry the right class and be placed in the wrong area.
+const grid = await page.evaluate(() => {
+  const box = (selector) => {
+    const el = document.querySelector(selector);
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    return { left: Math.round(r.left), right: Math.round(r.right), top: Math.round(r.top) };
+  };
+  return {
+    pace: box(".slot-pace"),
+    tire: box(".slot-tire"),
+    situation: box(".slot-situation"),
+    pit: box(".slot-pit"),
+    radio: box(".slot-radio"),
+    rag: box(".slot-rag"),
+  };
+});
+check(
+  grid.pace.right <= grid.tire.left && grid.tire.right <= grid.situation.left,
+  "the three columns run pace, tire, then the side stack",
+);
+check(
+  grid.situation.top < grid.pit.top && grid.situation.left === grid.pit.left,
+  "SITUATION sits over PIT in one column",
+);
+check(
+  grid.radio.left === grid.pace.left && grid.radio.right >= grid.tire.right,
+  "RADIO spans the two chart columns",
+);
+check(
+  grid.rag.left === grid.situation.left && grid.rag.top >= grid.radio.top,
+  "and RAG closes the corner",
+);
+
+// **Nothing may overflow the client.** The old harness ran at 1320x900 - 67 px
+// taller than the window - so a layout that did not fit could not be seen here
+// at all. Asserted on the document, which is what the OS window scrolls or
+// clips, not on any one panel.
+const overflow = await page.evaluate(() => {
+  const h = (selector) => {
+    const el = document.querySelector(selector);
+    return el ? Math.round(el.getBoundingClientRect().height) : null;
+  };
+  return {
+    vertical: document.documentElement.scrollHeight - document.documentElement.clientHeight,
+    horizontal: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+    // In the failure message, because "it does not fit" is not actionable and
+    // "the band is 195 and the grid wants 600" is.
+    client: document.documentElement.clientHeight,
+    // WHICH element sticks out, not just that something does. `.agent-card`
+    // is deliberately `overflow: visible` so nothing can clip its tooltip, so
+    // a card whose content exceeds its cell spills into the document rather
+    // than scrolling, and the document is where it shows up.
+    past: [...document.querySelectorAll(".agents-body *")]
+      .map((el) => ({
+        what: `${el.tagName.toLowerCase()}.${(el.className || "").toString().split(" ").join(".")}`,
+        over: Math.round(el.getBoundingClientRect().bottom - document.documentElement.clientHeight),
+      }))
+      .filter((e) => e.over > 0)
+      .sort((a, b) => b.over - a.over)
+      .slice(0, 4),
+    strata: {
+      header: h(".header-bar"),
+      band: h(".agents-band"),
+      grid: h(".agents-grid"),
+      status: h(".status-bar"),
+    },
+  };
+});
+check(
+  overflow.vertical <= 0 && overflow.horizontal <= 0,
+  `the window fits its client (${JSON.stringify(overflow)})`,
+);
 
 // The tooltip must appear only where the host sent content, and NOTHING
 // may clip it. Two fixes failed here and the second was passed by a check

--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -394,6 +394,38 @@ const overlap = await page.evaluate(() => {
 });
 check(overlap === 0, `the tooltip does not cover its own card (${overlap} px2)`);
 
+// **And the same when the popup fits on neither side**, which is the branch a
+// wide card reaches and the one that used to place it on its own subject.
+// Forced rather than waited for: the width is `max-content`, so whether a real
+// tooltip trips it depends on the fonts the machine happens to have - it fired
+// on a CI runner and never here, from the same code and the same fixture.
+await page.mouse.move(0, 0);
+await page.waitForTimeout(150);
+const widen = await page.addStyleTag({
+  content: ".agent-tooltip { min-width: 1200px !important; }",
+});
+await page.locator(".agent-card").nth(4).hover();
+await page.waitForTimeout(200);
+const forced = await page.evaluate(() => {
+  const tip = document.querySelector(".agent-tooltip").getBoundingClientRect();
+  const card = document.querySelectorAll(".agent-card")[4].getBoundingClientRect();
+  const x = Math.max(0, Math.min(tip.right, card.right) - Math.max(tip.left, card.left));
+  const y = Math.max(0, Math.min(tip.bottom, card.bottom) - Math.max(tip.top, card.top));
+  return {
+    overlap: Math.round(x * y),
+    onScreen: tip.top >= 0 && tip.bottom <= window.innerHeight,
+    width: Math.round(tip.width),
+  };
+});
+check(
+  forced.overlap === 0,
+  `a popup too wide for either side still clears its card (${JSON.stringify(forced)})`,
+);
+check(forced.onScreen, `and stays on screen (${JSON.stringify(forced)})`);
+await widen.evaluate((node) => node.remove());
+await page.mouse.move(0, 0);
+await page.waitForTimeout(150);
+
 // Qt's `showMessage(text, 1500)` clears itself. The port typed a
 // `transient` flag and read it nowhere until #871.
 // The scrollbars are HIDDEN, not deleted. Víctor asked for the bars inside

--- a/src/pitwall/ui/src/features/agents/AgentCard.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentCard.tsx
@@ -58,22 +58,45 @@ function Tooltip({ view, anchor }: { view: TooltipView; anchor: DOMRect }) {
     // card was blanketed and the popup spilled below it. A tooltip that
     // hides its own subject is worse than no tooltip.
     //
-    // Right of the card by preference, left when there is no room, and only
-    // then below - which is the old behaviour kept as the last resort for a
-    // card that is wider than the space either side of it.
+    // Right of the card by preference, left when there is no room, and
+    // OUTSIDE IT VERTICALLY when neither side fits.
+    //
+    // **That third branch used to keep the popup at the card's own left edge,
+    // which is on top of it.** It was survivable while every card was about a
+    // third of the window; the decision band made RADIO span two columns, so
+    // the room either side of a 984 px card is 492 px and a tooltip wider than
+    // that lands on its own subject. It reached CI and not this machine,
+    // because `width` is `max-content` and the runner has neither JetBrains
+    // Mono nor the body font: 37,285 px2 of overlap there, zero here, from the
+    // same code and the same fixture.
     const roomRight = window.innerWidth - anchor.right - TOOLTIP_GAP;
     const roomLeft = anchor.left - TOOLTIP_GAP;
-    let left: number;
-    if (roomRight >= width) left = anchor.right + TOOLTIP_GAP;
-    else if (roomLeft >= width) left = anchor.left - TOOLTIP_GAP - width;
-    else left = Math.max(TOOLTIP_GAP, Math.min(anchor.left, window.innerWidth - width - TOOLTIP_GAP));
+    const onScreenTop = (wanted: number) =>
+      Math.max(TOOLTIP_GAP, Math.min(wanted, window.innerHeight - height - TOOLTIP_GAP));
 
-    // Vertically aligned with the card's top, then pulled up only as far as
-    // it must be to stay on screen.
-    const top = Math.max(
-      TOOLTIP_GAP,
-      Math.min(anchor.top, window.innerHeight - height - TOOLTIP_GAP),
-    );
+    let left: number;
+    let top: number;
+    if (roomRight >= width) {
+      left = anchor.right + TOOLTIP_GAP;
+      top = onScreenTop(anchor.top);
+    } else if (roomLeft >= width) {
+      left = anchor.left - TOOLTIP_GAP - width;
+      top = onScreenTop(anchor.top);
+    } else {
+      left = Math.max(
+        TOOLTIP_GAP,
+        Math.min(anchor.left, window.innerWidth - width - TOOLTIP_GAP),
+      );
+      // Under the card if it fits there, over it if not. Preferring BELOW
+      // rather than above keeps the reading order for the four cards that have
+      // room under them; RADIO and RAG sit on the bottom row and take the
+      // other branch.
+      const roomBelow = window.innerHeight - anchor.bottom - TOOLTIP_GAP;
+      const roomAbove = anchor.top - TOOLTIP_GAP;
+      if (roomBelow >= height) top = anchor.bottom + TOOLTIP_GAP;
+      else if (roomAbove >= height) top = anchor.top - TOOLTIP_GAP - height;
+      else top = onScreenTop(anchor.top);
+    }
     setBox({ left, top });
   }, [anchor, view]);
 

--- a/src/pitwall/ui/src/features/agents/AgentCard.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentCard.tsx
@@ -105,10 +105,13 @@ function Tooltip({ view, anchor }: { view: TooltipView; anchor: DOMRect }) {
 export function AgentCard({
   title,
   card,
+  slot,
   children,
 }: {
   title: string;
   card: AgentCardView;
+  /** Which console this is, as a `slot-*` class; the stylesheet owns the shape. */
+  slot?: string;
   children?: React.ReactNode;
 }) {
   const idle = card.status === "IDLE";
@@ -119,7 +122,16 @@ export function AgentCard({
 
   return (
     <section
-      className={idle ? "card agent-card is-idle" : "card agent-card"}
+      className={
+        [
+          "card",
+          "agent-card",
+          idle ? "is-idle" : "",
+          slot ? `slot-${slot}` : "",
+        ]
+          .filter(Boolean)
+          .join(" ")
+      }
       onMouseEnter={(event) => card.tooltip && setAnchor(event.currentTarget.getBoundingClientRect())}
       onMouseLeave={() => setAnchor(null)}
     >

--- a/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
@@ -1,14 +1,20 @@
 /**
- * PITWALL · AGENTS — the 1:1 port of the Qt strategy window.
+ * PITWALL · AGENTS — a decision band over six specialist consoles.
  *
- * The layout is frozen and matches `window.py:141-207`: a header strip, a
- * horizontal split at 540 / 740, the left column carrying the
- * orchestrator card, the scenario bars and the reasoning tabs, the right
- * column a 3x2 grid of agent cards, and a status bar at the bottom.
+ * **The Qt lineage ends here for the LAYOUT, and only for the layout.** Every
+ * string, colour and glyph below still comes out of `src/pitwall/agents_view/`,
+ * which is the Qt window's own code; what changed is where they sit. The port
+ * was a header strip, a 540 / 740 horizontal split with the decision in the
+ * left column and a 3x2 card grid in the right, and a status bar - `window.py`
+ * geometry, faithfully. Faithful is what was wrong with it: the split made the
+ * decision a PEER of the agent grid, two territories with no reading order, and
+ * the most important content on the window shared its column with a reasoning
+ * panel measured at 1.9 % ink.
  *
- * **One Qt bug fixes itself here.** The left column gave the reasoning
- * tabs about 268 px, so the decision-memory counterweight sentence fell
- * below the fold on the one lap it matters. CSS has no fixed heights.
+ * Four strata now, top to bottom: header, the DECISION BAND, the agent grid,
+ * status bar. The band answers one question per module, left to right, in the
+ * order a reader asks them - what are we doing, why, on what evidence, and what
+ * happens next - along the line the eye lands on anyway.
  *
  * Before the first view arrives the window renders what the Qt window
  * shows at startup, rather than a spinner. That is not the same as
@@ -31,12 +37,19 @@ import { AgentCard } from "./AgentCard";
 import { OrchestratorCard } from "./OrchestratorCard";
 import { ReasoningTabs } from "./ReasoningTabs";
 import { ScenarioBars } from "./ScenarioBars";
+import { PlanPanel } from "./PlanPanel";
 import { HeaderBar } from "./HeaderBar";
 import { PaceChart } from "./PaceChart";
 import { TireChart } from "./TireChart";
 import { useAgentsView, type AgentCardView, type AgentsView } from "../../lib/agents";
 
-/** Grid order, reading across then down, exactly as `window.py` adds them. */
+/**
+ * The six consoles, for the boot view's own card map.
+ *
+ * No longer a render order: the grid places them by name (`agents.css`'s
+ * `grid-template-areas`) because three of the six want a shape the reading
+ * order does not give them.
+ */
 const CARDS: ReadonlyArray<readonly [key: string, title: string]> = [
   ["pace", "Pace"],
   ["tire", "Tire"],
@@ -156,6 +169,33 @@ const IDLE_VIEW: AgentsView = {
   status_bar: { text: "Waiting for arcade stream…", transient: false },
 };
 
+/**
+ * One console in the grid.
+ *
+ * `chart` is a single optional node rather than two conditionals at the call
+ * site. Two of them made `children` an ARRAY OF NULLS for the four cards
+ * without a chart, and an array is truthy, so every text card rendered an
+ * empty `.agent-chart` - a 140 px min-height box holding nothing. That phantom
+ * box, not the grid, is what put 89-112 px of dead strip under four cards.
+ */
+function Console({
+  slot,
+  title,
+  card,
+  chart,
+}: {
+  slot: string;
+  title: string;
+  card: AgentCardView;
+  chart?: React.ReactNode;
+}) {
+  return (
+    <AgentCard title={title} card={card} slot={slot}>
+      {chart ?? null}
+    </AgentCard>
+  );
+}
+
 export function AgentsWindow() {
   const { view } = useAgentsView();
   const shown = view ?? IDLE_VIEW;
@@ -204,30 +244,57 @@ export function AgentsWindow() {
       <HeaderBar header={shown.header} frozen={frozen} />
 
       {/* Dimmed, not desaturated: the cards' colour is content here too - the
-          alarm red, the WARNING amber on a changed call, the confidence bar. */}
-      <div className={frozen ? "agents-split is-frozen" : "agents-split"}>
-        <div className="agents-left">
+          alarm red, the WARNING amber on a changed call, the confidence bar.
+
+          ONE class for this state, and it is the shipped one. The elevation
+          spec proposed a second, `.is-stale`, keyed off
+          `connection !== "Connected"` - which is also true for
+          "Connecting...", i.e. the whole ~11 s startup, and which would have
+          composed its `brightness()` with this one on a dead producer. Two
+          names for one state is this repo's dominant defect class. */}
+      <div className={frozen ? "agents-body is-frozen" : "agents-body"}>
+        {/* The decision band: what, how sure, why, and what happens next, in
+            one left-to-right sweep along the top of the window. It replaces a
+            540 px left column that made the decision a PEER of the agent grid
+            - two territories with no reading order, the most important content
+            sharing a column with the least. */}
+        <div className="agents-band">
           <OrchestratorCard view={shown.orchestrator} />
-          <ScenarioBars rows={shown.scenarios} />
           <ReasoningTabs tabs={shown.reasoning} />
+          <ScenarioBars rows={shown.scenarios} />
+          <PlanPanel plan={shown.orchestrator.plan} />
         </div>
-        <div className="agents-right">
-          {CARDS.map(([key, title]) => (
-            <AgentCard key={key} title={title} card={shown.cards[key] ?? IDLE_CARD}>
-              {/* ONE expression, not two conditionals. Two of them make
-                  `children` an ARRAY OF NULLS for the other four cards, and an
-                  array is truthy, so every text card rendered an empty
-                  `.agent-chart` — a 140 px min-height box holding nothing.
-                  That phantom box, not the grid, is what put 89-112 px of
-                  dead strip under four cards and pushed their bodies into a
-                  scroll with no scrollbar to show for it. */}
-              {key === "pace" ? (
-                <PaceChart series={shown.charts.pace} />
-              ) : key === "tire" ? (
-                <TireChart series={shown.charts.tire} />
-              ) : null}
-            </AgentCard>
-          ))}
+
+        {/* The six consoles below it, in named grid areas rather than source
+            order: the two chart cards take the tall slots, SITUATION and PIT
+            are compact and both feed the decision so they stack beside them,
+            and RADIO carries the wordiest content on the window - transcripts -
+            so it spans two columns.
+
+            SITUATION and PIT share ONE area through a stack rather than taking
+            a grid row each. Given a row each they sat at the top of two equal
+            cells and the leftover fell BETWEEN them, which reads as a card
+            that failed to load; stacked, the whole remainder is one block of
+            window background under the pair. */}
+        <div className="agents-grid">
+          <Console
+            slot="pace"
+            title="Pace"
+            card={shown.cards.pace ?? IDLE_CARD}
+            chart={<PaceChart series={shown.charts.pace} />}
+          />
+          <Console
+            slot="tire"
+            title="Tire"
+            card={shown.cards.tire ?? IDLE_CARD}
+            chart={<TireChart series={shown.charts.tire} />}
+          />
+          <div className="agents-side">
+            <Console slot="situation" title="Situation" card={shown.cards.situation ?? IDLE_CARD} />
+            <Console slot="pit" title="Pit" card={shown.cards.pit ?? IDLE_CARD} />
+          </div>
+          <Console slot="radio" title="Radio" card={shown.cards.radio ?? IDLE_CARD} />
+          <Console slot="rag" title="RAG" card={shown.cards.rag ?? IDLE_CARD} />
         </div>
       </div>
 

--- a/src/pitwall/ui/src/features/agents/OrchestratorCard.tsx
+++ b/src/pitwall/ui/src/features/agents/OrchestratorCard.tsx
@@ -1,6 +1,10 @@
 /**
- * The N31 decision panel: action badge, confidence, the two regime chips
- * and the plan line.
+ * The decision band's first module: what the orchestrator called, and how
+ * sure it is.
+ *
+ * The plan line moved to `PlanPanel` when the band replaced the left column:
+ * "what we are doing" and "what happens next" are two of the four questions
+ * the band answers in order, and they were sharing a card.
  *
  * 1:1 with `orchestrator_card.py`. Every string and colour is decided
  * host side, including the plan line's three branches, so the "stint
@@ -45,10 +49,6 @@ export function OrchestratorCard({ view }: { view: OrchestratorView }) {
           {view.risk}
         </span>
       </div>
-
-      {/* The plan line can carry a compound pill, which is an HTML span
-          built and escaped in src/arcade/palette.py. */}
-      <p className="orch-plan" dangerouslySetInnerHTML={{ __html: view.plan }} />
 
       {/* What changed since the last lap, which this window had no
           first-class answer to: everything else overwrites in place ten times

--- a/src/pitwall/ui/src/features/agents/PlanPanel.tsx
+++ b/src/pitwall/ui/src/features/agents/PlanPanel.tsx
@@ -1,0 +1,25 @@
+/**
+ * The decision band's fourth module: what happens next.
+ *
+ * Today it is the orchestrator's own plan line, moved out of the decision card
+ * and given a column of its own. The line is built host side and carries three
+ * branches - a scheduled stop, "stint continues · no pit window yet" on
+ * STAY_OUT with nothing tactical, and "Pit plan pending" otherwise - so the
+ * copy cannot quietly become three "--" chips here.
+ *
+ * It keeps `dangerouslySetInnerHTML` because the line can carry a compound
+ * pill, an HTML span built and escaped in `src/arcade/palette.py`. That is the
+ * last markup sink on this window's decision surface and it is the reason the
+ * pill has to become a typed segment before the card bodies do: a component
+ * that re-imports the path the migration is retiring makes the migration's
+ * claim false.
+ */
+
+export function PlanPanel({ plan }: { plan: string }) {
+  return (
+    <section className="card plan-panel">
+      <h2 className="band-title">PLAN</h2>
+      <p className="plan-caption" dangerouslySetInnerHTML={{ __html: plan }} />
+    </section>
+  );
+}

--- a/src/pitwall/ui/src/styles/agents.css
+++ b/src/pitwall/ui/src/styles/agents.css
@@ -1,11 +1,16 @@
-/* PITWALL · AGENTS — the Qt window's geometry, in CSS.
+/* PITWALL · AGENTS — a decision band over six specialist consoles.
  *
- * Every number here comes from a Qt call in the retired `src/arcade/dashboard/`:
- * the 44 px header (`HeaderBar.setFixedHeight`), the 540 / 740 split
- * (`splitter.setSizes`), the 10 px panel margins and 8 px spacing
- * (`setContentsMargins` / `setSpacing`), the card border and radius
- * (`theme.apply_dark_palette`'s `QFrame[card="true"]` rule), and the
- * font sizes on each widget.
+ * The chrome numbers are still the Qt window's, because they were never the
+ * problem: the 44 px header (`HeaderBar.setFixedHeight`), the 10 px panel
+ * margins and 8 px spacing (`setContentsMargins` / `setSpacing`), the card
+ * border and radius (`theme.apply_dark_palette`'s `QFrame[card="true"]` rule),
+ * and the font sizes on each widget.
+ *
+ * **The SHAPE is not.** The 540 / 740 split (`splitter.setSizes`) is gone with
+ * the column it described, and so is the `WindowSpec` width derived from it.
+ * What replaces it is four horizontal strata, sized by the client the window
+ * really gets - 1486x833, measured inside the real window rather than taken
+ * from the `WindowSpec`.
  *
  * The `--qt-*` tokens and the `body` rule moved to `qt-base.css` when the
  * DATA window needed the same palette in sprint 4. Pasting them into a
@@ -73,56 +78,139 @@
  * changed call, the confidence bar). `brightness()` scales all three channels
  * together, so nothing moves relative to anything else. The header strip and the
  * status bar stay at full strength: they carry the tells. */
-.agents-split.is-frozen {
+.agents-body.is-frozen {
   filter: brightness(0.72);
 }
 
-/* --- The split ---------------------------------------------------------- */
+/* --- The four strata ------------------------------------------------------
+ *
+ * header 44 · band · grid · status bar, inside 833 px of client. The band is
+ * `auto` and the grid is `1fr`, so the band takes what its content needs and
+ * the grid absorbs the remainder. Writing both as fixed pixel budgets is what
+ * the elevation spec proposed and it came out 5 px over the real height - a
+ * grid that takes the leftover cannot be over budget by construction. */
 
-.agents-split {
+.agents-body {
   display: grid;
-  /* 540 PIXELS, not 540fr. `setStretchFactor(0, 0)` pins the left panel
-   * and sends every extra pixel right; a proportional split grew it to
-   * 807 px at 1920, 267 px wider than Qt. The 740 was only ever the
-   * initial size of the half that stretches. */
-  grid-template-columns: 540px 1fr;
-  gap: 2px; /* QSplitter.setHandleWidth(2) */
+  grid-template-rows: auto 1fr;
+  gap: 8px;
+  padding: 10px;
+  box-sizing: border-box;
   flex: 1;
   min-height: 0;
 }
-.agents-left,
-.agents-right {
-  padding: 10px;
+
+/* --- The decision band ----------------------------------------------------
+ *
+ * Four modules in the order the reader's question unfolds: what we are doing,
+ * why, on what evidence, and what happens next.
+ *
+ * The three fixed columns are budgeted against the client's real inner width
+ * (1486 − 20 px padding = 1466), which leaves PLAN 482 px of `1fr`. They are
+ * pixels rather than fractions for the same reason Qt's left panel was: the
+ * first three carry a known amount of text and the fourth is the one that
+ * should absorb width, so a proportional split would grow the wrong three. */
+
+.agents-band {
   display: grid;
+  grid-template-columns: 340px 290px 330px 1fr;
   gap: 8px;
   min-height: 0;
-  overflow: auto;
 }
-.agents-left {
-  /* Orchestrator and scenarios size to content; the reasoning tabs take
-   * what their text needs and no more. In Qt they took the rest, which
-   * left ~268 px and dropped the decision-memory block below the fold;
-   * here the opposite happened - the largest bordered surface in the
-   * window carried five short lines at 1.9 % ink, 318 px of it empty.
-   * An empty bordered panel reads as content missing; the leftover is
-   * honest window background instead. */
-  grid-template-rows: auto auto minmax(180px, max-content);
-  align-content: start;
+.band-title {
+  margin: 0 0 6px;
+  color: var(--qt-fg-2);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 1px;
 }
-.agents-right {
-  grid-template-columns: 1fr 1fr;
-  /* Qt's own caps were `agent_card.py:70-72`: a text card 140-260, and
-   * `attach_chart` bumping the two with charts to 260-420. The grid is a
-   * fixed 3x2, so the three rows are written out rather than inferred.
-   *
-   * The two text rows size to CONTENT rather than toward a 260 px cap.
-   * Handing height out by grid position left four cards 44-57 % dead
-   * strip - a reader scanning past ~100 px of panel-coloured nothing to
-   * reach the next headline - while the two charts, the densest surfaces
-   * here, sat at 319 px in a row that could go to 420. Density is
-   * hierarchy on a glance surface, so the surplus goes to row 1, which
-   * is also where the tyre chart needs it. */
-  grid-template-rows: minmax(260px, 1fr) minmax(140px, max-content) minmax(140px, max-content);
+.plan-panel {
+  padding: 10px 14px;
+  min-width: 0;
+}
+.plan-caption {
+  margin: 0;
+  color: var(--qt-fg-2);
+  font-size: 12px;
+}
+
+/* --- The agent grid -------------------------------------------------------
+ *
+ * Named areas rather than source order, because three of the six want a shape
+ * the reading order does not give them: the two chart cards need the tall
+ * slots, SITUATION and PIT are compact and both feed the decision so they
+ * stack beside them, and RADIO carries the wordiest content on the window -
+ * transcripts - so it spans two columns.
+ *
+ * Rows 1 and 2 are `minmax(0, 1fr)` so the chart column splits the available
+ * height evenly with the two stacked cards; row 3 is content-sized with a
+ * floor. `minmax(0, …)` rather than `1fr` alone: a `1fr` row has an automatic
+ * MINIMUM of its content, so a card that overflows pushes the grid past its
+ * container instead of scrolling inside itself. */
+
+.agents-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-rows: minmax(0, 1fr) auto;
+  grid-template-areas:
+    "pace tire side"
+    "radio radio rag";
+  gap: 8px;
+  min-height: 0;
+}
+.slot-pace {
+  grid-area: pace;
+}
+.slot-tire {
+  grid-area: tire;
+}
+/* The stack that holds SITUATION over PIT, so the column's leftover is one
+ * block under the pair rather than a gap between them. */
+.agents-side {
+  grid-area: side;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 0;
+}
+/* **`min-height: 0`, or a long card leaves the window entirely.** A flex item's
+ * automatic minimum is its content, so a console with more lines than the
+ * column has room for cannot shrink - and `.agent-card` is deliberately
+ * `overflow: visible` so nothing can clip its tooltip, so it does not scroll
+ * either: it simply renders past the bottom of the client. Measured on the
+ * smoke's own fixture, PIT ran 384 px past a 833 px client while every stratum
+ * still summed to exactly 833, which is why the check that caught it asserts
+ * the DOCUMENT rather than the panels.
+ *
+ * With the minimum lifted the pair share the column and each body scrolls,
+ * which is this window's own rule: `qt-base.css` hides the scrollBAR and keeps
+ * the body reachable. */
+.agents-side > .agent-card {
+  min-height: 0;
+}
+.slot-radio {
+  grid-area: radio;
+}
+.slot-rag {
+  grid-area: rag;
+}
+
+/* **Size the CARD, not the cell.** A grid cell stretches its item by default,
+ * so the four text consoles took whatever height their row was handed and
+ * carried the difference as dead strip inside a bordered panel - 44-57 % of
+ * the card on the layout this replaces, and the reason sprint 8 made the rows
+ * content-sized in the first place. An empty bordered panel reads as content
+ * missing; window background does not read as anything.
+ *
+ * The two chart consoles are the exception and stretch on purpose: a chart
+ * has no natural height and the density is the point. */
+.agents-grid > .agent-card {
+  align-self: start;
+  max-height: 100%;
+}
+.agents-grid > .slot-pace,
+.agents-grid > .slot-tire {
+  align-self: stretch;
 }
 
 /* --- Cards -------------------------------------------------------------- */
@@ -343,11 +431,6 @@
   font-size: 12px;
   font-weight: 700;
 }
-.orch-plan {
-  margin: 0;
-  color: var(--qt-fg-2);
-  font-size: 12px;
-}
 /* The previous call, on the lap this one replaced it. Tertiary text with a
  * WARNING dot: it is a CHANGE, which is worth noticing, and not a fault,
  * which is what the alarm colour one line below means. */
@@ -439,18 +522,18 @@
   white-space: pre;
 }
 
-/* The reasoning tabs land here in PR 5; the slot keeps the column's
- * `auto auto 1fr` honest in the meantime. */
-.reasoning-slot {
-  min-height: 0;
-}
-
 /* --- Reasoning tabs (reasoning_tabs.py) ---------------------------------- */
 
+/* The band's WHY slot, until the module that replaces it lands. It is a card
+ * now rather than a bare panel, so it reads as one of the four modules. */
 .reasoning {
   display: flex;
   flex-direction: column;
   min-height: 0;
+  overflow: hidden;
+}
+.reasoning-tabbar {
+  flex-wrap: wrap;
 }
 .reasoning-tabbar {
   display: flex;


### PR DESCRIPTION
## What

The AGENTS window becomes four horizontal strata: header, a full-width **decision band**, an agent
grid, status bar. The 540 / 740 Qt split and the left column go with it.

```
+-------------------------------------------------------------------------------+
| Melbourne · 2025  NOR                 [Connected] [2.00x · PLAYING] [L 23/57]  | 44
+-------------------------------------------------------------------------------+
| +- CALL ------+ +- WHY -------+ +- SCENARIOS ---+ +- PLAN ------------------+  | 159
| |             | |             | |               | |                         |  |
+-------------------------------------------------------------------------------+
| +- @ PACE --------+ +- @ TIRE --------+ +- @ SITUATION -------------------+    |
| |                 | |                 | +---------------------------------+    |
| |     chart       | |     chart       | +- @ PIT -------------------------+    | 580
| |                 | |                 | +---------------------------------+    |
| +-----------------+ +-----------------+                                        |
| +- @ RADIO (spans two) ---------------+ +- @ RAG -----------------------+       |
+-------------------------------------------------------------------------------+
| lap 23 · streaming                                                            | 23
+-------------------------------------------------------------------------------+
```

## Why

The split made the decision a PEER of the agent grid: two territories, no reading order, and the
most important content on the window sharing a column with a reasoning panel measured at 1.9 % ink.
A band puts the four questions a reader asks - what are we doing, why, on what evidence, what
happens next - in one left-to-right sweep along the line the eye lands on anyway, and everything
below it becomes drill-down.

## How

- `AgentsWindow.tsx`: `.agents-split` → `.agents-body` holding `.agents-band` + `.agents-grid`.
  The six consoles are placed by NAME (`grid-template-areas`) rather than by source order, because
  three of them want a shape the reading order does not give them.
- `PlanPanel.tsx` is new and holds the plan line, which moved out of the decision card: "what we
  are doing" and "what happens next" are two of the band's four questions and they were sharing a
  card.
- `ReasoningTabs` keeps the WHY slot for now. It is cramped there, deliberately: moving its content
  is the next PR's subject and nothing is lost in the meantime.
- `AgentCard` gains a `slot` prop rendered as a `slot-*` class, so the whole shape lives in the
  stylesheet rather than half of it in an inline style the layout checks cannot read.

### Two things the layout got wrong first, both caught by measurement

**SITUATION and PIT took a grid row each.** Content-sized cards at the top of two equal cells put
the leftover BETWEEN them, which reads as a card that failed to load. They share one area through a
stack now, so the remainder is one block of window background under the pair.

**The cards were sized by their cell.** Stretching them is what put 44-57 % dead strip inside
bordered panels on the layout sprint 8 fixed, so `align-self: start` sizes the card and the two
chart consoles stretch on purpose - a chart has no natural height and the density is the point.

## The check the old harness could not make

`smoke-agents.mjs` ran at 1320x900, 67 px taller than the real client, so a layout that did not fit
could not fail there. It now runs at 1486x833 (#1009) and asserts the document, not the panels:

```
the window fits its client ({"vertical":384,"horizontal":0,"client":833,
  "past":[{"what":"section.card.agent-card.slot-pit","over":384}, …],
  "strata":{"header":44,"band":160,"grid":578,"status":23}})
```

That failure is this PR's own first draft. **Every stratum summed to exactly 833 and the window
still overflowed by 384 px**, because a flex item's automatic minimum is its content: PIT could not
shrink, and `.agent-card` is deliberately `overflow: visible` so nothing can clip its tooltip, so it
did not scroll either. It simply rendered past the bottom of the client. `min-height: 0` on the
stack's children fixes it; the failure message names the offending element because "it does not fit"
is not actionable.

## Verified

- `tests/surfaces/` 248 passed. `npm run typecheck` clean.
- `smoke-agents` **30 checks**, up from 22: the 540 px assertion died with the column it described
  and eight took its place - four modules on one row in reading order, PLAN absorbing the width, the
  six consoles by rendered geometry, and the document fitting its client.
- **The real windows opened and probed** with `evaluate_js`, not a headless capture:
  `{"inner":[1486,833],"overflowY":0,"overflowX":0,"strata":[["​.header-bar",44],[".agents-band",159],
  [".agents-grid",580],[".status-bar",23]],"bandModules":4,"consoles":6}`.
- Five states captured at 1486x833 and looked at: live, conditional agents idle, an unenacted
  winner, an empty `per_agent`, and a dead producer. The frozen treatment survives the relayout on
  `.agents-body`.

## Still to come, in this sprint

The CALL module is still a filled red pill, the WHY slot is still the six tabs, and PLAN holds one
line of text in 482 px. Those are the next three PRs: the banner, the WHY module, and the plan
timeline.


Closes #1014
