### PR TITLE
fix(pitwall): the RADIO popup carries the NLP corrections

### DIFF
--- a/scripts/dev_pitwall_producer.py
+++ b/scripts/dev_pitwall_producer.py
@@ -145,7 +145,19 @@ def decision(lap: int, action: str, confidence: float) -> LapDecisionDTO:
                     }
                 ],
                 "alerts": [{"intent": "PROBLEM", "driver": "NOR"}],
-                "corrections": [],
+                # A mismatch against the radio above, because an empty list here
+                # leaves the section this fixture exists to exercise invisible.
+                # N29 only fills this on an LLM profile, so the free dev path is
+                # the ONLY way to see it without spending a call.
+                "corrections": [
+                    {
+                        "driver": "NOR",
+                        "original_intent": "PROBLEM",
+                        "suggested_intent": "INFORMATION",
+                        "span": "especially through the last sector",
+                        "reason": "reads as a description of where, not a request to act",
+                    }
+                ],
                 "reasoning": "The driver reports rear grip fading; sector 2 is under yellow.",
             },
             pit={

--- a/src/pitwall/agent_formatters.py
+++ b/src/pitwall/agent_formatters.py
@@ -340,6 +340,30 @@ def _radio_intent(event: dict[str, Any]) -> str:
     return str((event.get("analysis") or {}).get("intent") or "INFO")
 
 
+def _correction_row(entry: dict[str, Any]) -> dict[str, str]:
+    """One NLP mismatch, as a tooltip row.
+
+    N29 asks the LLM to compare each message's text against the intent the
+    classifier assigned it and to say so when they contradict. The entry names
+    the label it would have given instead, the verbatim span that contradicts the
+    model, and a one-line reason.
+
+    It is a claim ABOUT a label, never a replacement for one: `alerts` stays
+    deterministic and the orchestrator weighs the two itself, so this reads as
+    "treat that PROBLEM as weaker" rather than as a relabelling. Every value is
+    LLM-filled free text and is stringified here for that reason.
+    """
+    original = str(entry.get("original_intent") or "?")
+    suggested = str(entry.get("suggested_intent") or "?")
+    reason = str(entry.get("reason") or "").strip()
+    span = str(entry.get("span") or "").strip()
+    text = f'{reason} Quoted: "{span}"' if span else reason
+    return {
+        "lead": f"{str(entry.get('driver') or '?')} {original} reads as {suggested}",
+        "text": text,
+    }
+
+
 def radio_tooltip(r: dict[str, Any] | None) -> dict[str, Any] | None:
     """Every radio and RCM of the lap, as DATA the window renders itself.
 
@@ -372,7 +396,8 @@ def radio_tooltip(r: dict[str, Any] | None) -> dict[str, Any] | None:
         return None
     radio_events = r.get("radio_events") or []
     rcm_events = r.get("rcm_events") or []
-    if not radio_events and not rcm_events:
+    corrections = r.get("corrections") or []
+    if not radio_events and not rcm_events and not corrections:
         return None
 
     sections: list[dict[str, Any]] = []
@@ -399,6 +424,17 @@ def radio_tooltip(r: dict[str, Any] | None) -> dict[str, Any] | None:
                         "text": str(ev.get("message") or ""),
                     }
                     for ev in radio_events
+                ],
+            }
+        )
+    # Last, because it qualifies what the two sections above say rather than
+    # adding events of its own: a reader needs the message before the doubt.
+    if corrections:
+        sections.append(
+            {
+                "title": "NLP corrections",
+                "rows": [
+                    _correction_row(entry) for entry in corrections if isinstance(entry, dict)
                 ],
             }
         )

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -607,6 +607,84 @@ def test_the_tooltips_return_data_and_never_markup():
         assert "<" not in repr(value), f"markup reached the view: {value!r}"
 
 
+def test_the_radio_tooltip_carries_the_nlp_corrections():
+    """N29's mismatch list reaches the popup, and an LLM string in it is not markup.
+
+    `corrections` rides the tick on every lap, because the producer `asdict`s the
+    whole `RadioOutput`, and reached nothing. It is what lets a reader judge how
+    much to trust a quoted message: the classifier said PROBLEM, the LLM read the
+    text and disagreed, and `alerts` stays deterministic either way.
+
+    Every field of an entry is LLM-filled free text with no pattern and no length
+    bound, which is the same shape as the `undercut_target` that reached a markup
+    sink in #1037. The tooltip is data rather than markup, so the guarantee here
+    is that it stays data.
+    """
+    from src.pitwall.agent_formatters import radio_tooltip
+
+    built = radio_tooltip(
+        {
+            "radio_events": [
+                {"driver": "NOR", "message": "Box now", "analysis": {"intent": "PROBLEM"}}
+            ],
+            "rcm_events": [],
+            "corrections": [
+                {
+                    "driver": "NOR",
+                    "original_intent": "PROBLEM",
+                    "suggested_intent": "INFORMATION",
+                    "span": "Box now",
+                    "reason": "a routine call, not a complaint",
+                }
+            ],
+        }
+    )
+    section = built["sections"][-1]
+    assert section["title"] == "NLP corrections", (
+        f"the corrections never reach the popup: {[s['title'] for s in built['sections']]}"
+    )
+    assert section["rows"] == [
+        {
+            "lead": "NOR PROBLEM reads as INFORMATION",
+            "text": 'a routine call, not a complaint Quoted: "Box now"',
+        }
+    ]
+    # It qualifies the messages above it, so a reader meets the message first.
+    assert [s["title"] for s in built["sections"]] == ["Radio", "NLP corrections"]
+
+    # A lap with a correction and no events still has something to say.
+    only = radio_tooltip({"radio_events": [], "rcm_events": [], "corrections": [{"reason": "r"}]})
+    assert only is not None and only["sections"][0]["title"] == "NLP corrections"
+
+    # A hostile entry stays DATA: carried verbatim, in a str, never assembled into
+    # a markup string here. That is this tooltip's whole contract - it decides what
+    # is said and the TSX decides how it looks, so the string reaches a React text
+    # node, which is not a parser. The thing to guard is therefore not escaping but
+    # SHAPE: the moment any of this is concatenated into markup, the sink is back
+    # and the escaping question returns with it (#1037).
+    hostile = radio_tooltip(
+        {
+            "radio_events": [],
+            "rcm_events": [],
+            "corrections": [
+                {
+                    "driver": _HOSTILE,
+                    "original_intent": _HOSTILE,
+                    "suggested_intent": _HOSTILE,
+                    "span": _HOSTILE,
+                    "reason": _HOSTILE,
+                }
+            ],
+        }
+    )
+    row = hostile["sections"][0]["rows"][0]
+    assert set(row) == {"lead", "text"} and all(isinstance(v, str) for v in row.values())
+    assert _HOSTILE in row["text"], f"the hostile string was dropped rather than carried: {row}"
+    assert "&lt;" not in row["text"], (
+        "escaped here, this string would render as visible entity noise in a text node"
+    )
+
+
 def test_the_two_charts_bound_their_axes_to_what_they_actually_draw():
     """The headline chart fix of sprint 8, which shipped with no guard (#966).
 


### PR DESCRIPTION
## What

The RADIO console's tooltip gains an "NLP corrections" section.

## Why

`RadioOutput` has five fields and the window rendered four. The producer `asdict`s the whole dataclass (`src/arcade/strategy.py:714`), so `corrections` has been on the tick on every lap and reached nothing: zero hits across all 60 PITWALL files.

It is N29's mismatch list. The prompt (`radio_agent.py:679-685`) asks the LLM to compare each message's text against the intent the classifier assigned it and, when they clearly contradict, to record the label it would have given instead, the verbatim span, and a one-line reason. Its own docstring is explicit that `alerts` is **not** modified by it: the orchestrator receives the deterministic alerts and the mismatch assessment separately and weighs them itself.

That makes it exactly the field a reader needs in order to decide how much of a quoted PROBLEM radio to believe, and the RADIO tooltip is already the drill-down tier for the lap's messages.

## How

- `_correction_row` renders one entry as `NOR PROBLEM reads as INFORMATION` with the reason and the quoted span. Every value is LLM-filled free text with no pattern and no length bound, so all of it is stringified at the boundary.
- The section is appended **last**, after RCM and Radio, because it qualifies what those say and a reader needs the message before the doubt.
- The tooltip's emptiness check now counts corrections, so a lap that has one and no events still produces a popup rather than `None`.

## On escaping, deliberately not done

The tooltip returns data and the TSX decides how it looks, so these strings reach React text nodes. Checked rather than assumed: the three `dangerouslySetInnerHTML` sinks on this window are `AgentCard.tsx:77` and `:85` (headline and body lines) and `PlanTimeline.tsx:105` (the caption). `Tooltip.tsx` mentions it only in a comment.

So the guard asserts the **shape**, not escaping: two string keys, the hostile string carried verbatim, and no `&lt;`, because escaping into a text node renders visible entity noise. If any of this is ever concatenated into markup the sink is back and the escaping question returns with it, which is what #1037 was.

## Checks

- New guard driven RED first. Removed the corrections section in a scratch copy: `AssertionError ... - NLP corrections + Radio`. Restored from the copy and verified byte-identical with `cmp`.
- `pytest tests/surfaces/` 265 passed (264 on this base plus the new one).
- `ruff 0.15.22 check` clean; `format --check .` repo-wide, 184 files already formatted.
- Real path. The view built by the real `AgentsViewBuilder`, rendered by the built bundle, reached by pressing Tab until focus lands on the RADIO console rather than by calling `.focus()`:

```
focused RADIO by keyboard: true
RCM
L23 YELLOW          Yellow flag in sector 2 - debris on the racing line.
Radio
NOR PROBLEM         Rear grip is going away, especially through the last sector.
NLP corrections
NOR PROBLEM reads as INFORMATION   a descriptive report rather than a request Quoted: "especially through the last sector"
Model detail
radio_events 1
```

The bundle was not rebuilt: the change is python-side view data and the renderer is untouched.

- No LLM spend. `corrections` is only populated on an LLM profile, so the fixtures carry it rather than a run producing it.

## Out of scope

The other unrendered wire fields: #1040, #1043. #1041 covers TIRE's two.

Closes #1042
