### PR TITLE
fix(agents): the exit gate's findings - an LLM string in a markup sink, a calm-green PIT_NOW, an unreachable tooltip

### DIFF
--- a/src/pitwall/agent_formatters.py
+++ b/src/pitwall/agent_formatters.py
@@ -84,6 +84,26 @@ def _escaped(text: str | None, limit: int = 70) -> str:
     return html.escape(_truncate(text, limit))
 
 
+def _markup_safe(value: Any) -> str:
+    """A producer string, made safe as MARKUP, with nothing else done to it.
+
+    `_escaped` is this plus the body's 70-character width budget, which is
+    right for a transcript and wrong for a compound label or a driver code: a
+    truncated `MEDIUM` is a different fact, and a truncated `RUS` is a
+    different driver.
+
+    **Every field that lands in a headline or a body line needs one of the
+    two.** Those still reach the window through `dangerouslySetInnerHTML`
+    because they can carry the compound pill and the flag chips, so the WHOLE
+    line is markup, and the exit gate found the free-text ones riding
+    unescaped: the orchestrator's `undercut_target` is an unconstrained
+    `Optional[str]` filled by an LLM, and it reached the PLAN caption verbatim.
+    `test_no_agent_string_can_become_markup` feeds a hostile string through
+    every formatter rather than trusting this list to stay complete.
+    """
+    return html.escape(str(value))
+
+
 def _truncate(text: str | None, limit: int = 70) -> str:
     """Collapse a free-text string to ``limit`` visible characters with an ellipsis suffix.
 
@@ -216,7 +236,7 @@ def format_tire(t: dict[str, Any] | None) -> Formatted:
         pill = compound_pill_html(compound_label)
         body: list[Line] = [
             (f"deg {deg_text} · {pill}", TEXT_SECONDARY),
-            (warning, _status_colour(status)),
+            (_markup_safe(warning), _status_colour(status)),
         ]
         return headline, TEXT_TERTIARY, body, STATUS_WATCH if status == STATUS_OK else status
 
@@ -225,7 +245,7 @@ def format_tire(t: dict[str, Any] | None) -> Formatted:
     body = [
         (f"range {int(p10)}–{int(p90)} laps", TEXT_SECONDARY),
         (f"deg {deg_text} · {pill}", TEXT_SECONDARY),
-        (warning, _status_colour(status)),
+        (_markup_safe(warning), _status_colour(status)),
     ]
     return headline, TEXT_PRIMARY, body, status
 
@@ -277,7 +297,7 @@ def format_situation(s: dict[str, Any] | None) -> Formatted:
         (f"safety car {sc * 100:.0f}%", sc_color),
         (f"gap {gap:.1f}s · Δpace {_signed(pace_delta, 2)}s/lap", TEXT_TERTIARY),
     ]
-    return f"Threat {threat}", headline_color, body, status
+    return f"Threat {_markup_safe(threat)}", headline_color, body, status
 
 
 # --- N29 Radio ----------------------------------------------------------
@@ -558,6 +578,12 @@ def format_radio(r: dict[str, Any] | None) -> Formatted:
 
 # --- N28 Pit (conditional) ---------------------------------------------
 
+# The two `PitStrategyOutput.action` values that mean "stop on this lap", as
+# opposed to a plan with a window. Read from the agent's own verdict rather
+# than inferred from a proxy: `sc_reactive` covers safety-car urgency only, and
+# keying on it alone painted a degradation-driven PIT_NOW calm green.
+_PIT_ACTIONS_NOW: frozenset[str] = frozenset({"PIT_NOW", "REACTIVE_SC"})
+
 
 def format_pit(p: dict[str, Any] | None, active: bool) -> Formatted:
     """CLI §1.5: active shows pit p50 → compound; idle shows trigger hint.
@@ -592,21 +618,32 @@ def format_pit(p: dict[str, Any] | None, active: bool) -> Formatted:
     # is the whole excursion including the lap-time loss; this is the first, and
     # a headline reading "pit 22.40s" invites the reader to take it for the
     # second. The two are a pair this repo's notes flag by name.
-    headline = f"stop {p50:.2f}s → {compound}" + (" · SC" if sc_reactive else "")
+    headline = f"stop {p50:.2f}s → {_markup_safe(compound)}" + (" · SC" if sc_reactive else "")
     lines: list[Line] = [(f"range {p05:.2f}–{p95:.2f}s", TEXT_SECONDARY)]
     if up is not None and target:
-        lines.append((f"UCUT {float(up) * 100:.0f}% → {target}", WARNING))
+        lines.append((f"UCUT {float(up) * 100:.0f}% → {_markup_safe(target)}", WARNING))
     else:
         lines.append(("no undercut target", TEXT_TERTIARY))
 
-    # **Being awake is not being worried.** The console wore WARNING amber and
-    # WATCH whenever N28 was routed, which is every lap with a pit question -
-    # so the state that means "look at this" was the state that means "this
-    # agent ran". WATCH is kept for the one thing in this block that says
-    # something is pressing: a recommendation driven by safety-car pressure
-    # rather than by tyre or compound logic, which carries a different risk
-    # profile and a deadline.
-    if sc_reactive:
+    # **Being awake is not being worried - but a stop THIS LAP is.**
+    #
+    # The console wore WARNING amber and WATCH whenever N28 was routed, which is
+    # every lap with a pit question, so the state that means "look at this" was
+    # the state that means "this agent ran". Removing that took the urgent lap
+    # with it: keyed on `sc_reactive` alone, a degradation- or undercut-driven
+    # `PIT_NOW` with low safety-car probability rendered a green OK disc while
+    # the SAME card's model detail printed `action = PIT_NOW` and
+    # `recommended_lap = <this lap>`. The glyph contradicted its own dump.
+    #
+    # So the question is the agent's own verdict, not a proxy for it.
+    # `PitStrategyOutput.action` is PIT_NOW / STAY_OUT / UNDERCUT / OVERCUT /
+    # REACTIVE_SC and `recommended_lap` is this lap whenever the action is not
+    # STAY_OUT; the two that mean "stop now" get WATCH. UNDERCUT and OVERCUT
+    # are plans with a window rather than a deadline, and they stay calm - the
+    # UCUT line carries their own amber.
+    action = str(p.get("action") or "").upper()
+    pressing = sc_reactive or action in _PIT_ACTIONS_NOW
+    if pressing:
         return headline, WARNING, lines, STATUS_WATCH
     return headline, TEXT_PRIMARY, lines, STATUS_OK
 
