### PR TITLE
feat(agents): the pace chart says where its prediction stopped

### DIFF
--- a/src/pitwall/agents_view/charts.py
+++ b/src/pitwall/agents_view/charts.py
@@ -99,6 +99,7 @@ def build_pace_series(
     actual: list[list[float]] = []
     pred: list[list[float]] = []
     band: list[list[float]] = []
+    predicted_laps: list[int] = []
     for lap in sorted(history):
         row = history[lap]
         observed = _sane_lap_time(row.get("actual"))
@@ -109,6 +110,7 @@ def build_pace_series(
             actual.append([float(lap), observed])
         if predicted is not None:
             pred.append([float(lap), predicted])
+            predicted_laps.append(lap)
         if low is not None and high is not None:
             band.append([float(lap), low, high])
     return {
@@ -126,6 +128,19 @@ def build_pace_series(
         "x_range": x_range,
         "current_lap": None if current_lap is None else float(current_lap),
         "cursor_colour": CURSOR_COLOUR,
+        # The newest lap that carries a PREDICTION, which is not the newest lap
+        # on the chart. A tick with no `per_agent` block still delivers the
+        # actual lap time, so the solid line keeps advancing while the dashed
+        # one and its band stop where the last prediction was - and nothing on
+        # the chart said so. The renderer dims the two stale series and prints
+        # the lap.
+        #
+        # **Only the PACE chart gets this.** The tyre chart's own stale element
+        # is the cliff band, which is recomputed from `per_agent.tire` every
+        # tick and simply disappears when there is none; its trend is a rolling
+        # mean of OBSERVED lap times and keeps advancing, so dimming it would
+        # claim staleness about live data.
+        "prediction_lap": float(max(predicted_laps)) if predicted_laps else None,
     }
 
 

--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -202,6 +202,7 @@ const VIEW = {
       x_range: [20.5, 34],
       current_lap: 23,
       cursor_colour: "#9ca3af",
+      prediction_lap: 22,
     },
     tire: {
       stints: [
@@ -317,6 +318,25 @@ const barWidths = await page.evaluate(() =>
   [...document.querySelectorAll(".scenario-bar-fill")].map((el) => Math.round(el.getBoundingClientRect().width)),
 );
 check(barWidths[1] > barWidths[0] && barWidths[0] > 0, `the bars carry their fill (${barWidths})`);
+
+// The fixture's prediction stopped a lap behind the car, so the pace chart owes
+// the reader a tag saying where. Asserted on the RENDERED chart rather than on
+// the option object: `graphic` is a config, and a config that never reaches the
+// canvas is exactly the mechanism-instead-of-effect trap this file keeps.
+const staleTag = await page.evaluate(() => {
+  const el = document.querySelector(".slot-pace .chart");
+  const chart = el && el.__pitwallChart;
+  if (!chart) return null;
+  const texts = [];
+  chart.getZr().storage.traverse((shape) => {
+    if (shape.type === "text" && shape.style && shape.style.text) texts.push(shape.style.text);
+  });
+  return texts;
+});
+check(
+  Array.isArray(staleTag) && staleTag.some((t) => t.includes("prediction to L22")),
+  `the pace chart names the lap its prediction stopped at (${JSON.stringify(staleTag)})`,
+);
 check(await page.locator(".orchestrator").isVisible(), "the orchestrator card");
 
 // --- The four strata -------------------------------------------------------

--- a/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
@@ -77,11 +77,6 @@ const IDLE_VIEW: AgentsView = {
     driver: "--",
     lap: "L 0/0",
     playback: "-- × · --",
-    // Qt builds the chip grey in the constructor and its client thread
-    // flips it to amber within milliseconds; the host's own
-    // `_connection_label` answers "Connecting..." until something has been
-    // rendered. Red "Disconnected" matched none of the three. #871 ported
-    // the badge, the plan line and the scores and left this one behind.
     // Overwritten from the polled channel below while there is no view. It is
     // a placeholder, not a claim: the host owns both the word and its colour
     // (`agents_view/panels.CONNECTION_COLOURS`), and this literal used to
@@ -151,6 +146,7 @@ const IDLE_VIEW: AgentsView = {
       x_range: null,
       current_lap: null,
       cursor_colour: "#9ca3af",
+      prediction_lap: null,
     },
     tire: {
       stints: [],

--- a/src/pitwall/ui/src/features/agents/PaceChart.tsx
+++ b/src/pitwall/ui/src/features/agents/PaceChart.tsx
@@ -18,9 +18,40 @@ import { useEChart } from "../../lib/chart";
 import { CHART_BASE, currentLapMark, lapAxis } from "./useEChart";
 
 export function PaceChart({ series }: { series: PaceSeries }) {
+  /**
+   * **The prediction stopped and the actual did not.**
+   *
+   * A tick with no `per_agent` block still carries the lap time, so the solid
+   * line keeps advancing while the dashed one and its band stay where the last
+   * prediction was. Nothing on the chart said so: the reader saw two lines,
+   * one of which had quietly become history.
+   *
+   * Dimmed AND labelled, because dimming alone is ambiguous on a chart that
+   * already draws a translucent band, and a label alone is easy to miss.
+   */
+  const stale =
+    series.prediction_lap !== null &&
+    series.current_lap !== null &&
+    series.prediction_lap < series.current_lap;
+
   const option = useMemo<EChartsOption>(
     () => ({
       ...CHART_BASE,
+      graphic: stale
+        ? [
+            {
+              type: "text",
+              right: 4,
+              top: 2,
+              silent: true,
+              style: {
+                text: `prediction to L${series.prediction_lap}`,
+                fill: series.cursor_colour,
+                font: "10px sans-serif",
+              },
+            },
+          ]
+        : [],
       // The tyre chart's lap axis, borrowed. Two charts of the same quantity
       // side by side used to autorange independently, so lap 23 sat at 95 %
       // of this plot and 47 % of its neighbour — a comparison a reader
@@ -43,7 +74,7 @@ export function PaceChart({ series }: { series: PaceSeries }) {
           stack: "band",
           data: series.band.map(([lap, low, high]) => [lap, high - low]),
           lineStyle: { opacity: 0 },
-          areaStyle: { color: series.band_colour, opacity: 0.2 },
+          areaStyle: { color: series.band_colour, opacity: stale ? 0.07 : 0.2 },
           symbol: "none",
           silent: true,
         },
@@ -51,8 +82,13 @@ export function PaceChart({ series }: { series: PaceSeries }) {
           type: "line",
           name: "predicted",
           data: series.pred,
-          lineStyle: { color: series.pred_colour, width: 2, type: "dashed" },
-          itemStyle: { color: series.pred_colour },
+          lineStyle: {
+            color: series.pred_colour,
+            width: 2,
+            type: "dashed",
+            opacity: stale ? 0.35 : 1,
+          },
+          itemStyle: { color: series.pred_colour, opacity: stale ? 0.35 : 1 },
           symbol: "none",
         },
         {
@@ -66,7 +102,7 @@ export function PaceChart({ series }: { series: PaceSeries }) {
         },
       ],
     }),
-    [series],
+    [series, stale],
   );
 
   return <div className="chart" ref={useEChart(option)} />;

--- a/src/pitwall/ui/src/lib/agents.ts
+++ b/src/pitwall/ui/src/lib/agents.ts
@@ -157,6 +157,12 @@ export interface PaceSeries {
   /** Where the car is NOW, marked on both charts. */
   current_lap: number | null;
   cursor_colour: string;
+  /**
+   * The newest lap carrying a PREDICTION, which is not the newest lap plotted.
+   * A tick with no `per_agent` still delivers the actual lap time, so the solid
+   * line advances while the dashed one stops - and nothing said so.
+   */
+  prediction_lap: number | null;
 }
 
 export interface TireStint {

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -698,6 +698,46 @@ def test_the_situation_card_says_out_of_range_and_never_zero_per_cent():
     assert view["cards"]["situation"]["lines"][0]["text"] == "overtake — (out of model range)"
 
 
+def test_the_pace_chart_says_where_its_prediction_stopped():
+    """The solid line advances and the dashed one does not.
+
+    A tick with no `per_agent` block still carries `lap_time_s`, so the actual
+    keeps being plotted while the prediction and its band stay where the last
+    one was - and nothing on the chart said so. The reader saw two lines, one
+    of which had quietly become history.
+
+    **Only the PACE chart.** The elevation spec dimmed the tyre chart's TREND
+    too, and that is backwards: the trend is a rolling mean of OBSERVED lap
+    times and keeps advancing on exactly the tick that makes the prediction
+    stale, so dimming it would claim staleness about live data. The tyre
+    chart's own stale element is the cliff band, which is recomputed from
+    `per_agent.tire` every tick and disappears when there is none.
+    """
+    from src.pitwall.agents_view.builder import AgentsViewBuilder
+
+    builder = AgentsViewBuilder()
+    for lap in range(20, 23):
+        builder.build(_payload(seq=lap, lap=lap, latest=_latest(lap)))
+
+    # Lap 23 arrives with a lap time and no per-agent block at all.
+    stale = builder.build(_payload(seq=99, lap=23, latest={"lap_number": 23, "lap_time_s": 81.4}))
+
+    pace = stale["charts"]["pace"]
+    assert pace["current_lap"] == 23.0
+    assert pace["prediction_lap"] == 22.0, "the prediction stopped a lap back"
+    assert [lap for lap, _ in pace["actual"]][-1] == 23.0, "and the actual did not"
+
+    # The tyre chart keeps advancing on the same tick, which is why it gets no
+    # tag: its trend is observed data.
+    tire = stale["charts"]["tire"]
+    assert tire["cliff"] is None, "the tyre chart's stale element removes itself"
+    assert [lap for lap, _ in tire["trend"]][-1] == 23.0, "its trend is live"
+
+    # And on a healthy tick the two agree, so the renderer draws no tag.
+    live = builder.build(_payload(seq=100, lap=24, latest=_latest(24)))
+    assert live["charts"]["pace"]["prediction_lap"] == live["charts"]["pace"]["current_lap"]
+
+
 def test_an_active_pit_console_is_not_a_warning_unless_something_is_pressing():
     """Being awake is not being worried.
 


### PR DESCRIPTION
## What

When a tick arrives with no `per_agent` block, the pace chart's prediction and its band dim to 0.35
and the chart prints `prediction to L22` in its corner.

## Why

The actual and the prediction do not stop together. A tick with no `per_agent` still carries
`lap_time_s`, so the solid blue line keeps advancing while the dashed purple one and its band stay
where the last prediction was - and nothing on the chart said so. The reader saw two lines, one of
which had quietly become history, on the state (`s4`) that ships as a golden fixture.

## What the design gate refuted, and it was right

The elevation spec dimmed **both** charts' history and tagged both. That is backwards for the tyre
chart: its `trend` is a rolling mean of **observed** lap times and `ingest_latest` keeps folding
`lap_time_s`, `tyre_life` and `compound` in on exactly the tick that makes the prediction stale, so
dimming it would claim staleness about live data - the inverse of this window's whole doctrine.

The tyre chart's stale element is the **cliff band**, and it removes itself: it is recomputed from
`per_agent.tire` every tick and simply is not there when there is none. The guard asserts that too,
on the same tick.

## Checks

`tests/surfaces/` **262 passed** (one new). `smoke-agents` **54 checks**. `ruff check .` and
`format --check .` clean. `npm run typecheck` clean.

The Python guard drives a real builder through three healthy laps and then one tick carrying a lap
time and nothing else: `prediction_lap == 22` against `current_lap == 23`, the actual still plotted
at 23, the tyre trend still at 23, the cliff gone. It also asserts that on a healthy tick the two
agree, so the tag is not simply always on.

The smoke asserts the tag **on the rendered canvas**, walking the ZRender storage rather than
reading the option object - a `graphic` config that never reaches the canvas is exactly the
mechanism-instead-of-effect trap this file keeps paying for. Driven red by pinning `stale = false`:
the tag list comes back as the axis labels alone. Restored with `cp` + `cmp`.

Captured at 1486x833 and looked at - and the first capture showed no tag, because the fixture
generator had been run from the wrong directory and failed silently behind a `>/dev/null`. The
regenerated fixture carries `prediction_lap: 22.0` and the tag is on the glass.


Closes #1033
