### PR TITLE
feat(agents): every console carries its model detail, reachable without a mouse

### DIFF
--- a/src/pitwall/agent_formatters.py
+++ b/src/pitwall/agent_formatters.py
@@ -44,6 +44,7 @@ from src.arcade.palette import (
     compound_pill_html,
     flag_chip_html,
 )
+from src.pitwall.reasoning_lines import agent_metrics, agent_reasoning
 
 # Status tokens consumed by AgentCard.set_status
 STATUS_OK: str = "OK"
@@ -367,6 +368,60 @@ def radio_tooltip(r: dict[str, Any] | None) -> dict[str, Any] | None:
             }
         )
     return {"sections": sections, "footer": None}
+
+
+def model_detail_sections(key: str, block: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """What the reasoning tab showed for one agent, as tooltip sections.
+
+    Two of them, and BOTH halves matter. The card says `Δnext -0.204s (81.00s)`
+    in operational language; the tab said that in `key = value` form AND
+    carried the agent's own sentences above it. A move that took only the
+    numbers would have dropped every agent's explanation of WHY off the window
+    entirely, on the runs where an agent produces one - which is every run with
+    an LLM.
+
+    Composed from `reasoning_lines`' own halves rather than re-derived here, so
+    there is one definition of what an agent's body is (`agent_body` is the
+    same pair joined for the tab).
+
+    The metric rows split on their first `=` into lead and value. The padding
+    that aligns them is for a monospace block; a tooltip lays the pair out
+    itself, so it goes.
+    """
+    reasoning = agent_reasoning(block)
+    metrics = agent_metrics(key, block)
+
+    sections: list[dict[str, Any]] = []
+    if reasoning:
+        sections.append({"title": "Reasoning", "rows": [{"lead": "", "text": reasoning}]})
+    if metrics:
+        rows = []
+        for line in metrics:
+            lead, separator, value = line.partition("=")
+            if separator:
+                rows.append({"lead": lead.strip(), "text": value.strip()})
+            else:
+                rows.append({"lead": "", "text": line.strip()})
+        sections.append({"title": "Model detail", "rows": rows})
+    return sections
+
+
+def with_model_detail(
+    tooltip: dict[str, Any] | None, key: str, block: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Append an agent's model detail to whatever tooltip it already had.
+
+    Appended rather than replacing, because two of the six already carry
+    content the tab never did - RADIO's whole lap of messages, RAG's question
+    and chunks - and that is the drill-down tier this joins rather than
+    supersedes.
+    """
+    sections = model_detail_sections(key, block)
+    if not sections:
+        return tooltip
+    if tooltip is None:
+        return {"sections": sections, "footer": None}
+    return {"sections": [*tooltip["sections"], *sections], "footer": tooltip.get("footer")}
 
 
 def format_radio(r: dict[str, Any] | None) -> Formatted:

--- a/src/pitwall/agents_view/panels.py
+++ b/src/pitwall/agents_view/panels.py
@@ -37,6 +37,7 @@ from src.pitwall.agent_formatters import (
     format_tire,
     radio_tooltip,
     rag_tooltip,
+    with_model_detail,
 )
 
 # window.py's HeaderBar.set_connection, with its three states and their
@@ -130,12 +131,38 @@ def build_cards(latest: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
     # legacy fallback for producers that have not been updated.
     rag_block = per.get("rag") or per.get("regulation_context")
     rag_active = "N30" in active
+
+    # **Every card carries its model detail now, and four of them had no
+    # tooltip at all.** The band's WHY module replaces the reasoning tabs, and
+    # what the tabs held for the five agents - each one's own sentences plus
+    # its `key = value` dump - has to land somewhere reachable or the window
+    # loses it. This is the drill-down tier a debugging engineer already opens
+    # for a transcript or a RAG chunk, so it joins them rather than adding a
+    # seventh place to look.
     return {
-        "pace": _card(format_pace(per.get("pace"))),
-        "tire": _card(format_tire(per.get("tire"))),
-        "situation": _card(format_situation(per.get("situation"))),
-        "pit": _card(format_pit(per.get("pit"), active="N28" in active)),
-        "radio": _card(format_radio(radio_block), radio_tooltip(radio_block)),
+        "pace": _card(
+            format_pace(per.get("pace")),
+            with_model_detail(None, "pace", per.get("pace")),
+        ),
+        "tire": _card(
+            format_tire(per.get("tire")),
+            with_model_detail(None, "tire", per.get("tire")),
+        ),
+        "situation": _card(
+            format_situation(per.get("situation")),
+            with_model_detail(None, "situation", per.get("situation")),
+        ),
+        "pit": _card(
+            format_pit(per.get("pit"), active="N28" in active),
+            with_model_detail(None, "pit", per.get("pit")),
+        ),
+        "radio": _card(
+            format_radio(radio_block),
+            with_model_detail(radio_tooltip(radio_block), "radio", radio_block),
+        ),
+        # RAG is the one agent with no `reasoning_lines` builder: its tooltip
+        # already carries the question and the retrieved chunks, which is the
+        # same tier and more of it than a dump would be.
         "rag": _card(
             format_rag(rag_block, active=rag_active),
             rag_tooltip(rag_block) if rag_active else None,

--- a/src/pitwall/agents_view/reasoning.py
+++ b/src/pitwall/agents_view/reasoning.py
@@ -35,7 +35,7 @@ import re
 from typing import Any
 
 from src.arcade.palette import TEXT_PRIMARY, hex_str
-from src.pitwall.reasoning_lines import LINE_BUILDERS, clean, compose
+from src.pitwall.reasoning_lines import agent_body, clean
 
 # reasoning_tabs.py's five colours, in its order. The order matters: the
 # action keywords are last, so `PIT_NOW` inside a percentage-bearing
@@ -150,8 +150,6 @@ def build_reasoning(latest: dict[str, Any] | None) -> list[dict[str, Any]]:
         if key == "orchestrator":
             body = _orchestrator_body(latest)
         else:
-            agent_out = per.get(key) or {}
-            metrics = LINE_BUILDERS[key](agent_out) if agent_out else []
-            body = compose(clean(agent_out.get("reasoning")), metrics)
+            body = agent_body(key, per.get(key))
         tabs.append({"key": key, "label": label, "segments": highlight(body)})
     return tabs

--- a/src/pitwall/reasoning_lines.py
+++ b/src/pitwall/reasoning_lines.py
@@ -117,6 +117,28 @@ LINE_BUILDERS: dict[str, Any] = {
 }
 
 
+def agent_reasoning(block: dict[str, Any] | None) -> str:
+    """One agent's own words for the lap, cleaned, or empty."""
+    return clean((block or {}).get("reasoning"))
+
+
+def agent_metrics(key: str, block: dict[str, Any] | None) -> list[str]:
+    """One agent's `key = value` dump, or empty when it produced nothing."""
+    if not block:
+        return []
+    return LINE_BUILDERS[key](block)
+
+
+def agent_body(key: str, block: dict[str, Any] | None) -> str:
+    """The whole of one agent's reasoning-tab body: its words, then its numbers.
+
+    **The one place that composition happens.** The tabs and the card tooltips
+    both show it, and writing it twice is how the copy that got a fix and the
+    copy that did not come about - the dominant defect class in this repo.
+    """
+    return compose(agent_reasoning(block), agent_metrics(key, block))
+
+
 def compose(reasoning: str, metrics: list[str]) -> str:
     """Assemble the final tab body: reasoning on top, metrics below.
 

--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -121,23 +121,42 @@ const VIEW = {
         // Structured, not markup. Sprint 8 turned the two tooltip formatters
         // into data, so a string here would be the stale-stub shape this file
         // already carries one scar from.
+        // Five of the six carry model detail now, which is where the reasoning
+        // tabs' per-agent bodies went. RAG keeps `null` on purpose: it is the
+        // one agent with no `reasoning_lines` builder, and a card with no
+        // tooltip is also what proves the tab-stop rule is not "every card".
         tooltip:
-          key === "radio"
-            ? {
+          key === "rag"
+            ? null
+            : {
                 sections: [
+                  ...(key === "radio"
+                    ? [
+                        {
+                          title: "Radio",
+                          rows: [
+                            {
+                              lead: "NOR PROBLEM",
+                              text: "Rear grip is going away, especially through the last sector, and the balance moves every lap.",
+                            },
+                          ],
+                        },
+                      ]
+                    : []),
                   {
-                    title: "Radio",
+                    title: "Reasoning",
+                    rows: [{ lead: "", text: `${key} agent reasoning for this lap` }],
+                  },
+                  {
+                    title: "Model detail",
                     rows: [
-                      {
-                        lead: "NOR PROBLEM",
-                        text: "Rear grip is going away, especially through the last sector, and the balance moves every lap.",
-                      },
+                      { lead: `${key}_first`, text: "1.234s" },
+                      { lead: `${key}_second`, text: "56.7%" },
                     ],
                   },
                 ],
                 footer: null,
-              }
-            : null,
+              },
       },
     ]),
   ),
@@ -421,7 +440,7 @@ check(
 check((await page.locator(".agent-tooltip").count()) === 0, "no tooltip before hover");
 await page.locator(".agent-card").nth(4).hover();
 await page.waitForTimeout(200);
-check((await page.locator(".agent-tooltip").count()) === 1, "one tooltip, on RADIO only");
+check((await page.locator(".agent-tooltip").count()) === 1, "one tooltip at a time");
 
 const clip = await page.evaluate(() => {
   const box = document.querySelector(".agent-tooltip").getBoundingClientRect();
@@ -532,6 +551,83 @@ check(
 );
 await page.waitForTimeout(1800);
 check((await page.locator(".status-bar").innerText()).trim() === "", "the status bar auto-clears");
+
+// --- Reachable without a mouse --------------------------------------------
+//
+// The reasoning tabs were `<button>`s, so the per-agent bodies they held were
+// reachable with Tab by anyone. The band replaces them with card tooltips, and
+// a mouse-only popup would make this window strictly WORSE for a keyboard user
+// than the panel it retires: zero of the dumps against six.
+//
+// Driven with real key presses, not by calling `.focus()`. Focus set from
+// script reaches an element the tab order may never visit, which is precisely
+// the thing in question.
+await page.mouse.move(0, 0);
+await page.waitForTimeout(150);
+
+const stops = await page.evaluate(() =>
+  [...document.querySelectorAll(".agent-card")].map((el) => ({
+    slot: [...el.classList].find((c) => c.startsWith("slot-")),
+    tabIndex: el.tabIndex,
+    hasTip: el.getAttribute("tabindex") !== null,
+  })),
+);
+check(
+  stops.filter((s) => s.tabIndex === 0).length === 5,
+  `the five consoles with content are tab stops (${JSON.stringify(stops.map((s) => [s.slot, s.tabIndex]))})`,
+);
+check(
+  stops.find((s) => s.slot === "slot-rag").tabIndex === -1,
+  "and the one with no tooltip is not, so it is not an empty stop in the way",
+);
+
+// Walk the tab order and collect what each stop reveals. The loop bounds
+// itself on the number of stops rather than on a fixed count, so adding a
+// console cannot leave one silently unvisited.
+const reached = [];
+await page.locator(".header-bar").click();
+for (let i = 0; i < 40 && reached.length < 5; i += 1) {
+  await page.keyboard.press("Tab");
+  await page.waitForTimeout(60);
+  const seen = await page.evaluate(() => {
+    const active = document.activeElement;
+    if (!active || !active.classList.contains("agent-card")) return null;
+    const tip = document.querySelector(".agent-tooltip");
+    return {
+      slot: [...active.classList].find((c) => c.startsWith("slot-")),
+      described: active.getAttribute("aria-describedby"),
+      tipId: tip ? tip.id : null,
+      text: tip ? tip.innerText : null,
+      clipped: tip ? tip.scrollHeight - tip.clientHeight : null,
+    };
+  });
+  if (seen) reached.push(seen);
+}
+check(
+  reached.length === 5,
+  `Tab alone reaches all five consoles (${reached.map((r) => r.slot).join(", ")})`,
+);
+check(
+  reached.every((r) => r.text && r.text.includes("Model detail")),
+  "and each one opens its model detail on focus",
+);
+check(
+  reached.every((r) => r.described && r.described === r.tipId),
+  "with the popup named by aria-describedby",
+);
+// **Nothing silently cut.** `.tip-text` used to carry a 4-line clamp, so a
+// long row was amputated with no scrollbar and no ellipsis to say so.
+check(
+  reached.every((r) => r.clipped <= 0),
+  `and nothing is clipped inside it (${reached.map((r) => r.clipped).join(", ")})`,
+);
+
+await page.keyboard.press("Escape");
+await page.waitForTimeout(120);
+check(
+  (await page.locator(".agent-tooltip").count()) === 0,
+  "Escape closes it without moving focus away",
+);
 
 await ctx.close();
 

--- a/src/pitwall/ui/src/features/agents/AgentCard.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentCard.tsx
@@ -42,7 +42,7 @@ import type { AgentCardView, TooltipView } from "../../lib/agents";
 /** Breathing room between the card and the popup, and from the viewport edge. */
 const TOOLTIP_GAP = 10;
 
-function Tooltip({ view, anchor }: { view: TooltipView; anchor: DOMRect }) {
+function Tooltip({ view, anchor, id }: { view: TooltipView; anchor: DOMRect; id: string }) {
   const ref = useRef<HTMLSpanElement>(null);
   const [box, setBox] = useState({ left: anchor.left, top: anchor.top + 32 });
 
@@ -107,7 +107,7 @@ function Tooltip({ view, anchor }: { view: TooltipView; anchor: DOMRect }) {
   // presentation below can drift from the Qt window's; the structure the host
   // returns is pinned by a test.
   return createPortal(
-    <span ref={ref} className="agent-tooltip" style={box}>
+    <span ref={ref} id={id} role="tooltip" className="agent-tooltip" style={box}>
       {view.sections.map((section, index) => (
         <span className="tip-section" key={index}>
           <span className="tip-title">{section.title}</span>
@@ -142,6 +142,24 @@ export function AgentCard({
   // popup - not the empty string Qt used, because a falsy value that is also
   // a legitimate rendering is the sentinel shape this repo keeps paying for.
   const [anchor, setAnchor] = useState<DOMRect | null>(null);
+  const tooltipId = `tip-${slot ?? title.toLowerCase()}`;
+
+  /**
+   * **The popup opens on FOCUS as well as on hover, and Escape closes it.**
+   *
+   * The reasoning tabs were `<button>`s: reachable with Tab, by anyone, and
+   * that is the only reason the per-agent dumps they held were reachable at
+   * all. Moving that content into a mouse-only popup would have made the
+   * window strictly worse for a keyboard user than the panel it replaces -
+   * zero of the six dumps against six - which is why the elevation spec's own
+   * line about the keyboard pattern no longer being needed is wrong: the
+   * WIDGET went away, the requirement did not.
+   *
+   * `onFocus`/`onBlur` rather than `onFocusCapture`: the card is the tab stop
+   * and nothing inside it is focusable, so the events do not repeat.
+   */
+  const open = (element: HTMLElement) => card.tooltip && setAnchor(element.getBoundingClientRect());
+  const close = () => setAnchor(null);
 
   return (
     <section
@@ -155,8 +173,17 @@ export function AgentCard({
           .filter(Boolean)
           .join(" ")
       }
-      onMouseEnter={(event) => card.tooltip && setAnchor(event.currentTarget.getBoundingClientRect())}
-      onMouseLeave={() => setAnchor(null)}
+      // Only a card that HAS something to show is a tab stop; six empty stops
+      // between the reader and the next panel is the cost of doing otherwise.
+      tabIndex={card.tooltip ? 0 : undefined}
+      aria-describedby={card.tooltip && anchor ? tooltipId : undefined}
+      onMouseEnter={(event) => open(event.currentTarget)}
+      onMouseLeave={close}
+      onFocus={(event) => open(event.currentTarget)}
+      onBlur={close}
+      onKeyDown={(event) => {
+        if (event.key === "Escape") close();
+      }}
     >
       <header className="agent-card-head">
         <span className="agent-glyph" style={{ color: card.glyph_colour }}>
@@ -165,7 +192,9 @@ export function AgentCard({
         <span className="agent-title">{title}</span>
       </header>
 
-      {card.tooltip && anchor ? <Tooltip view={card.tooltip} anchor={anchor} /> : null}
+      {card.tooltip && anchor ? (
+        <Tooltip view={card.tooltip} anchor={anchor} id={tooltipId} />
+      ) : null}
 
       {/* The card scrolls here, not on the card itself, so the card is not
           a scrolling ancestor of anything. Qt clips a card that overflows

--- a/src/pitwall/ui/src/styles/agents.css
+++ b/src/pitwall/ui/src/styles/agents.css
@@ -358,11 +358,14 @@
   margin-right: 6px;
   white-space: nowrap;
 }
+/* **No line clamp.** It cut every row at four lines with nothing saying so,
+ * which is the silent truncation this window's whole idle-state doctrine is
+ * against - and it now also lands on the model-detail rows, where the four
+ * lines would be an agent's reasoning cut mid-sentence. The popup has a height
+ * cap and a visible scrollbar for the case where the content really is long;
+ * a bar is a signal, a clamp is not. */
 .tip-text {
-  display: -webkit-box;
-  -webkit-line-clamp: 4;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+  overflow-wrap: anywhere;
 }
 .tip-footer {
   display: block;

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -165,6 +165,73 @@ def test_every_pill_and_badge_is_legible_against_its_own_fill():
     assert contrast_ratio(rgb(idle["action_colour"]), panel) >= 4.5, "the idle action too"
 
 
+def test_every_reasoning_tab_body_is_reachable_from_its_card_tooltip():
+    """The condition the layout elevation had to satisfy to retire the tabs.
+
+    The reasoning panel held two things per agent that live nowhere else on
+    the window: the agent's OWN sentences for the lap, and its `key = value`
+    dump. The elevation spec described those bodies as "snake_case field dumps
+    that duplicate what the cards already say", which is false the moment an
+    agent produces reasoning - `build_reasoning` composes the sentences ON TOP
+    of the numbers - so a move that carried only the numbers would have dropped
+    every agent's explanation of why.
+
+    Asserted ACROSS the two surfaces rather than inside either: the tab's own
+    body, token by token, against what the card's tooltip renders. A test that
+    checked the tooltip against the same builder that fills it would pass on a
+    move that dropped half the content, because both halves would have moved
+    together in its arithmetic.
+    """
+    # **The fixture has to CARRY reasoning or this guard is about nothing.**
+    # `_latest()` gives every agent numbers and no sentences, so the first
+    # draft of this test passed against a mutation that dropped the reasoning
+    # half entirely: there was none in the population it measured. The tab
+    # bodies and the tooltips agreed, and both agreed with the wrong thing.
+    agents = ("pace", "tire", "situation", "radio", "pit")
+    latest = _latest()
+    for name in agents:
+        latest["per_agent"][name]["reasoning"] = (
+            f"the {name} agent's own sentence for this lap, which lives nowhere else"
+        )
+
+    view = _host(_payload(latest=latest)).get_agents_view(-1)
+    tabs = {
+        tab["key"]: "".join(segment["text"] for segment in tab["segments"])
+        for tab in view["reasoning"]
+    }
+
+    checked = 0
+    for key in agents:
+        tooltip = view["cards"][key]["tooltip"]
+        assert tooltip is not None, f"{key} has no tooltip to reach its dump through"
+        rendered = " ".join(
+            f"{row['lead']} {row['text']}"
+            for section in tooltip["sections"]
+            for row in section["rows"]
+        )
+        for line in tabs[key].splitlines():
+            token = line.split("=")[0].strip()
+            if not token:
+                continue
+            checked += 1
+            assert token in rendered, (
+                f"{key}: the tab shows {token!r} and the tooltip does not: {rendered}"
+            )
+
+    # The enumeration itself, so an empty `per_agent` cannot make this pass by
+    # having nothing to compare - and the sentences separately from the
+    # numbers, because they are the half a move can drop while the count still
+    # looks healthy.
+    assert checked >= 25, f"only {checked} tab lines were cross-checked"
+    for key in agents:
+        rendered = " ".join(
+            row["text"]
+            for section in view["cards"][key]["tooltip"]["sections"]
+            for row in section["rows"]
+        )
+        assert "own sentence for this lap" in rendered, f"{key}'s reasoning is not reachable"
+
+
 def test_the_tooltips_return_data_and_never_markup():
     """What replaces the guarantee the hybrid gives up (#960).
 


### PR DESCRIPTION
## What

Every agent console carries its **model detail** in a tooltip, and the tooltip opens on **focus** as
well as on hover. Four of the six had no tooltip at all before this.

This lands *before* the reasoning tabs are retired, deliberately: their content has somewhere
reachable to be first, so nothing is unreachable for even one commit.

## Why

The elevation retires the reasoning panel and moves its per-agent bodies into the drill-down tier.
Two things had to be true for that to be honest, and neither was.

**The bodies are not what the spec says they are.** It describes them as "snake_case field dumps
that duplicate what the cards already say". `build_reasoning` composes
`compose(clean(agent_out["reasoning"]), metrics)` - the agent's OWN sentences on top of the numbers -
so on any run with an LLM, a move that carried only `reasoning_lines.py`'s rows would have dropped
every agent's explanation of why off the window entirely.

**A mouse-only popup is worse than the panel it replaces.** The tabs were `<button>`s: reachable
with Tab, by anyone. The spec's own build order says "keyboard pattern no longer needed (tabs are
gone)", which confuses the widget with the requirement. Zero of six dumps reachable against six is
not an elevation.

## How

- `reasoning_lines.py` grows `agent_reasoning`, `agent_metrics` and `agent_body`. The tabs and the
  tooltips call the same halves, so there is **one** definition of what an agent's body is rather
  than a copy that gets a fix and a copy that does not.
- `agent_formatters.model_detail_sections` renders those halves as `Reasoning` and `Model detail`
  sections; `with_model_detail` appends them to whatever a card already had, so RADIO keeps its
  whole lap of messages and RAG keeps its question and chunks.
- `AgentCard`: `tabIndex` on the cards that have content, `onFocus`/`onBlur` beside the mouse pair,
  Escape to close, `aria-describedby` naming the portal node, `role="tooltip"` on it.
  A card with no tooltip is **not** a tab stop, so the reader does not walk through empty ones.
- `.tip-text`'s `-webkit-line-clamp: 4` is gone. It cut every row at four lines with nothing saying
  so, which is the silent truncation this window's idle-state doctrine is against, and it would now
  land mid-sentence on an agent's reasoning. The popup keeps its height cap and its visible
  scrollbar; a bar is a signal, a clamp is not.

## ⚠️ The guard I wrote first proved nothing

The cross-surface check compares each reasoning tab's body against what that card's tooltip
renders. Driven against a mutation that dropped the reasoning half and kept the numbers, **it
passed** - because `_latest()` gives every agent numbers and no sentences, so there was no reasoning
in the population it measured. The tab bodies and the tooltips agreed, and both agreed with the
wrong thing.

The fixture now plants a sentence per agent, and the same mutation fails with:

```
pace: the tab shows "the pace agent's own sentence for this lap, which lives nowhere else"
and the tooltip does not: lap_time_pred 81.000s delta_vs_prev -0.204s …
```

## Checks

`tests/surfaces/` **249 passed**. `ruff check .` and `format --check .` clean. `npm run typecheck`
clean. `smoke-agents` **43 checks**, up from 36.

The keyboard checks are driven with **real key presses**, not `.focus()`: focus set from script
reaches an element the tab order may never visit, which is the thing in question. They assert that
Tab alone reaches all five consoles with content, that each opens its model detail, that
`aria-describedby` names the popup that is actually on screen, that nothing inside it is clipped,
and that Escape closes it.

The smoke's `VIEW` literal was migrated in the same commit. A fixture that was never migrated is
this repo's cheapest bug and this file already carries one scar from it.

One ordering trap paid for: the keyboard walk takes about two seconds, and the status bar
auto-clears after 1.5 s, so placing the block before the status-bar assertions made them fail on a
bar that had done exactly what it should.


Closes #1018
