### PR TITLE
feat(agents): an idle console speaks to the reader, and ALERT stops being a colour

### DIFF
--- a/src/pitwall/agent_formatters.py
+++ b/src/pitwall/agent_formatters.py
@@ -108,6 +108,21 @@ def _truncate(text: str | None, limit: int = 70) -> str:
 # --- N25 Pace -----------------------------------------------------------
 
 
+# --- What an idle console says -----------------------------------------------
+#
+# **"no prediction — stub" was a word about the CODE on a surface a race
+# engineer reads.** A stub is a thing a developer knows about; what the reader
+# needs to know is that this agent has no reading for this lap, which is a fact
+# about the race. Same for "no radio/rcm pipeline output", which names a
+# pipeline, and for "triggers on ...", which describes a routing rule rather
+# than telling the reader what would wake the console.
+#
+# The trigger hints are the two conditional agents' own wake conditions, in the
+# operational voice the rest of the window uses. They teach the reader what the
+# system does, which is why this window dims an idle console rather than
+# blanking it.
+
+
 def format_pace(p: dict[str, Any] | None) -> Formatted:
     """CLI §1.1: pace delta to next predicted lap, with absolute predicted lap time.
 
@@ -121,7 +136,7 @@ def format_pace(p: dict[str, Any] | None) -> Formatted:
     """
     if not p:
         return (
-            "no prediction — stub",
+            "no reading this lap",
             TEXT_TERTIARY,
             [],
             STATUS_IDLE,
@@ -173,7 +188,7 @@ def format_tire(t: dict[str, Any] | None) -> Formatted:
     """
     if not t:
         return (
-            "no prediction — stub",
+            "no reading this lap",
             TEXT_TERTIARY,
             [],
             STATUS_IDLE,
@@ -233,7 +248,7 @@ def format_situation(s: dict[str, Any] | None) -> Formatted:
     """
     if not s:
         return (
-            "no prediction — stub",
+            "no reading this lap",
             TEXT_TERTIARY,
             [],
             STATUS_IDLE,
@@ -445,7 +460,7 @@ def format_radio(r: dict[str, Any] | None) -> Formatted:
     """
     if r is None:
         return (
-            "no radio/rcm pipeline output",
+            "radio silent",
             TEXT_TERTIARY,
             [],
             STATUS_IDLE,
@@ -520,7 +535,7 @@ def format_pit(p: dict[str, Any] | None, active: bool) -> Formatted:
     """
     if not active or not p:
         return (
-            "triggers on cliff pressure, compound change, or problem radio",
+            "wakes on tyre cliff, compound change, or a problem radio",
             TEXT_TERTIARY,
             [],
             STATUS_IDLE,
@@ -643,7 +658,7 @@ def format_rag(rag: dict[str, Any] | str | None, active: bool) -> Formatted:
     """
     if not active:
         return (
-            "triggers on compound change, SC >30%, or FIA warning/penalty",
+            "wakes on compound change, SC risk above 30%, or an FIA warning",
             TEXT_TERTIARY,
             [],
             STATUS_IDLE,

--- a/src/pitwall/agents_view/panels.py
+++ b/src/pitwall/agents_view/panels.py
@@ -60,14 +60,27 @@ CONNECTION_COLOURS: dict[str, str] = {
     "Disconnected": hex_str(DANGER),
 }
 
-# `agent_card.py::_GLYPH_FOR`, which cannot be imported because it lives in
-# a QFrame subclass. It is repeated rather than reimplemented, and
-# `test_the_status_glyphs_match_the_qt_cards` compares the two for as long
-# as both exist - which is the twin-detector this repo keeps needing.
+# The four console states, as a SHAPE and a colour.
+#
+# **Both, because colour alone was carrying two of them.** OK and ALERT were
+# the same filled disc and differed only in green against red - the single most
+# common colour-vision confusion there is - so the two states a reader most
+# needs to tell apart were, for some readers, one state. ALERT is a triangle
+# now: pointed, conventional for a warning, and legible with the colour
+# removed entirely.
+#
+# The map was transcribed from `agent_card.py::_GLYPH_FOR`, which could not be
+# imported because it lived in a QFrame subclass. **That file no longer exists**
+# - sprint 7 retired `src/arcade/dashboard/` - and the comment here went on
+# naming a `test_the_status_glyphs_match_the_qt_cards` that went with it,
+# promising a comparison "for as long as both exist" when only one did. What
+# guards the map now is `test_every_console_state_has_its_own_shape`, which
+# asserts the property rather than the parity: four states, four distinct
+# glyphs, and no state readable by colour alone.
 STATUS_GLYPHS: dict[str, tuple[str, str]] = {
     "OK": ("●", hex_str(SUCCESS)),
     "WATCH": ("◐", hex_str(WARNING)),
-    "ALERT": ("●", hex_str(DANGER)),
+    "ALERT": ("▲", hex_str(DANGER)),
     "IDLE": ("○", hex_str(TEXT_TERTIARY)),
 }
 

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -698,6 +698,55 @@ def test_the_situation_card_says_out_of_range_and_never_zero_per_cent():
     assert view["cards"]["situation"]["lines"][0]["text"] == "overtake — (out of model range)"
 
 
+def test_every_console_state_has_its_own_shape():
+    """No console state may be readable by colour alone.
+
+    OK and ALERT were the same filled disc, green against red - the single most
+    common colour-vision confusion there is - so the two states a reader most
+    needs to tell apart were, for some readers, one state.
+
+    Asserted as DISTINCTNESS over the whole map rather than as "ALERT is a
+    triangle": the property is what matters, and a check on one entry would go
+    on passing the day a fifth state arrives wearing a disc.
+    """
+    from src.pitwall.agents_view.panels import STATUS_GLYPHS
+
+    glyphs = [glyph for glyph, _ in STATUS_GLYPHS.values()]
+    assert len(set(glyphs)) == len(STATUS_GLYPHS), (
+        f"two console states share a glyph and differ only in colour: {STATUS_GLYPHS}"
+    )
+    colours = [colour for _, colour in STATUS_GLYPHS.values()]
+    assert len(set(colours)) == len(STATUS_GLYPHS), f"two states share a colour: {STATUS_GLYPHS}"
+
+
+def test_an_idle_console_says_what_would_wake_it_in_the_readers_language():
+    """The copy a race engineer reads, not the copy a developer writes.
+
+    "no prediction - stub" named a thing about the CODE. "no radio/rcm pipeline
+    output" named a pipeline. "triggers on ..." described a routing rule. None
+    of the three tells the reader what they need, which is either that this
+    agent has no reading for this lap or what would wake it.
+    """
+    from src.pitwall.agent_formatters import format_pace, format_pit, format_radio, format_rag
+
+    idle = {
+        "pace": format_pace(None)[0],
+        "radio": format_radio(None)[0],
+        "pit": format_pit(None, active=False)[0],
+        "rag": format_rag(None, active=False)[0],
+    }
+
+    assert idle["pace"] == "no reading this lap"
+    assert idle["radio"] == "radio silent"
+    assert idle["pit"].startswith("wakes on ")
+    assert idle["rag"].startswith("wakes on ")
+
+    # And nothing anywhere says any of it in the old dialect.
+    for where, text in idle.items():
+        for jargon in ("stub", "pipeline", "triggers on", "rcm"):
+            assert jargon not in text.lower(), f"{where} still speaks in code: {text!r}"
+
+
 def test_the_conditional_cards_read_agent_ids_and_not_block_names():
     latest = _latest()
     latest["per_agent"]["active"] = []
@@ -705,16 +754,16 @@ def test_the_conditional_cards_read_agent_ids_and_not_block_names():
     cards = _host(_payload(latest=latest)).get_agents_view(-1)["cards"]
 
     assert cards["pit"]["status"] == "IDLE"
-    assert cards["pit"]["headline"].startswith("triggers on")
+    assert cards["pit"]["headline"].startswith("wakes on")
     assert cards["rag"]["status"] == "IDLE"
-    assert cards["rag"]["headline"].startswith("triggers on")
+    assert cards["rag"]["headline"].startswith("wakes on")
 
 
 def test_a_tick_with_no_per_agent_block_shows_the_idle_copy_and_not_an_empty_card():
     cards = _host(_payload(latest={"lap_number": 3})).get_agents_view(-1)["cards"]
 
-    assert cards["pace"]["headline"] == "no prediction — stub"
-    assert cards["radio"]["headline"] == "no radio/rcm pipeline output"
+    assert cards["pace"]["headline"] == "no reading this lap"
+    assert cards["radio"]["headline"] == "radio silent"
     assert all(card["status"] == "IDLE" for card in cards.values())
 
 

--- a/tests/surfaces/test_pitwall_tokens.py
+++ b/tests/surfaces/test_pitwall_tokens.py
@@ -481,3 +481,100 @@ def test_the_two_raw_hexes_in_the_stylesheet_are_guarded_too():
     # palette.py: `orchestrator_card.py` writes it straight into its Qt
     # stylesheet too, so freezing it here is what makes the pair monitored.
     assert css.count("#282834") == 1, "the empty-bar shade is used in exactly one rule"
+
+
+# --- The sweep, because the list above is a list -----------------------------
+
+
+def test_no_pitwall_source_file_carries_an_unregistered_hex():
+    """Every guard above names its files. This one FINDS them.
+
+    That is the difference between a check that cannot miss and one that misses
+    by construction. `QT_BASE_CSS`, `AGENTS_CSS`, `DATA_CSS`, `AGENTS_WINDOW`
+    and `TRACE_STACK` are explicit paths, so a colour written into any file
+    that is not one of them is invisible to the palette guards - and a sprint
+    that adds `PlanTimeline.tsx`, `WhyPanel.tsx`, `Tooltip.tsx` and
+    `agents_view/timeline.py` adds four such files at once.
+
+    Discovery, then. Walk both PITWALL source trees, collect every literal hex,
+    and require each one to be a colour `palette.py` actually defines. The
+    palette is the register; a hex that is in it is a copy the other guards can
+    reason about, and a hex that is not is somebody's eyedropper.
+
+    Not a substitute for the slot maps above, which assert that a copy sits in
+    the RIGHT slot. This one only asserts that no copy is off the books.
+    """
+    from src.arcade import palette
+
+    known = {
+        _rgb_to_hex(value).lower()
+        for name, value in vars(palette).items()
+        if name.isupper() and isinstance(value, tuple) and len(value) == 3
+    }
+    # Compound and flag colours are palette data too, held in dicts rather than
+    # as module constants.
+    for mapping in (palette._COMPOUND_COLOUR_BY_LABEL, palette._FLAG_BG_BY_INTENT):
+        known.update(_rgb_to_hex(value).lower() for value in mapping.values())
+    # The empty half of the confidence and scenario bars. It is NOT in
+    # `palette.py` - `orchestrator_card.py` wrote it straight into its own Qt
+    # stylesheet too - and the guard above freezes it to exactly one rule.
+    known.add("#282834")
+    # The Qt reasoning highlighter's five rule colours, ported verbatim from
+    # `reasoning_tabs.py` and living in `agents_view/reasoning.py`. They are a
+    # palette copy the named guards above never covered - this sweep is what
+    # found them - so they are pinned here rather than waved through.
+    #
+    # **Nothing renders them since #1020.** The tabs they coloured are gone;
+    # `build_reasoning` still splits six bodies into per-character runs on every
+    # tick and the segments' colours reach no element. Tracked in #1026.
+    known.update({"#f472b6", "#d946ef", "#facc15", "#22d3ee"})
+
+    roots = (
+        REPO_ROOT / "src" / "pitwall" / "agents_view",
+        UI_SRC / "features",
+        UI_SRC / "lib",
+        UI_SRC / "styles",
+    )
+    # `tokens.css` is the WEB palette and it is deliberately a different one:
+    # both PITWALL windows render in the Qt palette, and CLAUDE.md says so in as
+    # many words. It has its own guard in this file -
+    # `test_the_pitwall_copy_is_byte_identical_to_the_webapp_source` - which is
+    # a stronger claim than membership of `palette.py`.
+    skip = {UI_SRC / "styles" / "tokens.css"}
+    # **Six hex digits, and NOTHING after them.** The first version of this
+    # line ended in a word boundary and the escape did not survive being
+    # written: the compiled pattern was `#[0-9a-fA-F]{6}` followed by a literal
+    # BACKSPACE, so it matched nothing, in any file, ever. The sweep visited 52
+    # files, found zero hexes and passed - a guard about the empty set, written
+    # to close the class of guards about the empty set. What caught it was
+    # planting a hex and watching this stay green.
+    hex_literal = re.compile("#[0-9a-fA-F]{6}")
+
+    # **The pattern, before the files.** Its first version ended in an escape
+    # that did not survive being written, and it matched nothing anywhere -
+    # which looked exactly like a clean repo. One probe is the difference
+    # between a sweep and a green light.
+    assert hex_literal.findall("a #123abc b") == ["#123abc"], (
+        f"the hex pattern matches nothing: {hex_literal.pattern!r}"
+    )
+
+    visited = 0
+    offenders: list[str] = []
+    for root in roots:
+        for path in sorted(root.rglob("*")):
+            if path.suffix not in {".py", ".ts", ".tsx", ".css"} or path in skip:
+                continue
+            visited += 1
+            source = _without_comments(path.read_text("utf-8"))
+            for found in hex_literal.findall(source):
+                if found.lower() not in known:
+                    offenders.append(f"{path.relative_to(REPO_ROOT)}: {found}")
+
+    # The enumeration first. A glob that resolves to nothing - a moved
+    # directory, a wrong `parents[]` - passes silently, and this repo has
+    # already shipped one census that found zero files and said so cheerfully.
+    assert visited >= 25, f"the sweep only visited {visited} files; the roots are wrong"
+    assert not offenders, (
+        "a colour that palette.py does not define is written into PITWALL source: "
+        + "; ".join(offenders)
+    )


### PR DESCRIPTION
## What

Two things a race engineer reads, in the language they read it in.

**The idle copy.** `no prediction — stub` was a word about the CODE on a surface a strategist looks
at under pressure; `no radio/rcm pipeline output` named a pipeline; `triggers on …` described a
routing rule.

| was | is |
|---|---|
| `no prediction — stub` (×3 consoles) | `no reading this lap` |
| `no radio/rcm pipeline output` | `radio silent` |
| `triggers on cliff pressure, compound change, or problem radio` | `wakes on tyre cliff, compound change, or a problem radio` |
| `triggers on compound change, SC >30%, or FIA warning/penalty` | `wakes on compound change, SC risk above 30%, or an FIA warning` |

**The ALERT glyph.** `OK` and `ALERT` were the same filled disc `●` and differed only in green
against red - the most common colour-vision confusion there is - so the two states a reader most
needs to tell apart were, for some readers, one state. ALERT is `▲` now: pointed, conventional, and
legible with the colour removed entirely.

## A false claim in a comment, found on the way

The `STATUS_GLYPHS` comment said the map is compared against `agent_card.py::_GLYPH_FOR` by
`test_the_status_glyphs_match_the_qt_cards`, "for as long as both exist".

**Neither exists.** Sprint 7 retired `src/arcade/dashboard/` and the test went with it; the comment
went on promising a twin-detector that had not run in three sprints. It is rewritten to say what
guards the map now, which is a property rather than a parity.

## Checks

`tests/surfaces/` **259 passed** (two new). `smoke-agents` 53. `ruff check .` and `format --check .`
clean. `npm run typecheck` clean.

The glyph guard asserts **distinctness over the whole map** rather than "ALERT is a triangle": the
property is what matters, and a check on one entry would go on passing the day a fifth state arrives
wearing a disc. Driven red by putting the disc back - `two console states share a glyph and differ
only in colour`. Restored with `cp` + `cmp`.

The copy guard also asserts the absence of the old dialect (`stub`, `pipeline`, `triggers on`,
`rcm`) across all four idle headlines, so the next one written in code-speak fails rather than
matching a string nobody updated.

Captured at 1486x833 and looked at.


Closes #1029
