### PR TITLE
fix(pitwall): the AGENTS header says whether the track is neutralised

### DIFF
--- a/src/pitwall/agents_view/panels.py
+++ b/src/pitwall/agents_view/panels.py
@@ -86,7 +86,22 @@ STATUS_GLYPHS: dict[str, tuple[str, str]] = {
 
 
 def build_header(payload: dict[str, Any], connection: str) -> dict[str, Any]:
-    """The top strip: session, driver, connection, playback, lap counter."""
+    """The top strip: session, driver, neutralisation, connection, playback, lap.
+
+    **The track status comes off the tick, NOT off the situation agent.** N27
+    publishes `sc_currently_active` and `vsc_active` on the same payload, and
+    rendering those instead would put two sources for one fact on a desk where
+    both windows are open at once, free to disagree: one is FastF1's TrackStatus
+    for the lap on screen, decoded by the producer's own priority rule
+    (`app.py`'s `track_status_label`) precisely so no consumer re-derives it, and
+    the other is a boolean the agent computed for the lap it was asked about. The
+    DATA window renders the decoded one; so does this. The agent's pair are a
+    deletion, tracked with the schema work rather than as a third wire change.
+
+    The colour rides along for the same reason the label does: the priority order
+    and the palette entry are a project rule, and picking a colour here would be a
+    second copy of it in a second language.
+    """
     arcade = payload.get("arcade") or {}
     strategy = payload.get("strategy") or {}
     playback = payload.get("playback") or {}
@@ -107,6 +122,11 @@ def build_header(payload: dict[str, Any], connection: str) -> dict[str, Any]:
         "playback": f"{speed:.2f}× · {'PAUSED' if paused else 'PLAYING'}",
         "connection": connection,
         "connection_colour": CONNECTION_COLOURS.get(connection, hex_str(TEXT_SECONDARY)),
+        # Both `None` when the loader has no entry for the lap, which is NOT the
+        # same as a green track and must not render as one. The renderer's
+        # unknown treatment is what says so.
+        "track_status": arcade.get("track_status_label"),
+        "track_status_colour": arcade.get("track_status_color"),
     }
 
 

