### PR TITLE
docs(agents): the plan caption's comment stops claiming a hole that was open

### DIFF
--- a/src/pitwall/ui/src/features/agents/PlanTimeline.tsx
+++ b/src/pitwall/ui/src/features/agents/PlanTimeline.tsx
@@ -87,9 +87,21 @@ export function PlanTimeline({ view }: { view: PlanTimelineView }) {
       </div>
 
       {/* The orchestrator's own plan line, verbatim, including the compound
-          pill it can carry. That pill is an HTML span built and escaped in
-          `src/arcade/palette.py` and it is the last markup sink on this
-          window's decision surface. */}
+          pill it can carry - an HTML span built and escaped in
+          `src/arcade/palette.py`.
+
+          **This comment used to call that pill "the last markup sink on this
+          window's decision surface", and the exit gate found the hole one line
+          away from the sentence.** The pill was escaped; `undercut_target`
+          beside it was not, and it is an unconstrained `Optional[str]` the
+          orchestrator LLM fills - `<img src=x onerror=...>` reached this
+          caption verbatim. `_plan_line` escapes every field it interpolates
+          now, and `test_no_agent_string_can_become_markup` feeds a hostile
+          string through every formatter rather than trusting a list of sites.
+
+          The sink itself is still here, and it is still the reason #1036 wants
+          the pill to become a typed segment: a component that renders HTML is
+          one escape away from this every time somebody adds a field. */}
       <p className="plan-caption" dangerouslySetInnerHTML={{ __html: view.caption }} />
     </div>
   );


### PR DESCRIPTION
It called the escaped compound pill "the last markup sink on this window's decision surface". The sprint-10 exit gate found the hole **one line away from that sentence**: `undercut_target` rode into the same caption unescaped, and it is an unconstrained `Optional[str]` the orchestrator LLM fills.

#1038 escaped the field and left the sentence standing - which is the same defect class as the sentence itself, a comment asserting a hole is closed. Caught while writing the next sprint's handoff.

The comment now says what happened, and why the sink is still the reason #1036 wants the pill to become a typed segment: a component that renders HTML is one forgotten escape away from this every time somebody adds a field.

## Checks

`npm run typecheck` clean, `npm run build` clean, `smoke-agents` 59 checks. Comment-only change.