@@ -648,7 +685,7 @@ def _format_article_refs(articles: list[Any] | None) -> str:
         return ""
     head = cleaned[:3]
     tail = ", ..." if len(cleaned) > 3 else ""
-    return "Art. " + ", ".join(head) + tail
+    return "Art. " + ", ".join(_markup_safe(item) for item in head) + tail
 
 
 def rag_tooltip(r: dict[str, Any] | None) -> dict[str, Any] | None:
@@ -668,13 +705,25 @@ def rag_tooltip(r: dict[str, Any] | None) -> dict[str, Any] | None:
     if r is None:
         return None
     chunks = r.get("chunks") or []
-    if not chunks:
+    answer = str(r.get("answer") or "").strip()
+    # **The answer alone is enough to open a tooltip.** It used to require
+    # chunks, so a lap whose retriever returned none had no popup at all - and
+    # the answer is the one synthesised sentence this console exists to deliver.
+    if not chunks and not answer:
         return None
 
     sections: list[dict[str, Any]] = []
     question = (r.get("question") or "").strip()
     if question:
         sections.append({"title": "Question", "rows": [{"lead": "", "text": question}]})
+    # **The answer, in full.** The card renders it through `_escaped`'s 70
+    # character budget, so anything longer was truncated there and absent here -
+    # the model's actual answer reachable NOWHERE, while this function's own
+    # docstring said "the full answer text ... lives in the tooltip". Every
+    # other console's full text was wired into its popup in #1019; this is the
+    # one that was left with a ceiling on its primary content.
+    if answer:
+        sections.append({"title": "Answer", "rows": [{"lead": "", "text": answer}]})
 
     head = chunks[:4]
     for chunk in head:
@@ -699,9 +748,14 @@ def format_rag(rag: dict[str, Any] | str | None, active: bool) -> Formatted:
     The active branch surfaces a 70-character snippet of the LLM answer
     on body line 1 and the first three deduplicated article references
     (``"Art. 48.3, 55.1"``) on body line 2. The 70-char cap mirrors the
-    radio ticker so the two cards read as a balanced pair; the full
-    answer text and every retrieved chunk live in the tooltip, which the
-    window wires onto the card via ``rag_tooltip_html``.
+    radio ticker so the two cards read as a balanced pair; the full answer
+    text and every retrieved chunk live in the tooltip (``rag_tooltip``).
+
+    **That last sentence was false until the sprint-10 exit gate.** The
+    tooltip carried the question and the chunks and never the answer, so an
+    answer longer than 70 characters existed nowhere the reader could get to
+    it - and the function that says otherwise is this one. It also named
+    ``rag_tooltip_html``, which has not existed since sprint 8.
 
     The parameter is typed permissively (``dict | str | None``) because
     the upstream wire historically carried only the answer string; when

--- a/src/pitwall/agents_view/builder.py
+++ b/src/pitwall/agents_view/builder.py
@@ -49,8 +49,15 @@ class AgentsViewBuilder:
         self._run: dict[str, Any] | None = None
         self._seq: int | None = None
 
-    def build(self, payload: dict[str, Any], connection: str = "Connected") -> dict[str, Any]:
-        """The whole view for one tick."""
+    def build(self, payload: dict[str, Any], connection: str) -> dict[str, Any]:
+        """The whole view for one tick.
+
+        `connection` has **no default**. It used to default to "Connected",
+        which is a green claim about a socket in the one field whose entire job
+        (#982, #1004, #1024) is to say when that claim is false - and a caller
+        that forgot the argument got it for free. The only production caller
+        always passes `_connection_label()`.
+        """
         strategy = payload.get("strategy") or {}
         latest = strategy.get("latest") or {}
 

--- a/src/pitwall/agents_view/decision.py
+++ b/src/pitwall/agents_view/decision.py
@@ -16,6 +16,7 @@ changes which scenario reads as the winner.
 
 from __future__ import annotations
 
+import html
 import re
 from typing import Any
 
@@ -44,9 +45,12 @@ from src.pitwall.reasoning_lines import clean
 # point of an alarm colour is pre-attentive triage, and six semantics deny the
 # reader exactly that at the moment they need it.
 #
-# DANGER now belongs to alarm-class facts: the ALERT glyph and a dead
-# connection. The guardrail line was the third and it is gone, because nothing
-# could fill it (#974, `build_orchestrator`). The dicts stay rather than
+# DANGER's owners now, enumerated rather than described - the exit gate found
+# this comment claiming two while the file gave it four: the ALERT glyph, a dead
+# connection, the imperative ACTION text (`classify_action` paints PIT_NOW and
+# ERROR red, and the band renders that as the word plus its 4 px rule), and the
+# confidence floor below 0.33. A HIGH threat headline is a fifth site one module
+# over. What the posture chips must NOT be is a sixth. The dicts stay rather than
 # collapsing into a constant, because a posture the producer has never sent
 # must still fall to TEXT_TERTIARY - which is what says "not reported" as
 # against "reported and unremarkable".
@@ -98,10 +102,17 @@ def _plan_line(latest: dict[str, Any], action: str) -> str:
         if action.upper() == "STAY_OUT":
             return "stint continues · no pit window yet"
         return "Pit plan pending"
