### PR TITLE
feat(agents): the PLAN module draws the race on one lap axis

### DIFF
--- a/src/pitwall/agents_view/builder.py
+++ b/src/pitwall/agents_view/builder.py
@@ -23,6 +23,7 @@ from src.pitwall.agents_view.decision import build_orchestrator, build_scenarios
 from src.pitwall.agents_view.history import LapHistory
 from src.pitwall.agents_view.panels import build_cards, build_header, build_status_bar
 from src.pitwall.agents_view.reasoning import build_reasoning
+from src.pitwall.agents_view.timeline import build_plan_timeline
 
 # Bumped when the view's shape changes in a way a built UI bundle would
 # misread. Separate from the wire's `schema_version`, which describes the
@@ -72,11 +73,26 @@ class AgentsViewBuilder:
             "tire": tire,
         }
 
+        orchestrator = build_orchestrator(latest or None, strategy.get("history_tail"))
+
         return {
             "view_version": AGENTS_VIEW_VERSION,
             "seq": payload.get("seq"),
             "header": build_header(payload, connection),
-            "orchestrator": build_orchestrator(latest or None, strategy.get("history_tail")),
+            "orchestrator": orchestrator,
+            # The PLAN module reads the tyre chart's OWN cliff rather than
+            # recomputing it: one fact drawn at two zoom levels cannot disagree
+            # with itself. Its stints come from the never-trimmed compound map,
+            # not from the 40-lap chart store, because this lane spans the race.
+            "plan_timeline": build_plan_timeline(
+                self._history.compound_runs(),
+                latest or None,
+                payload.get("arcade") or {},
+                current_lap if isinstance(current_lap, int) else None,
+                tire.get("cliff"),
+                tire["cliff_colour"],
+                orchestrator["plan"],
+            ),
             # The action goes in with the scores: a guardrail can veto the
             # Monte Carlo winner, and a panel that does not know which plan
             # was ENACTED crowns the one that was overruled (#962).

--- a/src/pitwall/agents_view/history.py
+++ b/src/pitwall/agents_view/history.py
@@ -54,6 +54,18 @@ class LapHistory:
         self._keep = keep
         self._pace: dict[int, dict[str, Any]] = {}
         self._tire: dict[int, dict[str, Any]] = {}
+        # **Never trimmed, and that is the point.** The two stores above are a
+        # rolling 40-lap window because the charts draw one; the PLAN timeline
+        # draws the WHOLE race, so a stint that started on lap 1 has to still
+        # be describable on lap 57. Reading stint structure out of `_tire`
+        # would have made the opening bar shrink from the left from lap 41 and
+        # then vanish - and it would have worn the costume this window uses for
+        # "opened mid-race", so one rendering would have covered two truths
+        # with the boundary between them moving during the race.
+        #
+        # One short string per lap: about 60 entries for a grand prix, against
+        # the two dicts' 40 rows of floats.
+        self._compound_by_lap: dict[int, str] = {}
 
     # --- Ingest -----------------------------------------------------------
 
@@ -74,6 +86,8 @@ class LapHistory:
             tire_row.setdefault("tyre_life", row.get("tyre_life"))
             tire_row.setdefault("compound", row.get("compound"))
             tire_row.setdefault("lap_time_s", row.get("lap_time_s"))
+            if row.get("compound"):
+                self._compound_by_lap.setdefault(lap, str(row["compound"]))
         self.trim()
 
     def ingest_latest(self, latest: dict[str, Any] | None) -> None:
@@ -97,6 +111,7 @@ class LapHistory:
             trow["tyre_life"] = latest.get("tyre_life")
         if latest.get("compound"):
             trow["compound"] = latest.get("compound")
+            self._compound_by_lap[lap] = str(latest["compound"])
         if latest.get("lap_time_s") is not None:
             trow["lap_time_s"] = latest.get("lap_time_s")
         self.trim()
@@ -120,3 +135,27 @@ class LapHistory:
     def tire_rows(self) -> list[dict[str, Any]]:
         """Chronological rows, the shape `TireChart.update_from` takes."""
         return [{"lap": lap, **row} for lap, row in sorted(self._tire.items())]
+
+    def compound_runs(self) -> list[dict[str, Any]]:
+        """`[{lo, hi, compound}]`, one per stint, over the whole race so far.
+
+        A run breaks where the compound changes, and gaps in the lap numbers do
+        NOT break one: the featured laps drop safety-car and pit laps, so a
+        stint routinely has holes in it, and treating each hole as a pit stop
+        would draw a stop that never happened.
+
+        **Nothing is invented for an unknown compound.** The tyre chart's own
+        segmentation inherits the previous label and falls back to "MEDIUM",
+        which paints a confident yellow over a lap nobody reported; a timeline
+        of the whole race would carry that fiction from lap 1. A lap with no
+        compound simply is not in this map, so it lands in a run only if the
+        laps either side of it agree.
+        """
+        runs: list[dict[str, Any]] = []
+        for lap in sorted(self._compound_by_lap):
+            compound = self._compound_by_lap[lap]
+            if runs and runs[-1]["compound"] == compound:
+                runs[-1]["hi"] = lap
+                continue
+            runs.append({"lo": lap, "hi": lap, "compound": compound})
+        return runs

--- a/src/pitwall/agents_view/timeline.py
+++ b/src/pitwall/agents_view/timeline.py
@@ -1,0 +1,149 @@
+"""The decision band's PLAN module: the race on one lap axis.
+
+Three lanes over lap 1 to the flag - the tyre cliff, the stints run and the
+stint planned, and the marks for now and for the scheduled stop. It is the one
+place on this window that shows the whole race rather than a rolling window,
+which is why it reads `LapHistory.compound_runs` and not the 40-lap chart
+stores.
+
+**Positions leave here as FRACTIONS of the race, not as pixels.** The renderer
+places spans by per cent, so the arithmetic that decides where lap 24 sits is
+in the same language as everything else the view computes, and a test can read
+it without a browser.
+
+Nothing here invents a compound, a lap or a length. A stint whose compound the
+producer never reported renders in a neutral colour and says so; a race with no
+`total_laps` renders an empty track rather than dividing by zero.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.arcade.palette import TEXT_TERTIARY, compound_color, hex_str
+
+
+def _fraction(lap: float, total_laps: int) -> float:
+    """Where a lap sits along the track, in [0, 1].
+
+    Lap 1 is the start of the track and `total_laps` its end, so the divisor is
+    `total_laps - 1` rather than `total_laps`: with 57 laps, lap 57 has to land
+    at 1.0 and not at 0.982.
+    """
+    span = max(1, total_laps - 1)
+    return min(1.0, max(0.0, (lap - 1) / span))
+
+
+def _segment(lo: int, hi: int, compound: str | None, total_laps: int, planned: bool) -> dict:
+    """One bar on the stint lane, as a left/width pair in per cent.
+
+    `hi` is the last lap OF the stint, so the bar has to run to the end of that
+    lap rather than to its start - otherwise a one-lap stint has zero width and
+    every stint reads one lap short.
+    """
+    start = _fraction(lo, total_laps)
+    end = _fraction(hi + 1, total_laps)
+    known = bool(compound)
+    return {
+        "lo": lo,
+        "hi": hi,
+        "compound": compound if known else None,
+        # A stint nobody reported a compound for is TEXT_TERTIARY, the same
+        # colour this window uses everywhere for "not reported" - never the
+        # neutral-looking MEDIUM yellow a fallback would paint.
+        "colour": hex_str(compound_color(compound)) if known else hex_str(TEXT_TERTIARY),
+        "planned": planned,
+        "left_pct": round(start * 100, 2),
+        "width_pct": round(max(0.0, end - start) * 100, 2),
+    }
+
+
+def build_plan_timeline(
+    runs: list[dict[str, Any]],
+    latest: dict[str, Any] | None,
+    arcade: dict[str, Any],
+    current_lap: int | None,
+    cliff: dict[str, Any] | None,
+    cliff_colour: str,
+    caption: str,
+) -> dict[str, Any]:
+    """The whole PLAN module, ready to place.
+
+    Args:
+        runs: `LapHistory.compound_runs()` - the stints actually observed.
+        latest: this lap's decision, for `pit_lap_target` and `compound_next`.
+        arcade: the tick's arcade block, for `total_laps`.
+        current_lap: where the car is now, marked on the axis.
+        cliff: the tyre chart's own cliff band, so one fact is drawn at two
+            zoom levels rather than computed twice.
+        cliff_colour: and its colour, from the same place, so the two lanes
+            cannot drift onto two different ambers.
+        caption: the orchestrator's plan line, verbatim, including its
+            empty-state branches.
+    """
+    try:
+        total_laps = int(arcade.get("total_laps") or 0)
+    except (TypeError, ValueError):
+        total_laps = 0
+
+    # Before the first tick the arcade has not said how long the race is. An
+    # empty track is the honest rendering; a track drawn against a guessed
+    # length would place every mark somewhere wrong.
+    if total_laps < 2:
+        return {
+            "total_laps": 0,
+            "first_known_lap": None,
+            "segments": [],
+            "pit_lap": None,
+            "pit_pct": None,
+            "cliff": None,
+            "current_lap": None,
+            "current_pct": None,
+            "caption": caption,
+        }
+
+    segments = [
+        _segment(run["lo"], run["hi"], run.get("compound"), total_laps, planned=False)
+        for run in runs
+    ]
+
+    # The planned stint: from the scheduled stop to the flag, hollow. Only when
+    # the producer named BOTH a lap and a compound - a stop with no compound is
+    # a plan the window cannot draw, and inventing one is how a hollow bar
+    # becomes a claim.
+    pit_lap = latest.get("pit_lap_target") if latest else None
+    compound_next = latest.get("compound_next") if latest else None
+    if isinstance(pit_lap, int) and compound_next:
+        segments.append(_segment(pit_lap, total_laps, str(compound_next), total_laps, planned=True))
+
+    band = None
+    if cliff and cliff.get("lo") is not None and cliff.get("hi") is not None:
+        lo, hi = float(cliff["lo"]), float(cliff["hi"])
+        band = {
+            "lo": lo,
+            "hi": hi,
+            "colour": cliff_colour,
+            "left_pct": round(_fraction(lo, total_laps) * 100, 2),
+            "width_pct": round(
+                max(0.0, _fraction(hi, total_laps) - _fraction(lo, total_laps)) * 100, 2
+            ),
+        }
+
+    return {
+        "total_laps": total_laps,
+        # Laps before this one are blank TRACK, not a grey fill: a window opened
+        # mid-race never saw them, and drawing something there would be a claim
+        # about a stint nobody reported.
+        "first_known_lap": segments[0]["lo"] if runs else None,
+        "segments": segments,
+        "pit_lap": pit_lap if isinstance(pit_lap, int) else None,
+        "pit_pct": round(_fraction(pit_lap, total_laps) * 100, 2)
+        if isinstance(pit_lap, int)
+        else None,
+        "cliff": band,
+        "current_lap": current_lap if isinstance(current_lap, int) else None,
+        "current_pct": round(_fraction(current_lap, total_laps) * 100, 2)
+        if isinstance(current_lap, int)
+        else None,
+        "caption": caption,
+    }

--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -221,6 +221,21 @@ const VIEW = {
       cursor_colour: "#9ca3af",
     },
   },
+  plan_timeline: {
+    total_laps: 57,
+    first_known_lap: 11,
+    segments: [
+      { lo: 11, hi: 17, compound: "MEDIUM", colour: "#e6c832", planned: false, left_pct: 17.86, width_pct: 12.5 },
+      { lo: 18, hi: 23, compound: "HARD", colour: "#e6e6e6", planned: false, left_pct: 30.36, width_pct: 10.71 },
+      { lo: 24, hi: 57, compound: "HARD", colour: "#e6e6e6", planned: true, left_pct: 41.07, width_pct: 58.93 },
+    ],
+    pit_lap: 24,
+    pit_pct: 41.07,
+    cliff: { lo: 27, hi: 32, colour: "#f59e0b", left_pct: 46.43, width_pct: 8.93 },
+    current_lap: 23,
+    current_pct: 39.29,
+    caption: "Pit: L24 · Next: HARD · UCUT: RUS",
+  },
   status_bar: { text: "lap 23 · streaming", transient: true },
 };
 
@@ -380,6 +395,70 @@ check(
 check(
   banner.ranks[0] === banner.size && banner.ranks[1] === banner.confidence,
   `the action and its confidence are the band's top two type ranks (${banner.ranks})`,
+);
+
+// --- The PLAN timeline ------------------------------------------------------
+//
+// Four rectangles and two rules, so the assertions are the rendered geometry.
+// The one thing this lane must never do is make a lap it never saw look like a
+// lap it did: measured against the track's own box, not against a colour name.
+const plan = await page.evaluate(() => {
+  const track = document.querySelector(".plan-lane-stints").getBoundingClientRect();
+  const rel = (el) => {
+    const r = el.getBoundingClientRect();
+    return {
+      left: Math.round(((r.left - track.left) / track.width) * 1000) / 10,
+      right: Math.round(((r.right - track.left) / track.width) * 1000) / 10,
+      fill: getComputedStyle(el).backgroundColor,
+    };
+  };
+  const stints = [...document.querySelectorAll(".plan-stint")].map((el) => ({
+    ...rel(el),
+    planned: el.classList.contains("is-planned"),
+  }));
+  const now = document.querySelector(".plan-now");
+  const cliff = document.querySelector(".plan-cliff");
+  return {
+    stints,
+    nowLeft: now ? Math.round(((now.getBoundingClientRect().left - track.left) / track.width) * 1000) / 10 : null,
+    cliffFill: cliff ? getComputedStyle(cliff).backgroundColor : null,
+    trackFill: getComputedStyle(document.querySelector(".plan-lane-stints")).backgroundColor,
+    labels: [...document.querySelectorAll(".plan-end, .plan-cursor-label")].map((el) => el.innerText),
+    overflow: Math.max(...stints.map((s) => s.right)) - 100,
+  };
+});
+check(plan.stints.length === 3, `three stints on the lane (${plan.stints.length})`);
+// The window opened on lap 11, so the first ten laps are TRACK. A lane that
+// started its first bar at zero would be claiming a stint nobody reported.
+check(
+  plan.stints[0].left > 5,
+  `the laps this window never saw are blank track (first bar at ${plan.stints[0].left}%)`,
+);
+// Filled versus hollow, asserted as a computed fill rather than as a class:
+// the class is the mechanism, the paint is the encoding.
+check(
+  plan.stints.filter((s) => s.planned).every((s) => s.fill === "rgba(0, 0, 0, 0)"),
+  `the planned stint is hollow (${plan.stints.filter((s) => s.planned).map((s) => s.fill)})`,
+);
+check(
+  plan.stints.filter((s) => !s.planned).every((s) => s.fill !== "rgba(0, 0, 0, 0)"),
+  "and the stints already run are filled",
+);
+// **The empty track may not look like a stint.** This is the pair that came
+// out the same tone on the first draft: a run stint over `--qt-elevated` at
+// 0.42 alpha was indistinguishable from the ground behind it.
+check(
+  plan.trackFill !== plan.stints[0].fill,
+  `an unrun lap and a run stint are different paint (${plan.trackFill} vs ${plan.stints[0].fill})`,
+);
+check(plan.overflow <= 0.5, `no bar runs past the flag (${plan.overflow}% over)`);
+check(
+  plan.labels.includes("L1") && plan.labels.includes("L57") && plan.labels.includes("L23"),
+  `the axis names its ends and the current lap (${plan.labels.join(", ")})`,
+);
+check(
+  plan.nowLeft !== null && Math.abs(plan.nowLeft - 39.3) < 1.5,
+  `the NOW cursor sits on the current lap (${plan.nowLeft}%)`,
 );
 
 // The consoles, by rendered geometry rather than by class name: a card can

--- a/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
@@ -161,6 +161,17 @@ const IDLE_VIEW: AgentsView = {
       cursor_colour: "#9ca3af",
     },
   },
+  plan_timeline: {
+    total_laps: 0,
+    first_known_lap: null,
+    segments: [],
+    pit_lap: null,
+    pit_pct: null,
+    cliff: null,
+    current_lap: null,
+    current_pct: null,
+    caption: "Pit: — · Next: — · UCUT: —",
+  },
   history: { pace: [], tire: [] },
   // Replaced by `waitingStatus(connection)` while `view` is null: the idle
   // view cannot know whether the socket is up, and this window has no other
@@ -261,7 +272,7 @@ export function AgentsWindow() {
           <OrchestratorCard view={shown.orchestrator} />
           <WhyPanel view={shown.orchestrator} />
           <ScenarioBars rows={shown.scenarios} />
-          <PlanPanel plan={shown.orchestrator.plan} />
+          <PlanPanel view={shown.plan_timeline} />
         </div>
 
         {/* The six consoles below it, in named grid areas rather than source

--- a/src/pitwall/ui/src/features/agents/PlanPanel.tsx
+++ b/src/pitwall/ui/src/features/agents/PlanPanel.tsx
@@ -1,25 +1,19 @@
 /**
  * The decision band's fourth module: what happens next.
  *
- * Today it is the orchestrator's own plan line, moved out of the decision card
- * and given a column of its own. The line is built host side and carries three
- * branches - a scheduled stop, "stint continues · no pit window yet" on
- * STAY_OUT with nothing tactical, and "Pit plan pending" otherwise - so the
- * copy cannot quietly become three "--" chips here.
- *
- * It keeps `dangerouslySetInnerHTML` because the line can carry a compound
- * pill, an HTML span built and escaped in `src/arcade/palette.py`. That is the
- * last markup sink on this window's decision surface and it is the reason the
- * pill has to become a typed segment before the card bodies do: a component
- * that re-imports the path the migration is retiring makes the migration's
- * claim false.
+ * A card around the timeline, and the reason it is a separate file from it: the
+ * module is one of the band's four and wears their shared chrome, while the
+ * timeline is a drawing that could be placed anywhere.
  */
 
-export function PlanPanel({ plan }: { plan: string }) {
+import type { PlanTimelineView } from "../../lib/agents";
+import { PlanTimeline } from "./PlanTimeline";
+
+export function PlanPanel({ view }: { view: PlanTimelineView }) {
   return (
     <section className="card plan-panel">
       <h2 className="band-title">PLAN</h2>
-      <p className="plan-caption" dangerouslySetInnerHTML={{ __html: plan }} />
+      <PlanTimeline view={view} />
     </section>
   );
 }

--- a/src/pitwall/ui/src/features/agents/PlanTimeline.tsx
+++ b/src/pitwall/ui/src/features/agents/PlanTimeline.tsx
@@ -1,0 +1,114 @@
+/**
+ * The band's fourth module: the race on one lap axis.
+ *
+ * Three lanes over lap 1 to the flag - the tyre cliff above, the stints on the
+ * track, the marks below - plus the orchestrator's plan line as a caption.
+ *
+ * **Positioned spans, not a third chart.** This is four rectangles and two
+ * rules; a third imperative ECharts instance re-rendering at 10 Hz for that is
+ * cost with no return, and a span's geometry can be asserted from the DOM
+ * without asking a canvas what it drew.
+ *
+ * Every position arrives as a per cent computed host side (`timeline.py`), so
+ * the arithmetic that decides where lap 24 sits is in the same language as the
+ * rest of the view and a Python test can read it.
+ *
+ * The distinction the lane carries is **filled versus hollow**, not solid
+ * versus dashed: a dashed stroke already means broadcast-tier data in the
+ * sibling DATA window, and one stroke cannot mean two things across two
+ * windows a reader has open at once.
+ */
+
+import type { PlanTimelineView } from "../../lib/agents";
+
+export function PlanTimeline({ view }: { view: PlanTimelineView }) {
+  // Before the arcade has said how long the race is there is no axis to place
+  // anything on. An empty track and the caption's own empty-state branch is
+  // the honest rendering; a track drawn against a guessed length would put
+  // every mark somewhere wrong.
+  const drawable = view.total_laps >= 2;
+
+  return (
+    <div className="plan-timeline">
+      <div className="plan-track" role="img" aria-label={planLabel(view)}>
+        <div className="plan-lane plan-lane-hazard">
+          {view.cliff ? (
+            <span
+              className="plan-cliff"
+              style={{
+                left: `${view.cliff.left_pct}%`,
+                width: `${view.cliff.width_pct}%`,
+                // The tyre chart's own band colour, through the view. A token
+                // here would be a second place the amber lives.
+                backgroundColor: view.cliff.colour,
+              }}
+            />
+          ) : null}
+        </div>
+
+        <div className="plan-lane plan-lane-stints">
+          {view.segments.map((segment) => (
+            <span
+              key={`${segment.lo}-${segment.hi}-${segment.planned ? "p" : "r"}`}
+              className={segment.planned ? "plan-stint is-planned" : "plan-stint"}
+              style={{
+                left: `${segment.left_pct}%`,
+                width: `${segment.width_pct}%`,
+                // A run stint is a tint with a full-strength top edge; a
+                // planned one is an outline with nothing inside it.
+                borderColor: segment.colour,
+                backgroundColor: segment.planned ? "transparent" : segment.colour,
+              }}
+            />
+          ))}
+        </div>
+
+        {/* The marks. The cursor is the same 1 px `TEXT_TERTIARY` vertical the
+            two charts use for the current lap, so "now" is one mark in three
+            places rather than three marks that happen to line up. */}
+        {view.current_pct !== null ? (
+          <span className="plan-now" style={{ left: `${view.current_pct}%` }} />
+        ) : null}
+        {view.pit_pct !== null ? (
+          <span className="plan-pit" style={{ left: `${view.pit_pct}%` }}>
+            ▼
+          </span>
+        ) : null}
+
+        <div className="plan-lane plan-lane-labels">
+          {drawable ? <span className="plan-end is-start">L1</span> : null}
+          {view.current_lap !== null ? (
+            <span className="plan-cursor-label" style={{ left: `${view.current_pct}%` }}>
+              L{view.current_lap}
+            </span>
+          ) : null}
+          {drawable ? <span className="plan-end is-finish">L{view.total_laps}</span> : null}
+        </div>
+      </div>
+
+      {/* The orchestrator's own plan line, verbatim, including the compound
+          pill it can carry. That pill is an HTML span built and escaped in
+          `src/arcade/palette.py` and it is the last markup sink on this
+          window's decision surface. */}
+      <p className="plan-caption" dangerouslySetInnerHTML={{ __html: view.caption }} />
+    </div>
+  );
+}
+
+/**
+ * One sentence for a screen reader, since the lanes are geometry.
+ *
+ * Built from the same fields the spans are placed from, so it cannot describe
+ * a race the picture is not showing.
+ */
+function planLabel(view: PlanTimelineView): string {
+  if (view.total_laps < 2) return "No race loaded";
+  const stints = view.segments
+    .filter((segment) => !segment.planned)
+    .map((segment) => `${segment.compound ?? "unknown"} laps ${segment.lo} to ${segment.hi}`);
+  const planned = view.segments.find((segment) => segment.planned);
+  const parts = [`Lap ${view.current_lap ?? "?"} of ${view.total_laps}`, ...stints];
+  if (planned) parts.push(`planned ${planned.compound} from lap ${planned.lo}`);
+  if (view.cliff) parts.push(`cliff between laps ${view.cliff.lo} and ${view.cliff.hi}`);
+  return parts.join(", ");
+}

--- a/src/pitwall/ui/src/lib/agents.ts
+++ b/src/pitwall/ui/src/lib/agents.ts
@@ -184,6 +184,40 @@ export interface TireSeries {
   cursor_colour: string;
 }
 
+/** One bar on the stint lane. `compound` is null when nobody reported one. */
+export interface PlanSegment {
+  lo: number;
+  hi: number;
+  compound: string | null;
+  colour: string;
+  /** Hollow rather than filled: the stop has not happened yet. */
+  planned: boolean;
+  left_pct: number;
+  width_pct: number;
+}
+
+export interface PlanTimelineView {
+  /** 0 before the arcade has said how long the race is; the track draws empty. */
+  total_laps: number;
+  /** Laps before this one are blank track: this window never saw them. */
+  first_known_lap: number | null;
+  segments: PlanSegment[];
+  pit_lap: number | null;
+  pit_pct: number | null;
+  /** The tyre chart's own band, so one fact is drawn at two zoom levels. */
+  cliff: {
+    lo: number;
+    hi: number;
+    colour: string;
+    left_pct: number;
+    width_pct: number;
+  } | null;
+  current_lap: number | null;
+  current_pct: number | null;
+  /** The orchestrator's plan line, verbatim; may carry the compound pill. */
+  caption: string;
+}
+
 export interface AgentsView {
   view_version: number;
   seq: number | null;
@@ -193,6 +227,7 @@ export interface AgentsView {
   reasoning: ReasoningTab[];
   cards: Record<string, AgentCardView>;
   charts: { pace: PaceSeries; tire: TireSeries };
+  plan_timeline: PlanTimelineView;
   history: { pace: PaceHistoryRow[]; tire: TireHistoryRow[] };
   status_bar: { text: string; transient: boolean };
 }

--- a/src/pitwall/ui/src/styles/agents.css
+++ b/src/pitwall/ui/src/styles/agents.css
@@ -127,7 +127,121 @@
 .plan-panel {
   padding: 10px 14px;
   min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
+
+/* --- The race on one lap axis --------------------------------------------
+ *
+ * Three lanes and two marks, all placed by a per cent the host computed. The
+ * track is `position: relative` and everything inside it is absolute against
+ * that, so a lane's height never moves a mark's x. */
+
+.plan-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+.plan-track {
+  position: relative;
+  padding-top: 4px;
+}
+.plan-lane {
+  position: relative;
+  width: 100%;
+}
+.plan-lane-hazard {
+  height: 5px;
+  margin-bottom: 2px;
+}
+/* **The empty track has to read as a groove, not as a bar.** It was
+ * `--qt-elevated`, and a run stint at 0.42 alpha over it came out the same
+ * tone: the laps this window never saw looked exactly like a stint it did see,
+ * which is the one thing this lane must never do. Window ground with a hairline
+ * reads as absence. */
+.plan-lane-stints {
+  height: 26px;
+  border-radius: 3px;
+  background: var(--qt-bg);
+  border: 1px solid var(--qt-border);
+  box-sizing: border-box;
+}
+.plan-lane-labels {
+  height: 16px;
+  margin-top: 3px;
+}
+
+/* The colour arrives inline, from the tyre chart's own `cliff_colour`, so the
+ * cliff is one fact drawn at two zoom levels rather than two ambers that
+ * happen to be close. The alpha is here because it is presentation. */
+.plan-cliff {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  border-radius: 2px;
+  opacity: 0.45;
+}
+
+/* A run stint: the compound at low alpha with a full-strength top edge, which
+ * is the boundary treatment the tyre chart already uses. */
+.plan-stint {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  border-radius: 2px;
+  border-top: 2px solid;
+  /* Enough for a compound to read as itself against the groove. Below about
+   * 0.5 the HARD white and the empty track were the same value. */
+  opacity: 0.62;
+}
+/* Planned: hollow. Not DASHED - a dashed stroke means broadcast-tier data in
+ * the sibling DATA window, and one stroke cannot mean two things across two
+ * windows a reader has open at once. */
+.plan-stint.is-planned {
+  border: 1px solid;
+  opacity: 1;
+}
+
+.plan-now {
+  position: absolute;
+  top: 0;
+  bottom: 19px;
+  width: 1px;
+  background: var(--qt-fg-3);
+}
+/* Directly over the lane it points into, not floating at the top of the
+ * module: a marker three lanes away from the bar it refers to is a decoration.
+ * `top` is the hazard lane's height plus its margin. */
+.plan-pit {
+  position: absolute;
+  top: 1px;
+  transform: translateX(-50%);
+  color: var(--qt-fg-1);
+  font-size: 9px;
+  line-height: 1;
+}
+.plan-end,
+.plan-cursor-label {
+  position: absolute;
+  top: 0;
+  color: var(--qt-fg-3);
+  font-family: var(--qt-mono);
+  font-size: 9px;
+  white-space: nowrap;
+}
+.plan-end.is-start {
+  left: 0;
+}
+.plan-end.is-finish {
+  right: 0;
+}
+.plan-cursor-label {
+  transform: translateX(-50%);
+  color: var(--qt-fg-2);
+}
+
 .plan-caption {
   margin: 0;
   color: var(--qt-fg-2);

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -165,6 +165,108 @@ def test_every_pill_and_badge_is_legible_against_its_own_fill():
     assert contrast_ratio(rgb(idle["action_colour"]), panel) >= 4.5, "the idle action too"
 
 
+def test_the_plan_timeline_spans_the_race_and_not_the_chart_window():
+    """The lane draws lap 1 to the flag, so it cannot read the 40-lap stores.
+
+    `LapHistory` keeps a rolling `KEEP_LAPS = 40` window because the charts
+    draw one. Melbourne is 57 laps, so from lap 41 a timeline built on those
+    stores would lose its opening stint from the left, one lap at a time - and
+    it would lose it into the SAME rendering this module uses for "opened
+    mid-race", so one costume would cover two truths with the boundary between
+    them moving during the race.
+
+    Driven past the trim on purpose: 45 laps ingested, `KEEP_LAPS` laps of tyre
+    rows surviving, and the first stint still starting where it started.
+    """
+    from src.pitwall.agents_view.builder import AgentsViewBuilder
+    from src.pitwall.agents_view.history import KEEP_LAPS
+
+    builder = AgentsViewBuilder()
+    for lap in range(1, 46):
+        latest = _latest(lap)
+        latest["compound"] = "MEDIUM" if lap <= 20 else "HARD"
+        view = builder.build(_payload(seq=lap, lap=lap, latest=latest))
+
+    timeline = view["plan_timeline"]
+    assert len(view["history"]["tire"]) == KEEP_LAPS, "the chart store really did trim"
+    assert timeline["first_known_lap"] == 1, "and the timeline still starts at lap 1"
+    runs = [(s["lo"], s["hi"], s["compound"]) for s in timeline["segments"] if not s["planned"]]
+    assert runs == [(1, 20, "MEDIUM"), (21, 45, "HARD")]
+    assert timeline["segments"][0]["left_pct"] == 0.0, "lap 1 is the start of the track"
+
+
+def test_the_plan_timeline_invents_nothing_it_was_not_told():
+    """Three absences, three honest renderings.
+
+    An unknown compound is the one that matters most: the tyre chart's own
+    segmentation inherits the previous label and falls back to `"MEDIUM"`,
+    which paints a confident yellow over a lap nobody reported. Over a
+    40-lap window that is a small lie; over the whole race it would be the
+    opening bar.
+    """
+    from src.arcade.palette import TEXT_TERTIARY, hex_str
+    from src.pitwall.agents_view.timeline import build_plan_timeline
+
+    # No `total_laps`: an empty track, and no division by a zero span.
+    empty = build_plan_timeline([], None, {}, None, None, "#f59e0b", "Pit plan pending")
+    assert empty == {
+        "total_laps": 0,
+        "first_known_lap": None,
+        "segments": [],
+        "pit_lap": None,
+        "pit_pct": None,
+        "cliff": None,
+        "current_lap": None,
+        "current_pct": None,
+        "caption": "Pit plan pending",
+    }
+
+    # An unknown compound: neutral, and it says so by carrying no name.
+    unknown = build_plan_timeline(
+        [{"lo": 1, "hi": 5, "compound": None}], None, {"total_laps": 57}, 5, None, "#f59e0b", "x"
+    )
+    assert unknown["segments"][0]["compound"] is None
+    assert unknown["segments"][0]["colour"] == hex_str(TEXT_TERTIARY)
+
+    # A stop with no compound: no hollow bar. A planned stint the producer
+    # never named would be a claim the window made up.
+    nameless = build_plan_timeline(
+        [], {"pit_lap_target": 24}, {"total_laps": 57}, 23, None, "#f59e0b", "x"
+    )
+    assert [s for s in nameless["segments"] if s["planned"]] == []
+    assert nameless["pit_lap"] == 24, "the marker still shows; only the bar is withheld"
+
+
+def test_the_last_lap_lands_on_the_flag():
+    """Off-by-one, and it is the one everybody writes.
+
+    Dividing by `total_laps` puts lap 57 of 57 at 98.2 % and leaves a sliver of
+    track after the chequered flag; the span is `total_laps - 1`. And a stint's
+    bar runs to the END of its last lap, so a one-lap stint has width rather
+    than none.
+    """
+    from src.pitwall.agents_view.timeline import build_plan_timeline
+
+    view = build_plan_timeline(
+        [{"lo": 1, "hi": 57, "compound": "HARD"}], None, {"total_laps": 57}, 57, None, "#f59e0b", ""
+    )
+
+    assert view["current_pct"] == 100.0
+    assert view["segments"][0]["left_pct"] == 0.0
+    assert view["segments"][0]["width_pct"] == 100.0
+
+    one_lap = build_plan_timeline(
+        [{"lo": 30, "hi": 30, "compound": "SOFT"}],
+        None,
+        {"total_laps": 57},
+        30,
+        None,
+        "#f59e0b",
+        "",
+    )
+    assert one_lap["segments"][0]["width_pct"] > 0, "a one-lap stint is still a bar"
+
+
 def test_the_narrative_is_cut_at_a_sentence_and_never_mid_number():
     """`why` is the one line of prose the band puts on the glass.
 


### PR DESCRIPTION
## What

The band's PLAN module becomes the race on one lap axis: the tyre cliff above, the stints run and
the stint planned on the track, the marks for now and for the scheduled stop below, and the
orchestrator's plan line as the caption.

```
PLAN
      ▼                  ▁▁▁▁▁          <- cliff, laps 27-32
  [      ][███ MEDIUM ███|:::::: HARD ::::::::::::]
   L1                  L23                     L57
  Pit: L24 · Next: HARD · UCUT: RUS
```

Until now it held one line of text in 482 px, and an empty bordered panel reads as content missing -
which is the complaint this window has already answered twice.

## The lane it cannot be built from

`LapHistory` keeps a rolling **`KEEP_LAPS = 40`** window, because the two charts draw one. Melbourne
is 57 laps. A timeline built on those stores loses its opening stint from the left, one lap at a
time from lap 41, **into the same rendering this module uses for "the window opened mid-race"** - so
one costume would cover two truths, with the boundary between them moving during the race.

So `LapHistory` gains a never-trimmed `dict[lap, compound]`: one short string per lap, about 60
entries for a grand prix, against the two stores' 40 rows of floats. `compound_runs()` turns it into
`[{lo, hi, compound}]`, and a gap in the lap numbers does **not** break a run - the featured laps
drop safety-car and pit laps, so a stint routinely has holes and treating each hole as a stop would
draw a pit stop that never happened.

## Three absences, three honest renderings

- **A lap this window never saw** is blank track, not a grey bar.
- **An unknown compound** is `TEXT_TERTIARY` and carries no name. The tyre chart's own segmentation
  inherits the previous label and falls back to `"MEDIUM"`, which paints a confident yellow over a
  lap nobody reported. Over a 40-lap window that is a small lie; over the whole race it would be the
  opening bar.
- **A stop with no compound** gets its ▼ marker and no hollow bar. A planned stint the producer
  never named would be a claim the window made up.

## What the capture changed

The first draft used `--qt-elevated` for the empty track, and a run stint at 0.42 alpha over it came
out the **same tone**: the laps this window never saw looked exactly like a stint it did see, which
is the one thing this lane must never do. The track is window ground with a hairline now, and the
stints sit at 0.62. There is a check for that pair specifically, asserting the computed paint rather
than a class name.

Planned versus run is **hollow versus filled**, not dashed versus solid: a dashed stroke already
means broadcast-tier data in the sibling DATA window, and one stroke cannot mean two things across
two windows a reader has open at once.

## How

- `agents_view/timeline.py` is new. Positions leave it as **per cents of the race**, so the
  arithmetic that decides where lap 24 sits is in the same language as the rest of the view and a
  Python test can read it without a browser.
- `PlanTimeline.tsx` places positioned spans - four rectangles and two rules. A third imperative
  ECharts instance re-rendering at 10 Hz for that is cost with no return, and a span's geometry can
  be asserted from the DOM.
- The cliff's colour rides on the view from `tire.cliff_colour`, so the lane and the chart cannot
  drift onto two different ambers.
- The lanes carry an `aria-label` built from the same fields the spans are placed from, so it cannot
  describe a race the picture is not showing.

**Zero new tick fields.** Every input was already on the payload or in the builder's own state; what
is new is an accumulator, which is host state.

## Checks

`tests/surfaces/` **255 passed** (four new). `smoke-agents` **53 checks**, up from 45. `ruff check .`
and `format --check .` clean. `npm run typecheck` clean.

Driven red where it matters: `compound_runs` pointed at the trimmed store instead of the compound
map, which is what the elevation spec proposed, and the guard fails with `assert 6 == 1` on the
first known lap after 45 ingested laps. Restored with `cp` + `cmp`, byte-identical.

The off-by-one has its own guard: dividing by `total_laps` puts lap 57 of 57 at 98.2 % and leaves a
sliver of track after the flag, so the span is `total_laps - 1`; and a stint's bar runs to the END
of its last lap, so a one-lap stint has width rather than none.

Captured at 1486x833 and looked at, twice.


Closes #1022