--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -64,6 +64,11 @@ const VIEW = {
     playback: "2.00× · PLAYING",
     connection: "Connected",
     connection_colour: "#10b981",
+    // Green, so the default page exercises the OUTLINE branch; the filled and
+    // unknown branches are driven explicitly further down. A fixture that
+    // omitted these would only ever render the unknown one.
+    track_status: "GREEN",
+    track_status_colour: [16, 185, 129],
   },
   orchestrator: {
     action: "PIT NOW",
@@ -992,6 +997,71 @@ watchPage(viewPage, failures, "frozen");
 check(
   servedBar === "lap 23 · streaming",
   `a rendered view keeps its own host-built status line, not the polled word ("${servedBar}")`,
+);
+
+// ── The neutralisation chip, all three treatments ────────────────────────────
+//
+// The window said nothing about a safety car before this except as RCM prose
+// inside the RADIO card. What is asserted here is the EFFECT: a non-green status
+// has to be visibly heavier than green, because the failure this replaces is a
+// chip that only swapped its text and that a reader misses at a glance.
+//
+// The unknown branch is asserted too, and it is the one that costs if it is
+// wrong: `null` means the loader had no entry for the lap, which is not a green
+// track.
+const chipFor = async (header) => {
+  const ctx = await browser.newContext({ viewport: CLIENT });
+  const p = await ctx.newPage();
+  watchPage(p, failures);
+  await p.addInitScript(
+    (view) => {
+      window.pywebview = {
+        api: {
+          get_agents_view: async (s) => (s >= view.seq ? null : view),
+          get_tick: async () => null,
+          get_connection: async () => ({ label: "Connected", colour: "#10b981" }),
+        },
+      };
+    },
+    { ...VIEW, header: { ...VIEW.header, ...header } },
+  );
+  await p.goto(`http://127.0.0.1:${server.address().port}/agents.html`, {
+    waitUntil: "domcontentloaded",
+  });
+  await p.waitForSelector(".agent-card", { timeout: 5000 });
+  await p.waitForTimeout(400);
+  const seen = await p.evaluate(() => {
+    const chips = [...document.querySelectorAll(".header-bar .chip")];
+    const el = chips.find((c) => /GREEN|SAFETY CAR|VSC|RED|YELLOW|NO STATUS/.test(c.textContent));
+    if (!el) return null;
+    const s = getComputedStyle(el);
+    return { text: el.textContent, weight: s.fontWeight, background: s.backgroundColor };
+  });
+  await ctx.close();
+  return seen;
+};
+
+const greenChip = await chipFor({ track_status: "GREEN", track_status_colour: [16, 185, 129] });
+const scChip = await chipFor({ track_status: "SAFETY CAR", track_status_colour: [255, 140, 0] });
+const blindChip = await chipFor({ track_status: null, track_status_colour: null });
+
+check(greenChip?.text === "GREEN", `the header carries the track status ("${greenChip?.text}")`);
+check(scChip?.text === "SAFETY CAR", `a safety car reaches the header ("${scChip?.text}")`);
+check(
+  scChip?.background === "rgb(255, 140, 0)",
+  `the safety car chip is FILLED with the wire's own colour (${scChip?.background})`,
+);
+check(
+  Number(scChip?.weight) > Number(greenChip?.weight),
+  `a neutralised track is heavier than a green one (${scChip?.weight} vs ${greenChip?.weight})`,
+);
+check(
+  blindChip?.text === "NO STATUS",
+  `an absent status says so rather than rendering green ("${blindChip?.text}")`,
+);
+check(
+  blindChip?.background !== "rgb(255, 140, 0)",
+  "an absence does not borrow the alarm's weight",
 );
 
 await browser.close();

--- a/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
@@ -77,6 +77,11 @@ const IDLE_VIEW: AgentsView = {
     driver: "--",
     lap: "L 0/0",
     playback: "-- × · --",
+    // `null` before a view arrives, which renders the unknown chip. There is no
+    // tick yet, so the window genuinely does not know the track status, and
+    // "GREEN" here would be a claim it cannot make.
+    track_status: null,
+    track_status_colour: null,
     // Overwritten from the polled channel below while there is no view. It is
     // a placeholder, not a claim: the host owns both the word and its colour
     // (`agents_view/panels.CONNECTION_COLOURS`), and this literal used to

--- a/src/pitwall/ui/src/features/agents/HeaderBar.tsx
+++ b/src/pitwall/ui/src/features/agents/HeaderBar.tsx
@@ -1,12 +1,35 @@
 /**
- * The 44 px top strip: session, driver, connection, playback, lap counter.
+ * The 44 px top strip: session, driver, neutralisation, connection, playback, lap.
  *
- * 1:1 with `window.py::HeaderBar` — same order, same three chips on the
- * right, same three-state connection colour. Every string is built host
- * side; this places them.
+ * Every string is built host side; this places them.
+ *
+ * **The neutralisation chip is new and it is not decoration.** This window said
+ * nothing at all about a safety car except as RCM prose inside the RADIO card,
+ * which is the one fact that changes a strategy call the most. It reads the
+ * tick's decoded `track_status_label`, the same field the DATA strip reads, and
+ * wears it through the shared `trackStatusTreatment` so the two windows cannot
+ * disagree about it on a desk where both are open.
  */
 
 import type { HeaderView } from "../../lib/agents";
+import { trackStatusTreatment } from "../../lib/trackStatus";
+
+function TrackStatusChip({ header, frozen }: { header: HeaderView; frozen: boolean }) {
+  const worn = trackStatusTreatment(header.track_status, header.track_status_colour, frozen);
+  if (worn.kind === "unknown") return <span className="chip is-unknown">{worn.text}</span>;
+  return (
+    <span
+      className={worn.kind === "filled" ? "chip is-filled" : "chip"}
+      style={
+        worn.kind === "filled"
+          ? { background: worn.rgb, borderColor: worn.rgb }
+          : { color: worn.rgb, borderColor: worn.rgb }
+      }
+    >
+      {worn.text}
+    </span>
+  );
+}
 
 export function HeaderBar({ header, frozen = false }: { header: HeaderView; frozen?: boolean }) {
   return (
@@ -14,6 +37,9 @@ export function HeaderBar({ header, frozen = false }: { header: HeaderView; froz
       <span className="header-session">{header.session}</span>
       <span className="header-driver">{header.driver}</span>
       <span className="header-spacer" />
+      {/* Left of the connection chip, because it is about the RACE and the ones
+          after it are about this window's plumbing. */}
+      <TrackStatusChip header={header} frozen={frozen} />
       <span className="chip header-conn" style={{ color: header.connection_colour }}>
         {header.connection}
       </span>

--- a/src/pitwall/ui/src/features/data/StatusStrip.tsx
+++ b/src/pitwall/ui/src/features/data/StatusStrip.tsx
@@ -17,6 +17,7 @@
 
 import type { Connection, Tick } from "../../lib/bridge";
 import { driverStatus } from "../../lib/driverStatus";
+import { trackStatusTreatment } from "../../lib/trackStatus";
 
 interface StatusStripProps {
   tick: Tick | null;
@@ -88,11 +89,29 @@ function StripField({ label, value }: { label: string; value: string }) {
 }
 
 /**
- * The decoded status, or an explicit unknown.
+ * The decoded status, or an explicit unknown, in this strip's chip idiom.
  *
- * A null label means the loader has no TrackStatus entry for this lap, which
- * is NOT a green track. Rendering it as GREEN would be a confident answer to
- * a question nobody asked the data.
+ * **The three-state rule moved to `lib/trackStatus.ts` and is shared with the
+ * AGENTS header**, which renders the same neutralisation in its own idiom. Both
+ * windows are open on one desk; a second copy of this rule is a second chance
+ * for them to disagree, which is exactly what the connection chip did.
+ *
+ * What stays here is the markup, because the two chips are not the same object:
+ * this one is a 1465 x 28 strip cell and the other is a header chip.
+ *
+ * A non-green status is FILLED, and that is the whole of the window's reaction
+ * to a safety car. Before this it was an outline chip swapping its text, `GREEN`
+ * at 54.3 x 18 px against `SAFETY CAR` at about 86 x 18, and nothing else on the
+ * window changed at all: two captures, one green and one under the safety car,
+ * differed in no element but that one.
+ *
+ * The fill is a DIFFERENT amber from the one the pace grid's rail and the race
+ * trace's band use for the same state. The wire sends `SAFETY CAR` as
+ * rgb(255,140,0) while those two use `palette.WARNING` #f59e0b. Both names live
+ * in `palette.py` so neither is a stray literal, and at a glance the two are
+ * indistinguishable; recorded so the next reader finds a decision rather than a
+ * bug. The wire's colour is the right one to fill with, because it is the one
+ * the arcade paints its own banner in on the screen beside this window.
  */
 function TrackStatusChip({
   label,
@@ -103,41 +122,18 @@ function TrackStatusChip({
   colour: [number, number, number] | null;
   frozen: boolean;
 }) {
-  if (!label || !colour) return <span className="strip-chip is-unknown">NO STATUS</span>;
-  // **A dead feed cannot assert a track status.** The track may have gone red in
-  // the seconds since the last tick, and a frozen FILLED `SAFETY CAR` chip would
-  // be worse than a frozen green one: it would look like a live alarm. So the chip
-  // keeps its LABEL - the last thing that was true - and gives up its weight,
-  // rendering as the same dim unknown treatment `NO STATUS` uses.
-  if (frozen) return <span className="strip-chip is-unknown">{label}</span>;
-  const rgb = `rgb(${colour[0]}, ${colour[1]}, ${colour[2]})`;
-  // **A non-green status is FILLED, and that is the whole of the window's
-  // reaction to a safety car.** Before this it was an outline chip swapping its
-  // text - `GREEN` measured 54.3 x 18 px, `SAFETY CAR` about 86 x 18 - inside a
-  // 1465 x 28 strip, and nothing else on the window changed at all. Two captures
-  // of the same window, one green and one under the safety car, differed in no
-  // element but that one; glanced at from the arcade beside it, the race's most
-  // decision-dense state and its calmest looked the same.
-  //
-  // The colour is the wire's own (`track_status_color`, decoded by the producer
-  // out of `palette.py`), so this spends no new constant, and it degrades
-  // honestly: `NO STATUS` above stays the dim unknown chip rather than borrowing
-  // the weight, because an absence is not an alarm.
-  //
-  // It is a DIFFERENT amber from the one the pace grid's rail and the race trace's
-  // band use for the same state - the wire sends `SAFETY CAR` as rgb(255,140,0)
-  // while those two use `palette.WARNING` #f59e0b. Both names live in `palette.py`
-  // so neither is a stray literal, and at a glance the two are indistinguishable;
-  // it is recorded here so the next reader finds a decision rather than a bug. The
-  // wire's colour is the right one to fill with, because it is the one the arcade
-  // paints its own banner in on the screen beside this window.
-  const green = label === "GREEN";
+  const worn = trackStatusTreatment(label, colour, frozen);
+  if (worn.kind === "unknown") return <span className="strip-chip is-unknown">{worn.text}</span>;
   return (
     <span
-      className={green ? "strip-chip" : "strip-chip is-filled"}
-      style={green ? { color: rgb, borderColor: rgb } : { background: rgb, borderColor: rgb }}
+      className={worn.kind === "filled" ? "strip-chip is-filled" : "strip-chip"}
+      style={
+        worn.kind === "filled"
+          ? { background: worn.rgb, borderColor: worn.rgb }
+          : { color: worn.rgb, borderColor: worn.rgb }
+      }
     >
-      {label}
+      {worn.text}
     </span>
   );
 }

--- a/src/pitwall/ui/src/lib/agents.ts
+++ b/src/pitwall/ui/src/lib/agents.ts
@@ -56,6 +56,11 @@ export interface HeaderView {
   playback: string;
   connection: string;
   connection_colour: string;
+  /** The tick's decoded TrackStatus, `null` when the loader has no entry for
+   *  the lap. `null` is NOT a green track and must not render as one. */
+  track_status: string | null;
+  /** The wire's own colour for it, so neither window decodes the digits. */
+  track_status_colour: [number, number, number] | null;
 }
 
 export interface PaceHistoryRow {

--- a/src/pitwall/ui/src/lib/trackStatus.ts
+++ b/src/pitwall/ui/src/lib/trackStatus.ts
@@ -1,0 +1,48 @@
+/**
+ * How a track status is WORN, decided once for both windows.
+ *
+ * The two windows sit side by side on one desk and show the same neutralisation,
+ * so a second copy of this rule is a second chance for them to disagree about
+ * the race's most decision-changing fact. The connection chip was exactly that
+ * and cost a sprint: `Connecting...` rendered amber through one window and dim
+ * grey through the other's own CSS.
+ *
+ * What is shared is the DECISION, not the markup. The two windows have different
+ * chip idioms (`.strip-chip` in the DATA strip, `.chip` in the AGENTS header) and
+ * forcing one component on both would move a layout choice into a shared module
+ * to save a rule that fits in twenty lines.
+ *
+ * The colour is always the wire's own `track_status_color`, decoded by the
+ * producer out of `palette.py`, so neither window spends a constant on it.
+ */
+
+export type TrackStatusTreatment =
+  | { kind: "unknown"; text: string }
+  | { kind: "outline"; text: string; rgb: string }
+  | { kind: "filled"; text: string; rgb: string };
+
+/**
+ * The three states, in the order they have to be tested.
+ *
+ * - **No label or no colour is `unknown`**, and it says `NO STATUS` rather than
+ *   guessing green. The producer sends `null` when the loader has no entry for
+ *   the lap, which is not the same as a green track.
+ * - **A frozen feed keeps its LABEL and gives up its WEIGHT.** The track may have
+ *   gone red in the seconds since the last tick, and a frozen filled `SAFETY CAR`
+ *   would read as a live alarm. An absence is not an alarm either way.
+ * - **A non-green status is FILLED.** Before that it was an outline chip swapping
+ *   its text, and two captures of the same window, one green and one under the
+ *   safety car, differed in no element but that one.
+ */
+export function trackStatusTreatment(
+  label: string | null,
+  colour: [number, number, number] | null,
+  frozen: boolean,
+): TrackStatusTreatment {
+  if (!label || !colour) return { kind: "unknown", text: "NO STATUS" };
+  if (frozen) return { kind: "unknown", text: label };
+  const rgb = `rgb(${colour[0]}, ${colour[1]}, ${colour[2]})`;
+  return label === "GREEN"
+    ? { kind: "outline", text: label, rgb }
+    : { kind: "filled", text: label, rgb };
+}

--- a/src/pitwall/ui/src/styles/agents.css
+++ b/src/pitwall/ui/src/styles/agents.css
@@ -72,6 +72,28 @@
   font-weight: 800;
 }
 
+/* The neutralisation chip's two non-default states. The colours are INLINE, off
+ * the wire's own `track_status_color`, so nothing here names one: these rules
+ * carry the weight and the border only.
+ *
+ * A non-green status is filled and bold, because that is this window's whole
+ * reaction to a safety car and an outline chip swapping its text is a change a
+ * reader misses at a glance. The DATA strip made the same move for the same
+ * reason; `lib/trackStatus.ts` is the rule both of them ask. */
+.chip.is-filled {
+  color: var(--qt-bg);
+  font-weight: 800;
+  border: 1px solid transparent;
+}
+/* An absence is not an alarm, so it gives up its weight AND its colour. This is
+ * what a missing TrackStatus entry wears, and what a live status wears once the
+ * feed is frozen: the label was true, the assertion is not. */
+.chip.is-unknown {
+  color: var(--qt-fg-3);
+  background: var(--qt-elevated);
+  font-weight: 500;
+}
+
 /* The cards while the feed is dead: dimmed, NOT desaturated. Same reasoning as the
  * DATA window's `.data-main.is-frozen` - `saturate()` collapses hue differences and
  * this window's colour is content too (the alarm red, the WARNING amber on a

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -653,6 +653,46 @@ def test_the_tooltips_return_data_and_never_markup():
         assert "<" not in repr(value), f"markup reached the view: {value!r}"
 
 
+def test_the_agents_header_takes_the_neutralisation_off_the_tick():
+    """One source for the race's most decision-changing fact, and an absence stays one.
+
+    The situation agent publishes `sc_currently_active` and `vsc_active` on the
+    same payload. Rendering those would put two sources for one fact on a desk
+    where both windows are open: one is FastF1's TrackStatus for the lap on
+    screen, decoded once by the producer so nobody re-derives it, and the other is
+    a boolean N27 computed for the lap it was asked about. This asserts the header
+    reads the decoded one.
+
+    The second half is the part that costs if it is wrong. The producer sends
+    `None` when the loader has no entry for the lap, and that is NOT a green
+    track: a header that defaulted it would render a confident answer to a
+    question nobody asked the data.
+    """
+    green = _host(_payload()).get_agents_view(-1)["header"]
+    assert (green["track_status"], green["track_status_colour"]) == ("GREEN", [16, 185, 129])
+
+    under_sc = _payload()
+    under_sc["arcade"]["track_status_label"] = "SAFETY CAR"
+    under_sc["arcade"]["track_status_color"] = [255, 140, 0]
+    sc = _host(under_sc).get_agents_view(-1)["header"]
+    assert (sc["track_status"], sc["track_status_colour"]) == ("SAFETY CAR", [255, 140, 0])
+
+    blind = _payload()
+    del blind["arcade"]["track_status_label"]
+    del blind["arcade"]["track_status_color"]
+    unknown = _host(blind).get_agents_view(-1)["header"]
+    assert unknown["track_status"] is None, "an absent status became a claim"
+    assert unknown["track_status_colour"] is None
+
+    # And the agent's own pair is NOT what the header reads, which is the whole
+    # point: a payload whose agent says the safety car is out while the tick says
+    # green renders green, because the tick is the source.
+    disagreeing = _payload()
+    disagreeing["strategy"]["latest"]["per_agent"]["situation"]["sc_currently_active"] = True
+    still = _host(disagreeing).get_agents_view(-1)["header"]
+    assert still["track_status"] == "GREEN", "the header followed the agent instead of the tick"
+
+
 def test_the_radio_tooltip_carries_the_nlp_corrections():
     """N29's mismatch list reaches the popup, and an LLM string in it is not markup.
 
@@ -848,6 +888,11 @@ def _payload(
             "lap": lap,
             "total_laps": 57,
             "driver_main": "NOR",
+            # The decoded pair the producer publishes so no consumer reads the
+            # digits. Present here rather than omitted, because a fixture without
+            # them exercises only the unknown branch of everything downstream.
+            "track_status_label": "GREEN",
+            "track_status_color": [16, 185, 129],
         },
         "playback": {"speed": 2.0, "paused": False, "frame_index": 1000, "total_frames": 9000},
         "strategy": {
@@ -897,6 +942,8 @@ def test_the_view_is_what_the_qt_window_renders_line_for_line():
         "playback": "2.00× · PLAYING",
         "connection": "Connected",
         "connection_colour": "#10b981",
+        "track_status": "GREEN",
+        "track_status_colour": [16, 185, 129],
     }
     assert view["status_bar"] == {"text": "lap 23 · streaming", "transient": True}
 


### PR DESCRIPTION
## What

The AGENTS header gains a neutralisation chip, and the three-state rule behind it becomes shared with the DATA window instead of copied.

## Why

Before this the AGENTS window said nothing at all about a safety car except as RCM prose inside the RADIO card. That is the single fact that changes a strategy call the most, on the window whose entire subject is the call.

Two sources for it ride the same tick:

| source | what it is |
|---|---|
| `arcade.track_status_label` / `track_status_color` | FastF1 TrackStatus for the lap on screen, decoded by the producer's own priority rule (red > SC > VSC > yellow) precisely so no consumer re-derives it |
| `per_agent.situation.sc_currently_active` / `vsc_active` | booleans N27 computed for the lap it was asked about, on the tick because the producer `asdict`s the whole dataclass, rendered nowhere |

**The header reads the decoded one.** It is already the single-rule signal, it is what the DATA window renders three feet away, and rendering the agent's pair instead would put two sources for one fact on a desk where both windows are open, free to disagree. The agent's pair are a deletion, and that is a wire change, so it goes with #1048's schema work rather than being a third one.

## How

- `agents_view/panels.py`: `build_header` carries `track_status` and `track_status_colour` straight off the tick. Both stay `None` when the loader has no entry for the lap, because that is not a green track.
- `ui/src/lib/trackStatus.ts` (new): the three-state rule, one place. Unknown when either half is missing; label without weight when the feed is frozen, because a frozen filled `SAFETY CAR` reads as a live alarm; green outlined and everything else FILLED with the wire's own colour.
- `StatusStrip.tsx` and `HeaderBar.tsx` both ask it and each renders its own markup. The markup is deliberately not shared: one is a 1465 x 28 strip cell, the other a header chip.
- `agents.css`: `.chip.is-filled` and `.chip.is-unknown` carry weight and border only; the colour is inline off the wire, so no new constant.

This is the connection chip's lesson applied before the fact. That one wore WARNING amber through the AGENTS view and dim grey through the DATA strip's own CSS, for the same socket, on two windows open side by side.

## Checks

Both guards driven RED first, each against the thing it guards.

- **The renderer.** Mutated `trackStatusTreatment` so an absent status falls back to green, rebuilt, ran the smoke: `smoke FAILED (1): an absent status says so rather than rendering green ("GREEN")`. Restored with `cp` and verified with `cmp`.
- **The source.** Mutated `build_header` to prefer `sc_currently_active` over the tick and ran the guard: it failed on the disagreement case, `+ SAFETY CAR`. Restored the same way.
- `tests/surfaces/` **267 passed**, up from 266.
- `smoke-agents` **59 to 65 checks**; `smoke-data` **230**, unchanged.
- `ruff 0.15.22 check .` clean; `format --check .` repo-wide, 184 files already formatted.
- `tsc -b` 0 errors, checked with `grep -c "error TS"` before believing any smoke result. The first build of this branch failed on a header literal in `AgentsWindow.tsx` and the smoke duly measured the previous bundle, which is what that check exists for.

The new smoke checks assert the EFFECT, not the property: a neutralised track has to compute to a heavier font weight and the wire's own `rgb(255, 140, 0)` background, because the failure being replaced is a chip that only swapped its text and that a reader misses at a glance.

## One thing found while doing it

`smoke-data`'s 230 checks did **not** catch the mutation to the shared rule. The DATA window's own unknown branch is unguarded there, and has been. It is covered from the AGENTS side now, which is enough for one shared rule, but worth knowing before anyone assumes 230 checks means the strip is fully covered.

## Out of scope

Deleting `sc_currently_active` and `vsc_active` from the wire. It is a schema change and belongs with #1048, which is already migrating the telemetry block and the three frozen contract tests.

Closes #1043