+    # **Escaped, because this whole string is MARKUP.** It carries the compound
+    # pill, so `PlanTimeline` renders it through `dangerouslySetInnerHTML` - and
+    # `undercut_target` is an unconstrained `Optional[str]` the orchestrator LLM
+    # fills. The exit gate fed it `<img src=x onerror=...>` and watched it reach
+    # the caption verbatim, beside a comment of mine claiming the escaped pill
+    # was "the last markup sink on this window's decision surface". The pill was;
+    # the field next to it was not.
     bits = [
-        f"Pit: L{pit_target}" if pit_target else "Pit: —",
+        f"Pit: L{html.escape(str(pit_target))}" if pit_target else "Pit: —",
         f"Next: {compound_pill_html(compound_next)}" if compound_next else "Next: —",
-        f"UCUT: {undercut_target}" if undercut_target else "UCUT: —",
+        f"UCUT: {html.escape(str(undercut_target))}" if undercut_target else "UCUT: —",
     ]
     return " · ".join(bits)
 
@@ -158,7 +169,8 @@ def _previous_call(latest: dict[str, Any], tail: list[dict[str, Any]] | None) ->
 # that family.
 #
 # The bias is deliberate: when the rule is unsure it does NOT split, and the
-# module shows a longer sentence that CSS clamps to two lines. A first sentence
+# module shows a longer sentence that CSS clamps to three lines
+# (`.why-narrative`). A first sentence
 # that is too long is a layout question; one that is truncated is a lie.
 _SENTENCE_END = re.compile(r"(?<=[.!?])\s+(?=[A-Z\"'(])")
 _MIN_WORDS = 2

--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -772,8 +772,75 @@ check(
   `and nothing is clipped inside it (${reached.map((r) => r.clipped).join(", ")})`,
 );
 
+// **A popup taller than its 22rem cap must be reachable, by either hand.**
+// It has a visible scrollbar and nothing could drive it: the pointer crossing
+// the 10 px gap fired the card's `mouseleave` and unmounted it, and the
+// keyboard could not reach an element the tab order never visits. A RADIO lap
+// with the model-detail sections appended after its rows overflows routinely.
+//
+// Forced, not waited for - the cap depends on the fonts the machine has.
+{
+  const tall = await page.addStyleTag({
+    content: ".agent-tooltip { max-height: 60px !important; }",
+  });
+  await page.locator(".agent-card").nth(4).hover();
+  await page.waitForTimeout(200);
+  const overflowed = await page.evaluate(() => {
+    const tip = document.querySelector(".agent-tooltip");
+    return tip ? tip.scrollHeight - tip.clientHeight : null;
+  });
+  check(overflowed > 0, `the probe really does overflow the popup (${overflowed})`);
+
+  // The pointer: from the card into the popup, which must survive the crossing.
+  const box = await page.locator(".agent-tooltip").boundingBox();
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.waitForTimeout(220);
+  check(
+    (await page.locator(".agent-tooltip").count()) === 1,
+    "the popup survives the pointer crossing the gap into it",
+  );
+  await page.mouse.wheel(0, 200);
+  await page.waitForTimeout(150);
+  const wheeled = await page.evaluate(() => document.querySelector(".agent-tooltip")?.scrollTop ?? 0);
+  check(wheeled > 0, `and a wheel over it reaches its tail (${wheeled})`);
+
+  // The keyboard: the arrows are forwarded from the card, so the reader never
+  // has to reach an element Tab does not visit.
+  await page.mouse.move(0, 0);
+  await page.waitForTimeout(220);
+  // Blur first. `.focus()` on the element that is ALREADY `activeElement` fires
+  // no focus event, and the keyboard walk above left focus on this very card -
+  // so the probe read a closed popup and blamed the arrows.
+  await page.evaluate(() => document.activeElement?.blur());
+  await page.waitForTimeout(80);
+  await page.locator(".agent-card").nth(4).focus();
+  await page.waitForTimeout(200);
+  const beforeArrow = await page.evaluate(() => {
+    const tip = document.querySelector(".agent-tooltip");
+    const active = document.activeElement;
+    return {
+      open: Boolean(tip),
+      id: tip ? tip.id : null,
+      over: tip ? tip.scrollHeight - tip.clientHeight : null,
+      focused: active ? [...active.classList].join(".") : null,
+    };
+  });
+  check(beforeArrow.open, `the popup is open under keyboard focus (${JSON.stringify(beforeArrow)})`);
+  await page.keyboard.press("ArrowDown");
+  await page.keyboard.press("ArrowDown");
+  await page.waitForTimeout(150);
+  const arrowed = await page.evaluate(() => document.querySelector(".agent-tooltip")?.scrollTop ?? 0);
+  check(arrowed > 0, `and ArrowDown from the card scrolls it too (${arrowed})`);
+
+  await tall.evaluate((node) => node.remove());
+  await page.mouse.move(0, 0);
+  await page.waitForTimeout(220);
+}
+
+await page.locator(".agent-card").nth(4).focus();
+await page.waitForTimeout(200);
 await page.keyboard.press("Escape");
