### PR TITLE
feat(agents): the PIT console stops crying wolf, and RADIO ranks severity over recency

### DIFF
--- a/src/pitwall/agent_formatters.py
+++ b/src/pitwall/agent_formatters.py
@@ -439,6 +439,47 @@ def with_model_detail(
     return {"sections": [*tooltip["sections"], *sections], "footer": tooltip.get("footer")}
 
 
+# The card shows at most this many radio lines. Two, because the console spans
+# two grid columns in the decision-band layout and one line left the row half
+# empty; more than two and the RCM line below it falls out of the card.
+_RADIO_LINES = 2
+
+
+def _radios_worth_the_room(
+    radio_events: list[dict[str, Any]], alerts: list[Any]
+) -> list[dict[str, Any]]:
+    """The lap's radios, most important first, capped at what the card holds.
+
+    **Severity before recency, and the severity is not decided here.** The card
+    showed `radio_events[-1]` - the newest, whatever it said - so a rival's
+    routine "box this lap" could evict our own driver reporting a problem, on a
+    surface whose whole purpose is noticing the problem.
+
+    Which intents are severe is a question this module must not answer. The
+    radio agent already did: `_build_alerts` filters by
+    `RadioAgentCFG.alert_intents` and hands the result over in `alerts`, so the
+    ranking reads the agent's own verdict FOR THIS LAP rather than carrying a
+    copy of the rule. That matters here specifically - this repo already has
+    three separately maintained severity maps (`_ALERT_SEVERITY`,
+    `_FLAG_BG_BY_INTENT`, and the agent's own), one of which was found missing a
+    key the others had, and this module cannot import the agent's config at all
+    because doing so loads three models.
+
+    With no alerts the order is recency, which is what it always was.
+    """
+    flagged = {
+        str(alert.get("intent") or alert.get("event_type") or "").upper()
+        for alert in alerts
+        if isinstance(alert, dict)
+    }
+    ranked = sorted(
+        enumerate(radio_events),
+        key=lambda pair: (_radio_intent(pair[1]).upper() in flagged, pair[0]),
+        reverse=True,
+    )
+    return [event for _, event in ranked[:_RADIO_LINES]]
+
+
 def format_radio(r: dict[str, Any] | None) -> Formatted:
     """CLI §1.4: alert intents headline, plus a per-lap transcript ticker.
 
@@ -503,13 +544,12 @@ def format_radio(r: dict[str, Any] | None) -> Formatted:
                 TEXT_SECONDARY,
             )
         )
-    if radio_events:
-        last_radio = radio_events[-1]
+    for event in _radios_worth_the_room(radio_events, alerts):
         body.append(
             (
-                f"{html.escape(_radio_driver(last_radio))} "
-                f"{html.escape(_radio_intent(last_radio))}: "
-                f'"{_escaped(last_radio.get("message"))}"',
+                f"{html.escape(_radio_driver(event))} "
+                f"{html.escape(_radio_intent(event))}: "
+                f'"{_escaped(event.get("message"))}"',
                 TEXT_TERTIARY,
             )
         )
@@ -548,13 +588,27 @@ def format_pit(p: dict[str, Any] | None, active: bool) -> Formatted:
     target = p.get("undercut_target")
     sc_reactive = bool(p.get("sc_reactive", False))
 
-    headline = f"pit {p50:.2f}s → {compound}" + (" · SC" if sc_reactive else "")
+    # "stop", not "pit". `pit_duration_s` is the physical stop and `pit_delta`
+    # is the whole excursion including the lap-time loss; this is the first, and
+    # a headline reading "pit 22.40s" invites the reader to take it for the
+    # second. The two are a pair this repo's notes flag by name.
+    headline = f"stop {p50:.2f}s → {compound}" + (" · SC" if sc_reactive else "")
     lines: list[Line] = [(f"range {p05:.2f}–{p95:.2f}s", TEXT_SECONDARY)]
     if up is not None and target:
         lines.append((f"UCUT {float(up) * 100:.0f}% → {target}", WARNING))
     else:
         lines.append(("no undercut target", TEXT_TERTIARY))
-    return headline, WARNING, lines, STATUS_WATCH
+
+    # **Being awake is not being worried.** The console wore WARNING amber and
+    # WATCH whenever N28 was routed, which is every lap with a pit question -
+    # so the state that means "look at this" was the state that means "this
+    # agent ran". WATCH is kept for the one thing in this block that says
+    # something is pressing: a recommendation driven by safety-car pressure
+    # rather than by tyre or compound logic, which carries a different risk
+    # profile and a deadline.
+    if sc_reactive:
+        return headline, WARNING, lines, STATUS_WATCH
+    return headline, TEXT_PRIMARY, lines, STATUS_OK
 
 
 # --- N30 RAG (conditional) ---------------------------------------------

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -678,7 +678,7 @@ def test_the_view_is_what_the_qt_window_renders_line_for_line():
         "gap 1.4s · Δpace -0.12s/lap",
     ]
 
-    assert cards["pit"]["headline"] == "pit 22.40s → HARD"
+    assert cards["pit"]["headline"] == "stop 22.40s → HARD"
     assert cards["radio"]["headline"] == "quiet"
     assert cards["rag"]["headline"] == "regulation loaded"
 
@@ -696,6 +696,79 @@ def test_the_situation_card_says_out_of_range_and_never_zero_per_cent():
     view = _host(_payload(latest=latest)).get_agents_view(-1)
 
     assert view["cards"]["situation"]["lines"][0]["text"] == "overtake — (out of model range)"
+
+
+def test_an_active_pit_console_is_not_a_warning_unless_something_is_pressing():
+    """Being awake is not being worried.
+
+    The console wore WARNING amber and WATCH whenever N28 was routed, which is
+    every lap with a pit question - so the state that means "look at this" was
+    the state that means "this agent ran", and the reader had no way to tell
+    the two apart on a surface built for pre-attentive triage.
+
+    WATCH is kept for the one thing in the block that says something is
+    pressing: a recommendation driven by safety-car pressure, which carries a
+    different risk profile and a deadline.
+    """
+    from src.arcade.palette import TEXT_PRIMARY, WARNING, hex_str
+    from src.pitwall.agent_formatters import format_pit
+
+    block = {
+        "stop_duration_p05": 21.14,
+        "stop_duration_p50": 22.40,
+        "stop_duration_p95": 24.81,
+        "compound_recommendation": "HARD",
+    }
+
+    calm = format_pit(block, active=True)
+    pressing = format_pit({**block, "sc_reactive": True}, active=True)
+
+    assert calm[0] == "stop 22.40s → HARD", "and it says STOP, not PIT"
+    assert hex_str(calm[1]) == hex_str(TEXT_PRIMARY)
+    assert calm[3] == "OK"
+    assert hex_str(pressing[1]) == hex_str(WARNING)
+    assert pressing[3] == "WATCH"
+    assert pressing[0].endswith(" · SC")
+
+
+def test_the_radio_console_ranks_severity_over_recency():
+    """A rival's routine message could evict our own driver's problem.
+
+    The card showed `radio_events[-1]`, the newest whatever it said, on a
+    surface whose whole purpose is noticing the problem.
+
+    **Severity is read from the agent's own `alerts`**, not from a fourth copy
+    of an intent-severity map - this repo already carries three, one of which
+    was found missing a key the others had, and this module cannot import the
+    agent's config because doing so loads three models.
+    """
+    from src.pitwall.agent_formatters import format_radio
+
+    events = [
+        {"driver": "NOR", "analysis": {"intent": "PROBLEM"}, "message": "no grip at the rear"},
+        {"driver": "RUS", "analysis": {"intent": "INFORMATION"}, "message": "box this lap"},
+    ]
+    block = {
+        "radio_events": events,
+        "rcm_events": [],
+        "alerts": [{"driver": "NOR", "intent": "PROBLEM"}],
+    }
+
+    lines = [text for text, _ in format_radio(block)[2]]
+    messages = [line for line in lines if ":" in line and "radios" not in line]
+
+    assert messages, "the console shows at least one message"
+    assert "no grip at the rear" in messages[0], (
+        f"the flagged radio has to lead, not the newest: {messages}"
+    )
+    assert any("box this lap" in line for line in messages), "and the other still fits"
+
+    # With nothing flagged the order is recency, which is what it always was.
+    quiet = {"radio_events": events, "rcm_events": [], "alerts": []}
+    quiet_lines = [
+        text for text, _ in format_radio(quiet)[2] if ":" in text and "radios" not in text
+    ]
+    assert "box this lap" in quiet_lines[0], f"unflagged falls back to newest-first: {quiet_lines}"
 
 
 def test_every_console_state_has_its_own_shape():


### PR DESCRIPTION
## What

Two console semantics the design gate raised, both about a signal that had stopped being one.

**The PIT console stops crying wolf.** It wore WARNING amber and `WATCH` whenever N28 was routed -
which is every lap with a pit question - so the state that means *look at this* was the state that
means *this agent ran*. `WATCH` is now kept for the one thing in the block that says something is
pressing: a recommendation driven by safety-car pressure, which carries a different risk profile and
a deadline. Its headline also reads `stop 22.40s → HARD` rather than `pit …`: `pit_duration_s` is the
physical stop and `pit_delta` is the whole excursion, and a headline reading `pit` invites the reader
to take the first for the second.

**The RADIO console ranks severity over recency.** It showed `radio_events[-1]` - the newest,
whatever it said - so a rival's routine "box this lap" could evict our own driver reporting a
problem, on a surface whose whole purpose is noticing the problem. It now shows the flagged radios
first, then the newest, up to the two lines the two-column console holds.

## Where the severity comes from, and where it does not

Which intents are severe is a question this module must not answer. This repo already carries
**three** separately maintained severity maps - `_ALERT_SEVERITY`, `_FLAG_BG_BY_INTENT`, and the
radio agent's own `alert_intents` - and one of them was found missing a key the others had. A fourth
here would be that defect on purpose, and `agent_formatters` cannot import the agent's config at all
because doing so loads three models.

So the ranking reads the **agent's own verdict for this lap**: `_build_alerts` already filtered by
`alert_intents` and handed the result over in `alerts`. With no alerts the order is recency, which is
what it always was.

## Checks

`tests/surfaces/` **261 passed** (two new). `smoke-agents` 53. `ruff check .` and `format --check .`
clean.

Both driven red from a scratch copy: the PIT guard fails when the console goes back to
returning WARNING/WATCH unconditionally, and the RADIO guard fails when the ranking goes back to
newest-first. Restored with `cp` + `cmp`, byte-identical.

The RADIO guard also asserts the **fallback**: with nothing flagged, newest-first still leads. A test
that only checked the flagged case would have passed on a ranking that had quietly stopped being a
ranking.


Closes #1031
