### PR TITLE
feat(agents): the action is text on the panel, not a filled button

### DIFF
--- a/src/pitwall/agents_view/decision.py
+++ b/src/pitwall/agents_view/decision.py
@@ -28,7 +28,6 @@ from src.arcade.palette import (
     WARNING,
     compound_pill_html,
     hex_str,
-    readable_on,
 )
 from src.arcade.strategy import classify_action
 
@@ -185,10 +184,9 @@ def build_orchestrator(
         return {
             "action": "--",
             "action_colour": hex_str(TEXT_TERTIARY),
-            "action_text_colour": hex_str(readable_on(TEXT_TERTIARY)),
             "confidence": None,
             "confidence_fill": 0.0,
-            "confidence_label": "Confidence: --",
+            "confidence_text": "--",
             "confidence_colour": hex_str(TEXT_TERTIARY),
             "pace": "Pace: --",
             "pace_colour": hex_str(TEXT_TERTIARY),
@@ -206,13 +204,12 @@ def build_orchestrator(
 
     return {
         "action": badge_label,
+        # There is no `action_text_colour` beside it any more. That field
+        # existed to pick a readable ink for the badge's FILL - white measured
+        # 2.54:1 on SUCCESS - and the band's banner has no fill: the action is
+        # text in this colour on `--qt-panel`, where all seven of
+        # `_ACTION_STYLE`'s colours plus the ACCENT fallback clear AA.
         "action_colour": hex_str(badge_colour),
-        # The badge's own text colour, decided here rather than fixed to
-        # white in the renderer. White on SUCCESS measures 2.54:1, so the
-        # single most important element on the screen failed AA in the one
-        # state - a guardrail veto - where a strategist most needs to read
-        # it. `readable_on` picks whichever ground actually contrasts.
-        "action_text_colour": hex_str(readable_on(badge_colour)),
         "confidence": confidence,
         # The bar's width, to the 0.1 % Qt's gradient stop resolves to
         # (`orchestrator_card.py::_bar_style` rounds the stop to 3 dp).
@@ -220,7 +217,11 @@ def build_orchestrator(
         # coarser and the exact kind of arithmetic the view exists to
         # keep out of the renderer.
         "confidence_fill": round(min(1.0, max(0.0, confidence)) * 100, 1),
-        "confidence_label": f"Confidence: {confidence * 100:.0f}%",
+        # The numeral alone. It used to ship as `Confidence: 71%`, one string
+        # carrying a caption and a measurement, which the band renders at two
+        # different sizes: the caption is chrome and belongs to the stylesheet,
+        # the number is data and belongs here.
+        "confidence_text": f"{confidence * 100:.0f}%",
         "confidence_colour": hex_str(_confidence_colour(confidence)),
         "pace": f"Pace: {pace_mode or '--'}",
         "pace_colour": hex_str(_PACE_COLOURS.get(str(pace_mode or "").upper(), TEXT_TERTIARY)),

--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -61,7 +61,7 @@ const VIEW = {
     action_colour: "#ef4444",
     confidence: 0.71,
     confidence_fill: 71.0,
-    confidence_label: "Confidence: 71%",
+    confidence_text: "71%",
     confidence_colour: "#10b981",
     pace: "Pace: PUSH",
     pace_colour: "#ef4444",
@@ -276,6 +276,63 @@ check(
 check(
   band.widths[3] > Math.max(band.widths[0], band.widths[1], band.widths[2]),
   `PLAN absorbs the width (${band.widths})`,
+);
+
+// --- The action is text, not a button ---------------------------------------
+//
+// It was a 200x70 filled pill: 14,000 px2 of the action's colour, which for
+// PIT_NOW is the same DANGER red that means a fault everywhere else on the
+// window. Asserted as PAINTED AREA rather than as "the pill class is gone",
+// because the class going away is not the point and a differently-named fill
+// would pass that.
+const banner = await page.evaluate(() => {
+  const action = document.querySelector(".orch-action");
+  const card = document.querySelector(".orchestrator");
+  const style = getComputedStyle(action);
+  const cardStyle = getComputedStyle(card);
+  const rect = action.getBoundingClientRect();
+  const bandText = [...document.querySelectorAll(".agents-band *")]
+    .map((el) => parseFloat(getComputedStyle(el).fontSize))
+    .filter((size) => Number.isFinite(size));
+  return {
+    colour: style.color,
+    fill: style.backgroundColor,
+    rule: cardStyle.borderLeftColor,
+    ruleWidth: parseFloat(cardStyle.borderLeftWidth),
+    size: parseFloat(style.fontSize),
+    // Every distinct type size in the band, largest first. Comparing against
+    // "the largest OTHER size" put the confidence numeral in its own
+    // comparison set and asked whether 22 > 22.
+    ranks: [...new Set(bandText)].sort((a, b) => b - a),
+    confidence: parseFloat(getComputedStyle(document.querySelector(".orch-conf-value")).fontSize),
+    painted: Math.round(rect.width * rect.height),
+    cardHeight: Math.round(card.getBoundingClientRect().height),
+  };
+});
+// A transparent or fully-unset background is what "no fill" looks like in
+// computed style; anything else is a painted rectangle.
+check(
+  banner.fill === "rgba(0, 0, 0, 0)" || banner.fill === "transparent",
+  `the action carries no fill (${banner.fill})`,
+);
+check(
+  banner.colour === banner.rule,
+  `the rule and the word carry one identity colour (${banner.colour} vs ${banner.rule})`,
+);
+// The identity survives at the rule's area instead of the pill's. 4 px times
+// the card height against the 14,000 px2 the badge painted.
+check(
+  banner.ruleWidth * banner.cardHeight < 0.1 * 14000,
+  `the identity colour is painted at a fraction of the badge's area (${
+    Math.round(banner.ruleWidth * banner.cardHeight)
+  } px2)`,
+);
+// The pair reads as one unit: what, and how much to trust it. The confidence
+// number used to render at 11 px, the size of an axis tick, beside a 26 px
+// word - so the window's two most decisive values sat five ranks apart.
+check(
+  banner.ranks[0] === banner.size && banner.ranks[1] === banner.confidence,
+  `the action and its confidence are the band's top two type ranks (${banner.ranks})`,
 );
 
 // The consoles, by rendered geometry rather than by class name: a card can

--- a/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
@@ -89,12 +89,9 @@ const IDLE_VIEW: AgentsView = {
     action: "--",
     // ACCENT: `orchestrator_card.py:100` styles the badge at construction.
     action_colour: "#a78bfa",
-    // Dark on the accent fill, as `readable_on` picks for the live badge:
-    // white measured 2.72:1 here.
-    action_text_colour: "#121127",
     confidence: null,
     confidence_fill: 0,
-    confidence_label: "Confidence: --",
+    confidence_text: "--",
     confidence_colour: "#9ca3af",
     pace: "Pace: --",
     pace_colour: "#9ca3af",

--- a/src/pitwall/ui/src/features/agents/OrchestratorCard.tsx
+++ b/src/pitwall/ui/src/features/agents/OrchestratorCard.tsx
@@ -6,49 +6,58 @@
  * "what we are doing" and "what happens next" are two of the four questions
  * the band answers in order, and they were sharing a card.
  *
- * 1:1 with `orchestrator_card.py`. Every string and colour is decided
- * host side, including the plan line's three branches, so the "stint
- * continues · no pit window yet" copy cannot quietly become three "--"
- * chips here.
+ * **The action sheds its button costume.** It was a 200x70 px filled pill with
+ * a 10 px radius, centred - the geometry of a primary call-to-action, on a
+ * surface where nothing can be pressed. Filled, it also made the action the
+ * largest painted colour on the window, so a red `PIT NOW` out-alarmed the
+ * actual alarms: the same DANGER red that means a fault elsewhere was carrying
+ * an identity here, at ten times the area.
+ *
+ * Now it is text in `action_colour` on the panel, with a 4 px rule of the same
+ * colour down the card's left edge. The identity survives at a fraction of the
+ * painted area, and every action colour clears AA as text on `--qt-panel`
+ * (#181633) - DANGER 4.64:1, INFO 4.75, ACCENT 6.42, SUCCESS 6.89, WARNING
+ * 8.14, and TEXT_SECONDARY for DNF far above. Which is why
+ * `action_text_colour` is gone: it existed to pick a readable ink for the
+ * FILL, and there is no fill.
+ *
+ * The banner is bounded (`nowrap` + ellipsis) because `classify_action` falls
+ * back to echoing the raw string for anything outside its seven, and an
+ * unknown producer word at 32 px/800 is unbounded.
  */
 
 import type { OrchestratorView } from "../../lib/agents";
 
 export function OrchestratorCard({ view }: { view: OrchestratorView }) {
   return (
-    <section className="card orchestrator">
-      <div className="orch-top">
-        {/* The text colour comes from the host too. Fixed to white here it
-            measured 2.54:1 on the SUCCESS fill — the primary decision, below
-            AA, in the state where the orchestrator has just overruled the
-            Monte Carlo winner. */}
-        <div
-          className="orch-badge"
-          style={{ background: view.action_colour, color: view.action_text_colour }}
-        >
-          {view.action}
+    <section className="card orchestrator" style={{ borderLeftColor: view.action_colour }}>
+      <p className="orch-action" style={{ color: view.action_colour }}>
+        {view.action}
+      </p>
+
+      <div className="orch-conf">
+        <span className="orch-conf-value" style={{ color: view.confidence_colour }}>
+          {view.confidence_text}
+        </span>
+        {/* A div rather than <progress>: Qt paints a flat two-stop bar and
+            the native element brings a platform look that is not it. */}
+        <div className="orch-bar">
+          <div
+            className="orch-bar-fill"
+            style={{ width: `${view.confidence_fill}%`, background: view.confidence_colour }}
+          />
         </div>
-        <div className="orch-conf">
-          <span className="orch-conf-label">{view.confidence_label}</span>
-          {/* A div rather than <progress>: Qt paints a flat two-stop bar and
-              the native element brings a platform look that is not it. */}
-          <div className="orch-bar">
-            <div
-              className="orch-bar-fill"
-              style={{ width: `${view.confidence_fill}%`, background: view.confidence_colour }}
-            />
-          </div>
-        </div>
+        <span className="orch-conf-caption">CONFIDENCE</span>
       </div>
 
-      <div className="orch-chips">
-        <span className="orch-chip" style={{ color: view.pace_colour, borderColor: view.pace_colour }}>
-          {view.pace}
-        </span>
-        <span className="orch-chip" style={{ color: view.risk_colour, borderColor: view.risk_colour }}>
-          {view.risk}
-        </span>
-      </div>
+      {/* Two facts, not two chips. The outline-pill costume died with the
+          filled one: both said "press me" on a surface with nothing to press,
+          and the words carry the meaning on their own. */}
+      <p className="orch-facts">
+        <span style={{ color: view.pace_colour }}>{view.pace}</span>
+        <span className="orch-facts-sep"> · </span>
+        <span style={{ color: view.risk_colour }}>{view.risk}</span>
+      </p>
 
       {/* What changed since the last lap, which this window had no
           first-class answer to: everything else overwrites in place ten times

--- a/src/pitwall/ui/src/lib/agents.ts
+++ b/src/pitwall/ui/src/lib/agents.ts
@@ -75,14 +75,14 @@ export interface TireHistoryRow {
 
 export interface OrchestratorView {
   action: string;
+  /** Carried as TEXT on the panel, not as a fill: every value clears AA there. */
   action_colour: string;
-  /** The badge's TEXT colour, chosen host side against the fill (WCAG). */
-  action_text_colour: string;
   /** null before the first decision; the bar then draws empty. */
   confidence: number | null;
   /** The bar's width in per cent, already clamped and rounded host side. */
   confidence_fill: number;
-  confidence_label: string;
+  /** The numeral alone (`71%` / `--`); the caption beside it is chrome. */
+  confidence_text: string;
   confidence_colour: string;
   pace: string;
   pace_colour: string;

--- a/src/pitwall/ui/src/styles/agents.css
+++ b/src/pitwall/ui/src/styles/agents.css
@@ -374,62 +374,70 @@
 
 /* --- Orchestrator card (orchestrator_card.py) ---------------------------- */
 
+/* The 4 px rule is the identity colour's second, quieter home: the inline
+ * `border-left-color` is the action's own colour, so the module is marked
+ * without anything being painted. */
 .orchestrator {
-  padding: 12px 14px;
+  padding: 12px 14px 12px 12px;
+  border-left: 4px solid transparent;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 8px;
+  min-width: 0;
 }
-.orch-top {
-  display: flex;
-  gap: 14px;
-  align-items: center;
-}
-.orch-badge {
-  min-width: 200px;
-  min-height: 70px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 10px;
-  padding: 14px 18px;
-  /* Fallback only. The live colour is inline, decided against the fill by
-   * `readable_on`, because a fixed white measured 2.54:1 on SUCCESS. */
-  color: var(--qt-fg-1);
-  font-size: 26px;
+
+/* **Bounded on purpose.** `classify_action` maps seven actions and falls back
+ * to echoing the raw string, so an unknown producer word arrives here at
+ * 32 px/800 with no upper length. Seven of the seven fit (UNDERCUT is the
+ * widest at 179 px against ~308 px of inner width); the eighth is whatever a
+ * future producer sends. */
+.orch-action {
+  margin: 0;
+  font-size: 32px;
   font-weight: 800;
   letter-spacing: 1px;
-  text-align: center;
+  line-height: 1.1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .orch-conf {
-  flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 3px;
 }
-.orch-conf-label {
-  color: var(--qt-fg-2);
-  font-size: 11px;
+/* Promoted from 11 px to the same visual rank as the word it qualifies: the
+ * action and its confidence are one unit, and the number used to render at
+ * the size of an axis tick. */
+.orch-conf-value {
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1;
+}
+.orch-conf-caption {
+  color: var(--qt-fg-3);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 1px;
 }
 .orch-bar {
-  height: 14px;
-  border-radius: 6px;
+  height: 8px;
+  border-radius: 4px;
   background: #282834; /* the empty stop of Qt's gradient */
   overflow: hidden;
 }
 .orch-bar-fill {
   height: 100%;
 }
-.orch-chips {
-  display: flex;
-  gap: 8px;
-}
-.orch-chip {
-  padding: 4px 10px;
-  border: 1px solid currentColor;
-  border-radius: 10px;
+/* Plain text. These were outline pills, which is a button costume on a surface
+ * where nothing can be pressed, and they are facts: a posture somebody chose,
+ * not a state to act on. */
+.orch-facts {
+  margin: 0;
   font-size: 12px;
-  font-weight: 700;
+}
+.orch-facts-sep {
+  color: var(--qt-fg-3);
 }
 /* The previous call, on the lap this one replaced it. Tertiary text with a
  * WARNING dot: it is a CHANGE, which is worth noticing, and not a fault,

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -74,6 +74,30 @@ def test_the_badge_builders_escape_what_comes_off_the_wire():
     assert "&lt;" in flag_chip_html("A<B")
 
 
+def _qt_token(name: str) -> str:
+    """One `--qt-*` value, read out of the stylesheet that declares it.
+
+    Not a hex written here. The ground the action is drawn on is a CSS custom
+    property, and a copy of it in this file would be one more site to drift -
+    which is the whole subject of `test_pitwall_tokens.py` next door.
+    """
+    import re
+    from pathlib import Path
+
+    css = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "pitwall"
+        / "ui"
+        / "src"
+        / "styles"
+        / "qt-base.css"
+    ).read_text(encoding="utf-8")
+    match = re.search(rf"{re.escape(name)}:\s*(#[0-9a-fA-F]{{6}})", css)
+    assert match, f"{name} is not declared in qt-base.css"
+    return match.group(1).lower()
+
+
 def _rendered_pair(span: str) -> tuple[str, str]:
     """The `(background, foreground)` a pill span actually carries."""
     import re
@@ -119,18 +143,26 @@ def test_every_pill_and_badge_is_legible_against_its_own_fill():
         ratio = contrast_ratio(rgb(background), rgb(foreground))
         assert ratio >= 4.5, f"{name}: {foreground} on {background} is {ratio:.2f}:1"
 
-    # The badge takes the same treatment through the view, for every action
-    # `classify_action` knows plus the fallback.
+    # The action takes the same treatment, against the ground it is now drawn
+    # on. It used to be a fill with an ink chosen against it; the band renders
+    # it as TEXT on `--qt-panel`, so the pair that has to contrast is the
+    # action colour and the card.
+    #
+    # **Over `_ACTION_STYLE` itself, not a hand-written list.** The old version
+    # named five actions; the map holds SEVEN (DNF and ERROR are display states
+    # the producer really emits) plus an unknown-key fallback that echoes the
+    # raw string in ACCENT. A guard that asserts about part of an enumeration
+    # is how the two missing ones would have stayed missing.
+    from src.arcade.strategy import _ACTION_STYLE
     from src.pitwall.agents_view.decision import build_orchestrator
 
-    for action in ("PIT_NOW", "STAY_OUT", "UNDERCUT", "OVERCUT", "SOMETHING_ELSE"):
+    panel = rgb(_qt_token("--qt-panel"))
+    for action in (*_ACTION_STYLE, "SOMETHING_A_FUTURE_PRODUCER_SENDS"):
         built = build_orchestrator({"action": action, "confidence": 0.5})
-        ratio = contrast_ratio(rgb(built["action_colour"]), rgb(built["action_text_colour"]))
-        assert ratio >= 4.5, f"{action}: {ratio:.2f}:1"
+        ratio = contrast_ratio(rgb(built["action_colour"]), panel)
+        assert ratio >= 4.5, f"{action}: {built['action_colour']} on the panel is {ratio:.2f}:1"
     idle = build_orchestrator(None)
-    assert contrast_ratio(rgb(idle["action_colour"]), rgb(idle["action_text_colour"])) >= 4.5, (
-        "the idle badge too"
-    )
+    assert contrast_ratio(rgb(idle["action_colour"]), panel) >= 4.5, "the idle action too"
 
 
 def test_the_tooltips_return_data_and_never_markup():
@@ -549,7 +581,7 @@ def test_the_orchestrator_card_is_the_qt_one_field_for_field():
 
     assert view["action"] == "PIT NOW"
     assert view["action_colour"] == "#ef4444"
-    assert view["confidence_label"] == "Confidence: 71%"
+    assert view["confidence_text"] == "71%"
     assert view["confidence_colour"] == "#10b981", "0.71 is over the 0.66 green tier"
     assert view["pace"] == "Pace: PUSH"
     # Text colour, not DANGER: a posture is a setting somebody chose, and

--- a/tests/surfaces/test_pitwall_tokens.py
+++ b/tests/surfaces/test_pitwall_tokens.py
@@ -227,11 +227,16 @@ BOOT_SLOTS = {
     "trend_colour": "TEXT_PRIMARY",
     "cliff_colour": "WARNING",
     "boundary_colour": "TEXT_TERTIARY",
-    # Sprint 8's two additions. The map is a SUBSET assertion, so a new boot
-    # colour it does not name is invisible to it: flipping the badge's text
-    # back to white - 2.72:1 on the accent fill, the failure #965 fixed -
-    # left every check green until these two lines existed.
-    "action_text_colour": "BG_COLOR",
+    # Sprint 8's addition. The map is a SUBSET assertion, so a new boot colour
+    # it does not name is invisible to it - which is why every slot that exists
+    # has to be listed here rather than only the interesting ones.
+    #
+    # `action_text_colour` sat here too, mapped to BG_COLOR, until the decision
+    # band stopped painting the action as a FILL. Text on `--qt-panel` needs no
+    # chosen ink, so the field has no consumer and no boot literal; what
+    # replaces the guarantee is the contrast assertion in
+    # `test_pitwall_agents_view.py`, which now runs the action colour against
+    # the panel over the whole of `_ACTION_STYLE` plus its fallback.
     "cursor_colour": "TEXT_TERTIARY",
 }
 


### PR DESCRIPTION
## What

The action sheds its button costume. It was a 200x70 px filled pill with a 10 px radius, centred:
the geometry of a primary call-to-action, on a surface where nothing can be pressed. It is now text
in `action_colour` on the panel, with a 4 px rule of the same colour down the card's left edge.

The confidence numeral is promoted from 11 px to 22 px beside it, and the two posture chips become a
plain facts line.

## Why

Filled, the action was the largest painted colour on the window, so a red `PIT NOW` out-alarmed the
actual alarms: the same DANGER red that means a fault everywhere else was carrying an *identity*
here, at ten times the area. Measured: **14,000 px² of the pill against 452 px² of the rule.**

And the pair that decides is the action and its confidence. The confidence rendered at 11 px, the
size of an axis tick, beside a 26 px word, so the window's two most decisive values sat five type
ranks apart. They are the top two ranks now.

## How

- `OrchestratorCard.tsx`: the badge becomes `.orch-action`, the card takes an inline
  `border-left-color`, the chips become `.orch-facts`.
- **`action_text_colour` is deleted, not kept for compatibility.** It existed to pick a readable ink
  for the FILL, chosen by `readable_on` because a fixed white measured 2.54:1 on SUCCESS. With no
  fill it has no consumer, and a typed field written by nothing is what #974 was about two PRs ago.
  Every action colour clears AA as text on `--qt-panel`: DANGER 4.64:1, INFO 4.75, ACCENT 6.42,
  SUCCESS 6.89, WARNING 8.14.
- **`confidence_label` becomes `confidence_text`**, the numeral alone. One string carrying a caption
  and a measurement cannot render at two sizes; the caption is chrome and belongs to the stylesheet,
  the number is data and stays host side. One field, not two.
- The banner is `nowrap` + ellipsis, because `classify_action` maps seven actions and then falls
  back to echoing the raw string, and an unknown producer word at 32 px/800 has no upper length.

## The contrast guard now covers the whole enumeration

It named five actions. `_ACTION_STYLE` holds **seven** - `DNF` and `ERROR` are display states the
producer really emits - plus an unknown-key fallback in ACCENT. It iterates the map itself now, with
one unknown-key probe, against `--qt-panel` read out of `qt-base.css` rather than written into the
test as a hex.

## Checks

`tests/surfaces/` 248 passed. `npm run typecheck` clean. `ruff check .` and `format --check .` clean.
`smoke-agents` **36 checks**, up from 32 on `dev`, all asserting the effect:

- the action carries no fill (computed `background-color` is transparent),
- the rule and the word carry one identity colour,
- that colour is painted at under a tenth of the badge's 14,000 px²,
- the action and its confidence are the band's top two type ranks.

Driven red by putting the pill's costume back in `agents.css` from a scratch copy: `the action
carries no fill (rgb(239, 68, 68))`. Restored with `cp` + `cmp`, verified byte-identical, rebuilt
and re-run green.

The first draft of the rank check compared the confidence numeral against "the largest OTHER size in
the band", which put it in its own comparison set and asked whether 22 > 22. It ranks the distinct
sizes instead.

Captured at 1486x833 and looked at.


Closes #1016