-await page.waitForTimeout(120);
+await page.waitForTimeout(160);
 check(
   (await page.locator(".agent-tooltip").count()) === 0,
   "Escape closes it without moving focus away",

--- a/src/pitwall/ui/src/features/agents/AgentCard.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentCard.tsx
@@ -37,7 +37,7 @@ export function AgentCard({
   // the empty string Qt used, because a falsy value that is also a legitimate
   // rendering is the sentinel shape this repo keeps paying for.
   const tooltipId = `tip-${slot ?? title.toLowerCase()}`;
-  const { anchor, props } = useTooltipTarget(tooltipId, card.tooltip !== null);
+  const { anchor, props, hold } = useTooltipTarget(tooltipId, card.tooltip !== null);
 
 
   return (
@@ -62,7 +62,7 @@ export function AgentCard({
       </header>
 
       {card.tooltip && anchor ? (
-        <Tooltip view={card.tooltip} anchor={anchor} id={tooltipId} />
+        <Tooltip view={card.tooltip} anchor={anchor} id={tooltipId} hold={hold} />
       ) : null}
 
       {/* The card scrolls here, not on the card itself, so the card is not

--- a/src/pitwall/ui/src/features/agents/Tooltip.tsx
+++ b/src/pitwall/ui/src/features/agents/Tooltip.tsx
@@ -27,7 +27,18 @@ import type { TooltipView } from "../../lib/agents";
 /** Breathing room between the card and the popup, and from the viewport edge. */
 const TOOLTIP_GAP = 10;
 
-export function Tooltip({ view, anchor, id }: { view: TooltipView; anchor: DOMRect; id: string }) {
+export function Tooltip({
+  view,
+  anchor,
+  id,
+  hold,
+}: {
+  view: TooltipView;
+  anchor: DOMRect;
+  id: string;
+  /** Keeps the popup open while the pointer is inside it. */
+  hold?: { onMouseEnter: () => void; onMouseLeave: () => void };
+}) {
   const ref = useRef<HTMLSpanElement>(null);
   const [box, setBox] = useState({ left: anchor.left, top: anchor.top + 32 });
 
@@ -92,7 +103,7 @@ export function Tooltip({ view, anchor, id }: { view: TooltipView; anchor: DOMRe
   // presentation below can drift from the Qt window's; the structure the host
   // returns is pinned by a test.
   return createPortal(
-    <span ref={ref} id={id} role="tooltip" className="agent-tooltip" style={box}>
+    <span ref={ref} id={id} role="tooltip" className="agent-tooltip" style={box} {...hold}>
       {view.sections.map((section, index) => (
         <span className="tip-section" key={index}>
           <span className="tip-title">{section.title}</span>
@@ -123,22 +134,80 @@ export function Tooltip({ view, anchor, id }: { view: TooltipView; anchor: DOMRe
  */
 export function useTooltipTarget(id: string, enabled: boolean) {
   const [anchor, setAnchor] = useState<DOMRect | null>(null);
-  const open = (element: HTMLElement) => enabled && setAnchor(element.getBoundingClientRect());
-  const close = () => setAnchor(null);
+  // The pointer's grace period between leaving the card and entering the popup,
+  // which sits `TOOLTIP_GAP` away from it. Long enough to cross 10 px, short
+  // enough that a popup left behind by a moving pointer does not linger.
+  const closing = useRef<number | undefined>(undefined);
+
+  const open = (element: HTMLElement) => {
+    window.clearTimeout(closing.current);
+    if (enabled) setAnchor(element.getBoundingClientRect());
+  };
+  const close = () => {
+    window.clearTimeout(closing.current);
+    setAnchor(null);
+  };
+  const closeSoon = () => {
+    window.clearTimeout(closing.current);
+    closing.current = window.setTimeout(() => setAnchor(null), 140);
+  };
+
+  /**
+   * **The popup's own content had no input path to it.**
+   *
+   * It has `max-height: 22rem` and a visible scrollbar, and the stylesheet
+   * argues the bar is the signal for a busy lap. Nothing could drive it. The
+   * mouse could not: the popup is a portal positioned 10 px away, so crossing
+   * the gap fired the card's `mouseleave` and unmounted it. The keyboard could
+   * not either: focus sits on the card, the popup has no `tabIndex`, and Tab
+   * moves focus, which closes it. So a RADIO tooltip on a busy lap - rows, then
+   * the model-detail sections appended after them - kept its reasoning and its
+   * nine `key = value` rows permanently below the fold.
+   *
+   * Two paths, one for each hand. The pointer gets the standard hover-intent
+   * grace period, and the popup keeps itself open while the pointer is inside
+   * it. The keyboard gets the arrows, forwarded from the card, so the reader
+   * never has to reach an element the tab order does not visit.
+   */
+  const hold = {
+    onMouseEnter: () => window.clearTimeout(closing.current),
+    onMouseLeave: close,
+  };
+
+  const scrollPopup = (delta: number) => {
+    const popup = document.getElementById(id);
+    if (!popup) return false;
+    const before = popup.scrollTop;
+    popup.scrollTop = before + delta;
+    return popup.scrollTop !== before;
+  };
 
   return {
     anchor,
+    /** Spread on the popup, so the pointer can enter it without closing it. */
+    hold,
     props: {
       // Only a target that HAS something to show is a tab stop; empty stops
       // between the reader and the next panel are a cost, not a courtesy.
       tabIndex: enabled ? 0 : undefined,
       "aria-describedby": enabled && anchor ? id : undefined,
       onMouseEnter: (event: React.MouseEvent<HTMLElement>) => open(event.currentTarget),
-      onMouseLeave: close,
+      onMouseLeave: closeSoon,
       onFocus: (event: React.FocusEvent<HTMLElement>) => open(event.currentTarget),
+      // Immediate, unlike the pointer's. Blur means the reader has moved on
+      // deliberately, and a grace period here left the previous console's popup
+      // on screen beside the next one's - two popups, and `aria-describedby`
+      // pointing at whichever the DOM listed first.
       onBlur: close,
       onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => {
-        if (event.key === "Escape") close();
+        if (event.key === "Escape") {
+          close();
+          return;
+        }
+        // Only swallow the arrow when it actually moved the popup; otherwise
+        // the reader loses the page scroll for nothing.
+        const step = event.key === "ArrowDown" ? 48 : event.key === "ArrowUp" ? -48 : 0;
+        if (step && scrollPopup(step)) event.preventDefault();
       },
     },
   };

--- a/src/pitwall/ui/src/features/agents/WhyPanel.tsx
+++ b/src/pitwall/ui/src/features/agents/WhyPanel.tsx
@@ -24,14 +24,14 @@ import { Tooltip, useTooltipTarget } from "./Tooltip";
 const TOOLTIP_ID = "tip-why";
 
 export function WhyPanel({ view }: { view: OrchestratorView }) {
-  const { anchor, props } = useTooltipTarget(TOOLTIP_ID, view.why_detail !== null);
+  const { anchor, props, hold } = useTooltipTarget(TOOLTIP_ID, view.why_detail !== null);
 
   return (
     <section className="card why-panel" {...props}>
       <h2 className="band-title">WHY THIS CALL</h2>
 
       {view.why_detail && anchor ? (
-        <Tooltip view={view.why_detail} anchor={anchor} id={TOOLTIP_ID} />
+        <Tooltip view={view.why_detail} anchor={anchor} id={TOOLTIP_ID} hold={hold} />
       ) : null}
 
       {/* An em dash, not an empty box. Before the first decision there is no

--- a/src/pitwall/ui/src/styles/agents.css
+++ b/src/pitwall/ui/src/styles/agents.css
@@ -686,11 +686,15 @@
 
 /* --- The two embedded charts --------------------------------------------- */
 
-/* The 260-420 band lives on the grid row (`.agents-right`), which carries
- * Qt's own caps; inside it the chart takes whatever the text leaves. An
- * earlier version of this comment said the row grew freely and that the
- * two magic numbers were absent - #871 put them in the sheet three
- * hundred lines above and left the sentence standing. */
+/* The chart takes whatever its console's text leaves.
+ *
+ * **Third generation of this comment, and the second time it was wrong about
+ * the same rule.** It described a 260-420 band on `.agents-right`, a column
+ * the decision band deleted; before that it claimed the row grew freely while
+ * the caps sat three hundred lines above it. There is no band and no right
+ * column now: the two chart consoles stretch to their grid row (`agents.css`'s
+ * `.agents-grid > .slot-pace`) and the chart fills what the headline and body
+ * do not take. */
 .chart {
   width: 100%;
   height: 100%;

--- a/src/pitwall/webserver.py
+++ b/src/pitwall/webserver.py
@@ -70,7 +70,9 @@ class TickSource(Protocol):
 
     def get_live_lap(self, since_rev: int = -1) -> dict[str, Any] | None: ...
 
-    def get_connection(self) -> str: ...
+    # `{label, colour}` since #1024: the colour rides with the word so the two
+    # windows cannot colour one socket state differently, which they did.
+    def get_connection(self) -> dict[str, str]: ...
 
 
 # Readers that take "the revision I hold" and answer null when it is current.

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -8,6 +8,7 @@ file guards the properties that make that possible.
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 import textwrap
@@ -185,7 +186,7 @@ def test_the_plan_timeline_spans_the_race_and_not_the_chart_window():
     for lap in range(1, 46):
         latest = _latest(lap)
         latest["compound"] = "MEDIUM" if lap <= 20 else "HARD"
-        view = builder.build(_payload(seq=lap, lap=lap, latest=latest))
+        view = builder.build(_payload(seq=lap, lap=lap, latest=latest), "Connected")
 
     timeline = view["plan_timeline"]
     assert len(view["history"]["tire"]) == KEEP_LAPS, "the chart store really did trim"
@@ -418,6 +419,124 @@ def test_every_reasoning_tab_body_is_reachable_from_its_card_tooltip():
             for row in section["rows"]
         )
         assert "own sentence for this lap" in rendered, f"{key}'s reasoning is not reachable"
+
+
+# A string that is harmless as TEXT and a tag as MARKUP. Not a curiosity: the
+# orchestrator's `undercut_target` is an unconstrained `Optional[str]` an LLM
+# fills, and every card headline and body line still reaches the window through
+# `dangerouslySetInnerHTML` because it can carry the compound pill.
+_HOSTILE = '<img src=x onerror="boom">'
+
+
+def test_no_agent_string_can_become_markup():
+    """Every formatter, every string-shaped field, one hostile value.
+
+    **Written because the enumeration is what fails, not the escaping.** The
+    module has had `_escaped` since sprint 8 and a docstring claiming every
+    free-text field went through it; the exit gate found six that did not, one
+    of them reaching a `dangerouslySetInnerHTML` sink this very sprint added.
+    A test naming the six would be the same list one layer down.
+
+    So this feeds `<img src=x onerror=...>` into every string field the
+    formatters accept and asserts no unescaped `<` survives into a headline or
+    a body line. A new field lands in this test the day it lands in a payload,
+    without anyone remembering to add it.
+
+    Tooltips are excluded ON PURPOSE and asserted separately: they return DATA
+    and the TSX renders React text nodes, so escaping there would put
+    `&lt;` on the screen as characters.
+    """
+    from src.pitwall.agent_formatters import (
+        format_pace,
+        format_pit,
+        format_radio,
+        format_rag,
+        format_situation,
+        format_tire,
+    )
+
+    blocks = {
+        "pace": (format_pace, {"lap_time_pred": 81.0, "delta_vs_prev": -0.2}),
+        "tire": (
+            format_tire,
+            {"compound": _HOSTILE, "warning_level": _HOSTILE, "laps_to_cliff_p50": 6.0},
+        ),
+        "situation": (format_situation, {"threat_level": _HOSTILE, "gap_ahead_s": 1.4}),
+        "radio": (
+            format_radio,
+            {
+                "radio_events": [{"driver": _HOSTILE, "message": _HOSTILE}],
+                "rcm_events": [{"lap": 23, "message": _HOSTILE}],
+                "alerts": [],
+            },
+        ),
+        "rag": (
+            format_rag,
+            {"question": _HOSTILE, "answer": _HOSTILE, "articles": [_HOSTILE], "chunks": []},
+        ),
+        "pit": (
+            format_pit,
+            {
+                "stop_duration_p50": 22.4,
+                "compound_recommendation": _HOSTILE,
+                "undercut_prob": 0.6,
+                "undercut_target": _HOSTILE,
+            },
+        ),
+    }
+
+    # **The assertion is "no angle bracket survives", not "no `<img` survives".**
+    # The first draft looked for the literal tag and passed against a real
+    # regression, because `format_situation` upper-cases its field and the
+    # headline read `Threat <IMG SRC=...>`. A case-sensitive substring check is
+    # a guard that is right for the wrong reason.
+    #
+    # The palette's own pill and chip spans are the one legitimate markup on
+    # these lines, so they are removed first - and the removal is anchored to
+    # their exact shape rather than to `<span`, so a hostile string wearing a
+    # span of its own is not waved through.
+    pill = re.compile(r'<span style="background-color: #[0-9a-f]{6};[^"]*">.*?</span>')
+
+    checked = 0
+    for name, (formatter, block) in blocks.items():
+        formatted = formatter(block, active=True) if name in {"pit", "rag"} else formatter(block)
+        headline, _, lines, _ = formatted
+        for text in [headline, *(line for line, _ in lines)]:
+            checked += 1
+            residue = pill.sub("", text)
+            assert "<" not in residue and ">" not in residue, (
+                f"{name}: an unescaped angle bracket reached a rendered line: {text!r}"
+            )
+
+    assert checked >= 12, f"only {checked} rendered strings were probed"
+
+
+def test_the_plan_caption_escapes_the_field_an_llm_fills():
+    """The sink this sprint added, and the field that rides into it.
+
+    `_plan_line` composes markup - it carries the compound pill - and
+    `PlanTimeline` renders it through `dangerouslySetInnerHTML`.
+    `undercut_target` is `Optional[str]` on `StrategyRecommendation` with no
+    pattern and no length bound, filled by the orchestrator LLM.
+    """
+    from src.pitwall.agents_view.decision import build_orchestrator
+
+    caption = build_orchestrator(
+        {
+            "action": "PIT_NOW",
+            "confidence": 0.7,
+            "pit_lap_target": 24,
+            "compound_next": "HARD",
+            "undercut_target": _HOSTILE,
+        }
+    )["plan"]
+
+    residue = re.sub(r'<span style="background-color: #[0-9a-f]{6};[^"]*">.*?</span>', "", caption)
+    assert "<" not in residue and ">" not in residue, f"the caption carries a tag: {caption!r}"
+    assert "&lt;img" in caption, "and the text is still there, escaped"
+    # The pill IS markup and must survive as markup, or the fix would have
+    # escaped the one thing on this line that is supposed to be a span.
+    assert '<span style="background-color:' in caption
 
 
 def test_the_tooltips_return_data_and_never_markup():
@@ -717,10 +836,12 @@ def test_the_pace_chart_says_where_its_prediction_stopped():
 
     builder = AgentsViewBuilder()
     for lap in range(20, 23):
-        builder.build(_payload(seq=lap, lap=lap, latest=_latest(lap)))
+        builder.build(_payload(seq=lap, lap=lap, latest=_latest(lap)), "Connected")
 
     # Lap 23 arrives with a lap time and no per-agent block at all.
-    stale = builder.build(_payload(seq=99, lap=23, latest={"lap_number": 23, "lap_time_s": 81.4}))
+    stale = builder.build(
+        _payload(seq=99, lap=23, latest={"lap_number": 23, "lap_time_s": 81.4}), "Connected"
+    )
 
     pace = stale["charts"]["pace"]
     assert pace["current_lap"] == 23.0
@@ -734,7 +855,7 @@ def test_the_pace_chart_says_where_its_prediction_stopped():
     assert [lap for lap, _ in tire["trend"]][-1] == 23.0, "its trend is live"
 
     # And on a healthy tick the two agree, so the renderer draws no tag.
-    live = builder.build(_payload(seq=100, lap=24, latest=_latest(24)))
+    live = builder.build(_payload(seq=100, lap=24, latest=_latest(24)), "Connected")
     assert live["charts"]["pace"]["prediction_lap"] == live["charts"]["pace"]["current_lap"]
 
 
@@ -760,7 +881,7 @@ def test_an_active_pit_console_is_not_a_warning_unless_something_is_pressing():
         "compound_recommendation": "HARD",
     }
 
-    calm = format_pit(block, active=True)
+    calm = format_pit({**block, "action": "STAY_OUT"}, active=True)
     pressing = format_pit({**block, "sc_reactive": True}, active=True)
 
     assert calm[0] == "stop 22.40s → HARD", "and it says STOP, not PIT"
@@ -769,6 +890,26 @@ def test_an_active_pit_console_is_not_a_warning_unless_something_is_pressing():
     assert hex_str(pressing[1]) == hex_str(WARNING)
     assert pressing[3] == "WATCH"
     assert pressing[0].endswith(" · SC")
+
+    # **And the console reads its own agent's verdict, not a proxy for it.**
+    # Keyed on `sc_reactive` alone, a degradation- or undercut-driven PIT_NOW
+    # with low safety-car probability rendered a green OK disc while the SAME
+    # card's model detail printed `action = PIT_NOW` - the glyph contradicting
+    # its own dump. Asserted over the whole enumeration of
+    # `PitStrategyOutput.action`, because a check on PIT_NOW alone would go on
+    # passing the day a sixth value arrives.
+    by_action = {
+        action: format_pit({**block, "action": action}, active=True)[3]
+        for action in ("PIT_NOW", "REACTIVE_SC", "UNDERCUT", "OVERCUT", "STAY_OUT")
+    }
+    assert by_action == {
+        "PIT_NOW": "WATCH",
+        "REACTIVE_SC": "WATCH",
+        # A plan with a window, not a deadline. Their own amber is the UCUT line.
+        "UNDERCUT": "OK",
+        "OVERCUT": "OK",
+        "STAY_OUT": "OK",
+    }, by_action
 
 
 def test_the_radio_console_ranks_severity_over_recency():
@@ -1637,11 +1778,11 @@ def test_a_different_race_does_not_inherit_the_last_ones_laps():
 
     builder = AgentsViewBuilder()
     for lap in range(14, 24):
-        builder.build(_payload(seq=lap, lap=lap))
-    melbourne = builder.build(_payload(seq=30, lap=23))
+        builder.build(_payload(seq=lap, lap=lap), "Connected")
+    melbourne = builder.build(_payload(seq=30, lap=23), "Connected")
     assert len(melbourne["history"]["pace"]) >= 9, "the fixture never accumulated anything"
 
-    suzuka = builder.build(_other_race_payload(seq=1, lap=3))
+    suzuka = builder.build(_other_race_payload(seq=1, lap=3), "Connected")
     laps = [row["lap"] for row in suzuka["history"]["pace"]]
     assert laps == [3], f"the new race inherited {laps}"
 
@@ -1657,9 +1798,9 @@ def test_the_same_race_relaunched_is_a_restart_too():
 
     builder = AgentsViewBuilder()
     for lap in range(14, 24):
-        builder.build(_payload(seq=lap, lap=lap))
+        builder.build(_payload(seq=lap, lap=lap), "Connected")
 
-    relaunched = builder.build(_payload(seq=1, lap=2))
+    relaunched = builder.build(_payload(seq=1, lap=2), "Connected")
     laps = [row["lap"] for row in relaunched["history"]["pace"]]
     assert laps == [2], f"the relaunched run inherited {laps}"
 
@@ -1676,11 +1817,11 @@ def test_a_rewind_inside_one_run_still_evicts_nothing():
 
     builder = AgentsViewBuilder()
     for lap in range(14, 24):
-        builder.build(_payload(seq=lap, lap=lap))
+        builder.build(_payload(seq=lap, lap=lap), "Connected")
 
     rewound = _payload(seq=99, lap=15)
     rewound["playback"]["frame_index"] = 10
-    view = builder.build(rewound)
+    view = builder.build(rewound, "Connected")
     laps = [row["lap"] for row in view["history"]["pace"]]
     assert max(laps) == 23, f"a rewind evicted the future: {laps}"
 
@@ -1697,13 +1838,13 @@ def test_the_stale_lap_that_setdefault_would_have_made_permanent():
 
     builder = AgentsViewBuilder()
     for lap in range(14, 24):
-        builder.build(_payload(seq=lap, lap=lap))
+        builder.build(_payload(seq=lap, lap=lap), "Connected")
 
     fresh = _other_race_payload(seq=1, lap=3)
     fresh["strategy"]["history_tail"] = [
         {"lap_number": 18, "lap_time_s": 92.18, "tyre_life": 4, "compound": "MEDIUM"}
     ]
-    view = builder.build(fresh)
+    view = builder.build(fresh, "Connected")
     lap18 = next((row for row in view["history"]["pace"] if row["lap"] == 18), None)
     assert lap18 is not None and lap18["actual"] == 92.18, (
         f"lap 18 kept the dead race's number: {lap18}"

--- a/tests/surfaces/test_pitwall_tokens.py
+++ b/tests/surfaces/test_pitwall_tokens.py
@@ -529,12 +529,24 @@ def test_no_pitwall_source_file_carries_an_unregistered_hex():
     # tick and the segments' colours reach no element. Tracked in #1026.
     known.update({"#f472b6", "#d946ef", "#facc15", "#22d3ee"})
 
-    roots = (
-        REPO_ROOT / "src" / "pitwall" / "agents_view",
-        UI_SRC / "features",
-        UI_SRC / "lib",
-        UI_SRC / "styles",
-    )
+    # Explicit globs, not one recursive root. `src/pitwall` contains `ui/dist`
+    # and `ui/node_modules`, and sweeping from the top pulled the BUILT bundle
+    # in - every hex in the repo, reported against a file nobody edits.
+    pitwall = REPO_ROOT / "src" / "pitwall"
+    sources = [
+        # The top level: `agent_formatters.py` and `host.py` live here, not in
+        # `agents_view`, and the first version of this sweep did not look.
+        *pitwall.glob("*.py"),
+        *(pitwall / "agents_view").rglob("*.py"),
+        *UI_SRC.joinpath("features").rglob("*.tsx"),
+        *UI_SRC.joinpath("features").rglob("*.ts"),
+        *UI_SRC.joinpath("lib").rglob("*.ts"),
+        *UI_SRC.joinpath("styles").rglob("*.css"),
+        # And the harness stubs, which spell colours BY DESIGN - they are what
+        # the smokes compare rendered pixels against, so a stub that drifts from
+        # the palette makes a green check meaningless.
+        *(pitwall / "ui" / "scripts").glob("*.mjs"),
+    ]
     # `tokens.css` is the WEB palette and it is deliberately a different one:
     # both PITWALL windows render in the Qt palette, and CLAUDE.md says so in as
     # many words. It has its own guard in this file -
@@ -560,20 +572,19 @@ def test_no_pitwall_source_file_carries_an_unregistered_hex():
 
     visited = 0
     offenders: list[str] = []
-    for root in roots:
-        for path in sorted(root.rglob("*")):
-            if path.suffix not in {".py", ".ts", ".tsx", ".css"} or path in skip:
-                continue
-            visited += 1
-            source = _without_comments(path.read_text("utf-8"))
-            for found in hex_literal.findall(source):
-                if found.lower() not in known:
-                    offenders.append(f"{path.relative_to(REPO_ROOT)}: {found}")
+    for path in sorted(set(sources)):
+        if path in skip:
+            continue
+        visited += 1
+        source = _without_comments(path.read_text("utf-8"))
+        for found in hex_literal.findall(source):
+            if found.lower() not in known:
+                offenders.append(f"{path.relative_to(REPO_ROOT)}: {found}")
 
     # The enumeration first. A glob that resolves to nothing - a moved
     # directory, a wrong `parents[]` - passes silently, and this repo has
     # already shipped one census that found zero files and said so cheerfully.
-    assert visited >= 25, f"the sweep only visited {visited} files; the roots are wrong"
+    assert visited >= 55, f"the sweep only visited {visited} files; the roots are wrong"
     assert not offenders, (
         "a colour that palette.py does not define is written into PITWALL source: "
         + "; ".join(offenders)


### PR DESCRIPTION
## What

The sprint-10 exit gate's findings, fixed. Three P2s and six smaller ones.

## P2 · An unconstrained LLM string reached `dangerouslySetInnerHTML` (F4)

`_plan_line` composes markup - it carries the compound pill - and `PlanTimeline` renders it through
`dangerouslySetInnerHTML`. `StrategyRecommendation.undercut_target` is `Optional[str]` with **no
pattern and no length bound**, filled by the orchestrator LLM, and it rode into that caption
unescaped. Executed:

```
caption tail: ' <img src=x onerror=alert(1)>'
```

The gate found it beside a comment **I wrote** in #1023 claiming the escaped pill was "the last
markup sink on this window's decision surface". The pill was. The field next to it was not.

Five more of the same shape in the card formatters, whose headlines and lines reach the same sink:
`format_situation`'s `threat`, `format_tire`'s `warning`, `format_pit`'s `compound` and `target`,
and the RAG article refs.

**The guard is a hostile string through every formatter**, not a list of the six. The module has had
`_escaped` since sprint 8 and a docstring claiming every free-text field went through it; a test
naming the six would be that same list one layer down. Each of the five sites was reverted in turn
and the sweep went red on every one.

⚠️ Its first draft asserted `"<img" not in text` and **passed against a real regression**, because
`format_situation` upper-cases its field and the headline read `Threat <IMG SRC=...>`. It strips the
palette's own pill spans and then asserts no angle bracket survives.

## P2 · A non-SC `PIT_NOW` rendered calm green (F10) — a regression from #1035

`format_pit` answered "is anything pressing" from `sc_reactive` alone, so a degradation- or
undercut-driven `PIT_NOW` with low safety-car probability showed a green OK disc **while the same
card's model detail printed `action = PIT_NOW`**. The glyph contradicted its own dump. #1035 removed
WATCH from the routed-and-calm case and took the routed-and-urgent one with it.

It reads `PitStrategyOutput.action` now: `PIT_NOW` and `REACTIVE_SC` are WATCH; `UNDERCUT`,
`OVERCUT` and `STAY_OUT` stay OK, because those are plans with a window rather than a deadline and
the UCUT line carries their own amber. The guard asserts the whole enumeration.

## P2 · The tooltip's tail was unreachable by any input (F7)

The popup has `max-height: 22rem` and a visible scrollbar, and the stylesheet argues the bar is the
signal for a busy lap. Nothing could drive it. **Mouse**: the popup is a portal 10 px away, so
crossing the gap fired the card's `mouseleave` and unmounted it. **Keyboard**: focus sits on the
card, the popup has no `tabIndex`, and Tab closes it. A RADIO tooltip with the model-detail sections
appended after its rows (#1019) puts exactly that content below the fold.

Two paths now, one per hand: hover-intent (a 140 ms grace on `mouseleave`, cancelled while the
pointer is inside the popup) and ArrowUp/ArrowDown forwarded from the card. Blur still closes at
once - a grace period there left two popups on screen and `aria-describedby` pointing at whichever
the DOM listed first.

## P2 · The RAG answer existed nowhere (F1)

The card renders it through `_escaped`'s 70-character budget and the tooltip had no Answer section,
so a longer answer - the one synthesised sentence that console exists to deliver - was reachable
nowhere, while `format_rag`'s own docstring said "the full answer text ... lives in the tooltip".
The tooltip carries it now, and opens on an answer alone rather than requiring chunks.

## The smaller ones

- **F8** `webserver.TickSource` still typed `get_connection -> str`; #1024 changed the host and left
  the Protocol, which is the only place the browser path's contract is written.
- **F9** `AgentsViewBuilder.build`'s `connection` defaulted to `"Connected"` - a green claim in the
  field whose whole job is to say when that is false. The default is gone; all 13 call sites are
  explicit.
- **F11** the palette sweep's roots missed `src/pitwall/*.py` and the harness `.mjs` files, which
  carry ten hexes the smokes compare rendered colours against. Widened - with **explicit globs**,
  because a recursive root pulled in `ui/dist` and reported every hex in the built bundle.
- **F2, F13** three comments naming mechanisms that are not there: DANGER's owners (two claimed,
  four real), a `.agents-right` column deleted in #1015, and a two-line clamp that ships as three.

## Not fixed, and why

**F3, F6, F12** are hardening the gate itself flagged as unsure, and **F5** is already tracked as
#1026. F3 (compound normalisation), F6 (a `pit_lap_target` behind the current lap) and F12
(`first_sentence` cutting at "e.g."/"Mr.") want a decision rather than a patch; each is real and
none is reachable from today's producer.

## Checks

`tests/surfaces/` **264 passed**. `smoke-agents` **59 checks**, `smoke-data` 230. `ruff check .` and
`format --check .` clean. `npm run typecheck` clean.

Every fix driven red first, restored with `cp` + `cmp`. One of those reverts exposed a **stale
`dist/`**: `npm run build` runs `tsc -b` first, my mutation did not compile, and the smoke reported
59 OK against the previous bundle. The mutation was narrowed until it compiled, and only then was
the red real.


Closes #1037
