### PR TITLE
fix(agents): say where the rival gap and pace delta actually go

### DIFF
--- a/documents/audits/MEASUREMENT_SESSION_2025_LOG.md
+++ b/documents/audits/MEASUREMENT_SESSION_2025_LOG.md
@@ -579,6 +579,14 @@ on every lap, that the car ahead sits exactly 2.0 s away and matches its pace ex
 2.0 is a plausible-looking number, so nothing downstream could tell it from a measurement.
 Filed as **#829**.
 
+**Corrected 2026-08-21 (#1044).** The first sentence above names two routes the fields do not
+take. `RaceState.gap_ahead_s` and `pace_delta_s` reach the orchestrator's synthesis prompt and
+stop there: N27 derives its own pair gap from `laps_df` and pairs by position, and the Monte
+Carlo is handed `lap_state["rivals"]` rather than anything off the RaceState. The conclusion in
+bold is unchanged and the figures are still not comparable, because the tier grades the
+synthesised decision and the synthesis is exactly what was fed the two constants. The same
+sentence was found in three other places and fixed there.
+
 **Corrected 2026-08-06 after an adversarial gate (F5).** The five laps tabled above are a
 probe, and the sentence this paragraph used to carry — *"the real gaps run 0.43 to 1.08"* —
 generalised them into a distribution. Over all 2744 laps the metric actually scores, the real

--- a/documents/eval_reports/decision_modes.md
+++ b/documents/eval_reports/decision_modes.md
@@ -59,9 +59,14 @@ This tier used to build its own ``RaceState`` instead of calling
 ``src/agents/race_state_builder.build_race_state``, and two of the fields it
 invented were constants: ``gap_ahead_s`` came from a key the driver dict does
 not carry, so it was **2.0 s on every lap of every race**, and ``pace_delta_s``
-was hardcoded to 0.0. Both feed N27's overtake scoring and the Monte Carlo this
-tier grades, so every figure published before this fix described a stack fed two
-constants. **Figures generated before 2026-08-06 are not comparable to these.**
+was hardcoded to 0.0. Both reach the orchestrator's synthesis prompt, which is
+what this tier grades, so every figure published before this fix described a
+synthesis told on every lap that the car ahead sat exactly 2.0 s away and matched
+its pace. **Figures generated before 2026-08-06 are not comparable to these.**
+
+They do not reach N27, which derives its own pair gap from ``laps_df``, nor the
+Monte Carlo, which takes the rivals list from the lap state. An earlier wording
+here said they did.
 
 ### Scope
 

--- a/src/agents/race_state_builder.py
+++ b/src/agents/race_state_builder.py
@@ -107,8 +107,13 @@ def _targeting_against_rival(
     Returns ``(gap_ahead_s, pace_delta_s)`` framed around the rival the user
     picked in the Strategy tab, so the recommendation reasons about the duel the
     user actually asked for instead of about whichever car happens to sit one
-    position ahead (#431). Both values land on the RaceState, which feeds N27's
-    overtake scoring inputs and the orchestrator's synthesis prompt.
+    position ahead (#431). Both values land on the RaceState, and from there they
+    reach the orchestrator's synthesis prompt (its RACE CONTEXT block) and
+    nothing else. They do NOT re-target the sub-agents: N27 derives its own pair
+    gap from laps_df against the car one position ahead, and N28 picks undercut
+    candidates positionally too, so choosing a rival reframes what the synthesis
+    READS, never what the models SCORE. Anything that needs the models to analyse
+    a chosen car is a different piece of work.
 
     gap_ahead_s is the absolute on-track interval to the rival, read from the
     rival's ``interval_to_driver_s`` (rival elapsed time minus ours: the sign

--- a/src/strategy/eval/decision_modes.py
+++ b/src/strategy/eval/decision_modes.py
@@ -337,9 +337,17 @@ def _decisions_in_window(
     # construct its own ``RaceState`` and two of its fields were constants: the gap
     # to the car ahead was `car.get("gap_ahead_s") or 2.0` on a dict that has no
     # such key (it carries `gap_to_leader_s`), so 2.0 was the value on 100% of laps
-    # of every race, and `pace_delta_s` was hardcoded to 0.0 beside it. Both feed
-    # N27's overtake scoring and the Monte Carlo this tier grades, so every figure
-    # it published described a stack fed two constants (#829).
+    # of every race, and `pace_delta_s` was hardcoded to 0.0 beside it. Both reach
+    # the orchestrator's SYNTHESIS PROMPT, which is the thing this tier grades, so
+    # every figure it published described a synthesis told on every lap that the car
+    # ahead sat exactly 2.0 s away and matched its pace (#829).
+    #
+    # Where they do NOT reach, because saying it wrongly is what #1044 corrected in
+    # four places at once: N27 derives its own pair gap from laps_df and pairs by
+    # position, and the Monte Carlo takes `lap_state["rivals"]` rather than anything
+    # off the RaceState (`engine.py`'s mc stage passes `rivals=`, `position=`,
+    # `laps_remaining=`, `pit_context=`). The invalidation stands; the route is the
+    # prompt.
     #
     # Imported here and not at module scope because ``build_race_state`` lazily
     # imports ``RaceState`` from the orchestrator on CALL, which pulls the whole
@@ -685,9 +693,14 @@ def _render_table(
         "``src/agents/race_state_builder.build_race_state``, and two of the fields it",
         "invented were constants: ``gap_ahead_s`` came from a key the driver dict does",
         "not carry, so it was **2.0 s on every lap of every race**, and ``pace_delta_s``",
-        "was hardcoded to 0.0. Both feed N27's overtake scoring and the Monte Carlo this",
-        "tier grades, so every figure published before this fix described a stack fed two",
-        "constants. **Figures generated before 2026-08-06 are not comparable to these.**",
+        "was hardcoded to 0.0. Both reach the orchestrator's synthesis prompt, which is",
+        "what this tier grades, so every figure published before this fix described a",
+        "synthesis told on every lap that the car ahead sat exactly 2.0 s away and matched",
+        "its pace. **Figures generated before 2026-08-06 are not comparable to these.**",
+        "",
+        "They do not reach N27, which derives its own pair gap from ``laps_df``, nor the",
+        "Monte Carlo, which takes the rivals list from the lap state. An earlier wording",
+        "here said they did.",
         "",
         "### Scope",
         "",


### PR DESCRIPTION
## What

Corrects where `RaceState.gap_ahead_s` and `pace_delta_s` are documented to go, in the four live places that said it wrongly.

## Why

`_targeting_against_rival` said "Both values land on the RaceState, which feeds N27's overtake scoring inputs and the orchestrator's synthesis prompt". The first clause is the exact sentence `RaceState`'s own docstring exists to repudiate (`strategy_orchestrator.py:236-238`, "this line claimed otherwise for as long as it existed").

Searching for the claim instead of the file found three more copies, and one of them is not a comment: `decision_modes.py:687-689` is a literal the eval report generator emits, so the sentence is in `documents/eval_reports/decision_modes.md` as published prose.

Traced where the two fields actually reach:

| consumer | reads them? | evidence |
|---|---|---|
| orchestrator synthesis prompt | yes | `strategy_orchestrator.py:291-292`, into RACE CONTEXT |
| N27 | no | derives its own pair gap from `laps_df`, pairs by position (`race_situation_agent.py:1162`) |
| Monte Carlo | no | the mc stage is passed `rivals=lap_state["rivals"]`, `position`, `laps_remaining`, `pit_context` (`engine.py:232-244`); `race_context_from_lap_state` reads the lap state plus `total_laps`/`lap` and nothing else (`strategy_orchestrator.py:871-915`) |

The `rival.gap_ahead_s` reads in `position_projection.py:848` are `RivalState`, a different object built from the rivals list.

## How

- `src/agents/race_state_builder.py`: the clause replaced with what the fields reach and an explicit note on what they do not, since re-targeting the models is a different piece of work.
- `src/strategy/eval/decision_modes.py`: the comment at the canonical-RaceState call site, and the report generator's literal.
- `documents/eval_reports/decision_modes.md`: the same text, so the committed report and the generator do not drift. Verified line by line rather than by eye.
- `documents/audits/MEASUREMENT_SESSION_2025_LOG.md`: a dated correction appended rather than a rewrite, which is how that file already records corrections.

## Out of scope

`notebooks/agents/N31_strategy_orchestrator.ipynb` carries the wording the family started from. Notebooks are read-only in this repo, so it is named in #1044 and left alone.

## What this does NOT change

The eval report's invalidation notice. The decision tier grades the synthesised decision, and the synthesis is exactly what was fed `gap_ahead_s = 2.0` and `pace_delta_s = 0.0` on every lap before #829, so figures generated before 2026-08-06 are still not comparable. Only the route is corrected, and correcting it matters because the old wording reads as "selecting a rival re-targets the overtake model and the MC", which is the claim a rival-selector design would be scoped from.

## Checks

- `ruff 0.15.22 check` and `format --check` on both touched python files: clean, already formatted.
- `pytest tests/eval/test_decision_modes.py`: 37 passed, 1 skipped (`data/raw` absent, the curated-install skip).
- Generator/report agreement asserted by executing a check over both files: all seven corrected lines present in each, and the stale sentence absent from both. The check carries its own probe so a match-anything bug would fail it.
- No LLM spend: nothing here runs the stack.

Closes #1044
