### PR TITLE
fix(pitwall): the TIRE console reports what the wear has cost

### DIFF
--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -545,6 +545,11 @@ class TireOutput:
             the Monte Carlo, nor the orchestrator prompt, nor any UI. Measured
             over the same 110 laps it correlates +0.369 with tyre life and swings
             0.411 s/lap across a stint.
+
+            #727 restored the first two. The UI half stayed true until #1041:
+            PITWALL's TIRE console now prints this and ``deg_cost_s`` in its
+            model detail (``src/pitwall/reasoning_lines.py``), which is the only
+            surface that renders either.
         deg_cost_s: Seconds per lap staying out costs versus a fresh set, bounded.
             This is ``cumulative_deg_s`` minus the model's own prediction on this
             stint's early laps, which cancels N04's per-stint baseline instead of

--- a/src/pitwall/reasoning_lines.py
+++ b/src/pitwall/reasoning_lines.py
@@ -53,10 +53,31 @@ def _pace_lines(p: dict[str, Any]) -> list[str]:
 
 
 def _tire_lines(t: dict[str, Any]) -> list[str]:
+    """N26's dump, with the two cost fields the console used to leave on the wire.
+
+    `deg_cost_s` is the one the scorers consume: seconds a lap that staying out
+    costs against a fresh set, bounded, with this stint's baseline cancelled. It
+    sits directly under `deg_rate` because it is the corrective to it - `deg_rate`
+    is a RAW lap-to-lap derivative that fuel burn cancels, negative on 43 of 110
+    measured laps and not monotonic by tyre-life band, so a reader taking it as
+    the wear signal is reading the wrong row (`tire_agent.py`'s own docstring).
+
+    `cumulative_deg_s` is the level rather than the cost, and it carries a
+    per-stint offset with a 5.48 s standard deviation across stints, so it is not
+    comparable between cars or laps. It is here as a model detail, which is what
+    this dump is, and not on the card.
+
+    Both are `None` and never 0.0 when the TCN did not run or its output did not
+    parse, because 0.0 is a reading a genuinely fresh tyre produces. `_fnum`
+    renders that absence rather than a number; do not give either a numeric
+    default.
+    """
     return [
         f"compound          = {t.get('compound', '—')}",
         f"current_tyre_life = {t.get('current_tyre_life', '—')} laps",
         f"deg_rate          = {_fnum(t.get('deg_rate'), 3)}s/lap",
+        f"deg_cost_s        = {_fnum(t.get('deg_cost_s'), 3)}s/lap",
+        f"cumulative_deg_s  = {_fnum(t.get('cumulative_deg_s'), 3)}s/lap",
         f"laps_to_cliff_p10 = {_fnum(t.get('laps_to_cliff_p10'), 1)}",
         f"laps_to_cliff_p50 = {_fnum(t.get('laps_to_cliff_p50'), 1)}",
         f"laps_to_cliff_p90 = {_fnum(t.get('laps_to_cliff_p90'), 1)}",

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -421,6 +421,52 @@ def test_every_reasoning_tab_body_is_reachable_from_its_card_tooltip():
         assert "own sentence for this lap" in rendered, f"{key}'s reasoning is not reachable"
 
 
+def test_the_tyre_console_reports_what_the_wear_has_cost():
+    """`deg_cost_s` and `cumulative_deg_s` reach a pixel, and an absent one is not a zero.
+
+    Both ride the tick on every lap because the producer `asdict`s the whole
+    `TireOutput`, and until now neither appeared anywhere in PITWALL. `deg_cost_s`
+    is the field the scorers consume; `deg_rate`, which the console DID show, is a
+    raw derivative that fuel burn cancels and that its own docstring says does not
+    separate a worn tyre from a fresh one.
+
+    The second half is the one that matters more. Both fields are `None` rather
+    than 0.0 when the TCN did not run, deliberately, because 0.0 is what a
+    genuinely fresh set reads - so a renderer that defaulted them to a number
+    would print a real-looking measurement for a missing one. This asserts the
+    absence renders AS an absence, which a test that only checked the populated
+    case would never see.
+
+    Asserted on the rendered tooltip rather than on `_tire_lines`, because what is
+    being claimed is that a reader can see them.
+    """
+
+    def tyre_rows(block: dict) -> str:
+        latest = _latest()
+        latest["per_agent"]["tire"].update(block)
+        view = _host(_payload(latest=latest)).get_agents_view(-1)
+        tooltip = view["cards"]["tire"]["tooltip"]
+        assert tooltip is not None, "the TIRE card has no tooltip to carry a dump"
+        return " | ".join(
+            f"{row['lead']}={row['text']}"
+            for section in tooltip["sections"]
+            for row in section["rows"]
+        )
+
+    measured = tyre_rows({"deg_cost_s": 0.412, "cumulative_deg_s": 1.284})
+    assert "deg_cost_s=0.412s/lap" in measured, (
+        f"the cost the scorers read is not shown: {measured}"
+    )
+    assert "cumulative_deg_s=1.284s/lap" in measured, f"the level is not shown: {measured}"
+
+    absent = tyre_rows({"deg_cost_s": None, "cumulative_deg_s": None})
+    for field in ("deg_cost_s", "cumulative_deg_s"):
+        assert f"{field}=—s/lap" in absent, f"{field} does not render its absence: {absent}"
+        assert f"{field}=0.000s/lap" not in absent, (
+            f"{field} printed a fresh-tyre reading for a missing one: {absent}"
+        )
+
+
 # A string that is harmless as TEXT and a tag as MARKUP. Not a curiosity: the
 # orchestrator's `undercut_target` is an unconstrained `Optional[str]` an LLM
 # fills, and every card headline and body line still reaches the window through


### PR DESCRIPTION
## What

The TIRE console's model detail gains two rows: `deg_cost_s` and `cumulative_deg_s`.

## Why

`TireOutput` has eleven fields and the window rendered nine. The producer `asdict`s the whole dataclass (`src/arcade/strategy.py:714`), so both have been on the tick on every lap and reached nothing: zero hits across all 60 PITWALL files, python and bundle.

`deg_cost_s` is the one that matters. Its own docstring calls it "the field the scorers consume", seconds a lap that staying out costs against a fresh set, with this stint's baseline cancelled. What the console did show instead is `deg_rate`, and the same file records what that is: a raw lap-to-lap derivative that fuel burn cancels, median +0.006 s/lap over 110 measured laps, negative on 43 of them, correlating +0.115 with tyre life and not monotonic by tyre-life band. A reader treating it as the wear signal was reading the wrong row.

`cumulative_deg_s` is the level rather than the cost. It carries a per-stint offset with a 5.48 s standard deviation across stints, so it is not comparable between cars or laps; it belongs in a model-detail dump, which is what this is, and not on the card.

## How

- `src/pitwall/reasoning_lines.py`: two rows in `_tire_lines`, placed under `deg_rate` because they are the corrective to it, plus a docstring saying which one the scorers read and why neither may take a numeric default.
- `src/agents/tire_agent.py`: the `cumulative_deg_s` docstring said it "reached neither the Monte Carlo, nor the orchestrator prompt, nor any UI". #727 restored the first two; the UI half was true until this PR, and the docstring now says so rather than leaving the next reader to infer it still holds.

## The sentinel, which is the load-bearing half

Both fields are `None` and never `0.0` when the TCN did not run or its output did not parse, deliberately, because 0.0 is what a genuinely fresh set reads. `_fnum` renders that as an absence. The guard asserts both directions: the populated case shows the number, and the absent case shows the absence and specifically does **not** show `0.000`. A test that only checked the populated case would pass against a renderer that defaulted a missing measurement to a real-looking one.

## Checks

- New guard driven RED first. Removed both rows from `_tire_lines` in a scratch copy and ran it: `AssertionError: the cost the scorers read is not shown: compound=MEDIUM | current_tyre_life=15 laps | deg_rate=0.031s/lap | laps_to_cliff_p10=4.0 | ...`. Restored from the copy and verified byte-identical with `cmp`, not with `git checkout`, which would have reverted the fix in the same file.
- `pytest tests/surfaces/` 265 passed, up from 264.
- `ruff 0.15.22 check` clean; `format --check .` repo-wide, 184 files already formatted.
- Real path, not just the suite. The view built by the real `AgentsViewBuilder` renders `deg_cost_s = 0.412s/lap` and `cumulative_deg_s = 1.284s/lap`, and the built bundle shows both in the TIRE popup, reached by pressing Tab until focus lands on the console rather than by calling `.focus()`:

```
focused TIRE by keyboard: true
Model detail
compound          MEDIUM
current_tyre_life 15 laps
deg_rate          0.031s/lap
deg_cost_s        0.412s/lap
cumulative_deg_s  1.284s/lap
laps_to_cliff_p10 4.0
```

The bundle was not rebuilt for this: the change is python-side view data and the renderer is untouched.

- No LLM spend.

## Out of scope

The other four unrendered wire fields, which have their own issues: #1040, #1042, #1043.

Closes #1041
