### PR TITLE
fix(pitwall): leaving the TRACES tab no longer loses the rest of the lap

### DIFF
--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -3894,6 +3894,93 @@ check(
   `the status bar tracks the same two states (up: "${waitingUp.bar}", down: "${waitingDown.bar}")`,
 );
 
+// ── Leaving TRACES and coming back keeps the lap (#1056) ─────────────────────
+//
+// The tab strip renders `OwnCarTraces` conditionally, so leaving TRACES unmounts
+// it. While the accumulator lived inside that component the unmount destroyed it
+// and the six panels restarted from wherever the car was on the way back, with
+// the rest of the lap gone and nothing on the wire able to rebuild it: the span
+// carries only what happened since the last tick.
+//
+// The assertion is the EFFECT and it has to be the LEFT edge of the data. Asking
+// whether the chart has points would pass against the defect, because after the
+// remount it has plenty of them; what it does not have is the beginning.
+{
+  const span = (from) =>
+    [0, 1, 2, 3, 4].map((i) => ({
+      lap: 24,
+      t: 10 + from / 100 + i,
+      dist: from + i * 100,
+      speed: 200 + i * 10,
+      throttle: 50 + i,
+      brake: 0,
+      gear: 6,
+      drs: 8,
+    }));
+
+  const ctx = await browser.newContext({ viewport: CLIENT });
+  const tabPage = await ctx.newPage();
+  watchPage(tabPage, failures, "tab-return");
+  await tabPage.addInitScript((payload) => {
+    window.__ticks = [payload];
+    window.__cursor = 0;
+    window.pywebview = {
+      api: {
+        get_tick: async (sinceSeq) => {
+          if (window.__ticks[window.__cursor].seq === sinceSeq) {
+            if (window.__cursor + 1 >= window.__ticks.length) return null;
+            window.__cursor += 1;
+          }
+          return window.__ticks[window.__cursor];
+        },
+        get_bulk: async () => null,
+        get_live_lap: async () => null,
+        get_connection: async () => ({ label: "Connected", colour: "#10b981" }),
+      },
+    };
+  }, tick(1, { main: span(100), rivalSpan: [] }));
+
+  await tabPage.goto(url, { waitUntil: "domcontentloaded" });
+  await tabPage.waitForSelector(".trace-stack-plot canvas", { timeout: 5000 });
+
+  const feed = async (payload) => {
+    await tabPage.evaluate((t) => window.__ticks.push(t), payload);
+    await tabPage.waitForTimeout(260);
+  };
+  const leftEdge = () =>
+    tabPage.evaluate(() => {
+      const el = document.querySelector(".trace-stack-plot");
+      const series = el.__pitwallChart.getOption().series.filter((x) => x.data?.length);
+      const xs = series.flatMap((x) => x.data.map((p) => p[0]));
+      return xs.length ? Math.min(...xs) : null;
+    });
+
+  await feed(tick(2, { main: span(600), rivalSpan: [] }));
+  const before = await leftEdge();
+
+  // Away, and the producer keeps sending while the panel is unmounted.
+  await tabPage.getByRole("tab", { name: "RACE PACE" }).click();
+  await tabPage.waitForTimeout(200);
+  check(
+    (await tabPage.locator(".trace-stack-plot").count()) === 0,
+    "leaving TRACES really unmounts the panel, or this check proves nothing",
+  );
+  await feed(tick(3, { main: span(1100), rivalSpan: [] }));
+  await feed(tick(4, { main: span(1600), rivalSpan: [] }));
+
+  await tabPage.getByRole("tab", { name: "TRACES" }).click();
+  await tabPage.waitForSelector(".trace-stack-plot canvas", { timeout: 5000 });
+  await tabPage.waitForTimeout(300);
+  const after = await leftEdge();
+
+  check(before === 100, `the lap starts where the first span did (${before})`);
+  check(
+    after === before,
+    `returning to TRACES keeps the whole lap, not just what arrived after (${after} vs ${before})`,
+  );
+  await ctx.close();
+}
+
 await browser.close();
 server.close();
 

--- a/src/pitwall/ui/src/features/data/DataWindow.tsx
+++ b/src/pitwall/ui/src/features/data/DataWindow.tsx
@@ -25,6 +25,7 @@ import { useState } from "react";
 
 import { BestsPanel } from "./BestsPanel";
 import { OwnCarTraces } from "./OwnCarTraces";
+import { useTraceFrame } from "./useTraceFrame";
 import { RacePaceGrid } from "./RacePaceGrid";
 import { RaceTraceChart } from "./RaceTraceChart";
 import { RadioFeed } from "./RadioFeed";
@@ -53,6 +54,13 @@ const TABS = [
 
 export function DataWindow() {
   const { tick, discontinuity, live } = useTick();
+  // **Owned here, not in the panel that draws it (#1056).** The tab strip renders
+  // `OwnCarTraces` conditionally, so a reader leaving TRACES unmounts it; a buffer
+  // living inside it was destroyed and the rest of the lap went with it, because
+  // the wire carries only the span since the last tick and cannot backfill. This
+  // component sees every tick whichever tab is showing, so ingestion continues
+  // while the panel is away.
+  const traceFrame = useTraceFrame(tick, discontinuity);
   const connection = useConnection();
   const bulk = useBulk();
   const liveLap = useLiveLap();
@@ -125,7 +133,9 @@ export function DataWindow() {
               </nav>
               {tab === "traces" && (
                 <div className="band4">
-                  <OwnCarTraces tick={tick} discontinuity={discontinuity} frozen={frozen} />
+                  {traceFrame && (
+                    <OwnCarTraces tick={tick} frame={traceFrame} frozen={frozen} />
+                  )}
                   <div className="side-column">
                     <TrackRing arcade={tick.arcade} />
                     <RadioFeed bulk={bulk} driverMain={tick.arcade.driver_main} />

--- a/src/pitwall/ui/src/features/data/OwnCarTraces.tsx
+++ b/src/pitwall/ui/src/features/data/OwnCarTraces.tsx
@@ -31,11 +31,9 @@
  * frozen/starved question.
  */
 
-import { useMemo, useRef } from "react";
 import type { Tick } from "../../lib/bridge";
-import type { Discontinuity } from "../../lib/frameClock";
 import { TraceStack } from "./TraceStack";
-import { TraceAccumulator, deltaSeries } from "./traceBuffer";
+import type { TraceFrame } from "./useTraceFrame";
 
 // --- What the stack does not own -----------------------------------------
 //
@@ -51,33 +49,26 @@ const MIN_CREDIBLE_CIRCUIT_M = 100;
 
 interface OwnCarTracesProps {
   tick: Tick;
-  discontinuity: Discontinuity;
+  /**
+   * The accumulated buffers, owned by `DataWindow`.
+   *
+   * **A prop rather than a `useRef` here, and that is the fix for #1056.** This
+   * component is rendered conditionally by the tab strip, so it unmounts when the
+   * reader leaves TRACES; owning the buffer meant losing the rest of the lap, with
+   * nothing on the wire able to rebuild it.
+   */
+  frame: TraceFrame;
   /** The producer is gone; these buffers will not fill. */
   frozen?: boolean;
 }
 
-export function OwnCarTraces({ tick, discontinuity, frozen = false }: OwnCarTracesProps) {
-  const accumulator = useRef(new TraceAccumulator());
+export function OwnCarTraces({ tick, frame, frozen = false }: OwnCarTracesProps) {
   const { arcade } = tick;
   const rivalCode = arcade.driver_rival;
 
-  // Keyed on the sequence, so one tick is folded in once per tick even
-  // though StrictMode runs this factory twice - `ingest` is idempotent for
-  // exactly that reason. The X lock is derived here too: `circuit_length_m`
-  // rides on every tick, so unlike Qt there is no first-time flag to hold.
-  const frame = useMemo(() => {
-    const { telemetry } = arcade;
-    // The producer's own eviction signals, plus the clock's - `FrameClock`
-    // sees a backwards jump smaller than one broadcast that the flags miss.
-    const evict =
-      telemetry.rewound || telemetry.dropped > 0 || discontinuity.kind !== "continuous";
-    accumulator.current.ingest(telemetry.main, telemetry.rival, evict);
-    const main = accumulator.current.mainTrace;
-    const rival = accumulator.current.rivalTrace;
-    return { main, rival, delta: deltaSeries(main, rival) };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tick.seq]);
-
+  // The X lock is derived here because `circuit_length_m` rides on every tick, so
+  // unlike Qt there is no first-time flag to hold. The BUFFERS are not derived
+  // here any more; see the `frame` prop.
   const xMax =
     arcade.circuit_length_m > MIN_CREDIBLE_CIRCUIT_M ? arcade.circuit_length_m : FALLBACK_X_MAX;
 

--- a/src/pitwall/ui/src/features/data/useTraceFrame.ts
+++ b/src/pitwall/ui/src/features/data/useTraceFrame.ts
@@ -1,0 +1,54 @@
+/**
+ * The own-car trace buffers, owned ABOVE the tab that renders them.
+ *
+ * **This exists because of where it is called, not because of what it does.**
+ * The accumulator used to be a `useRef` inside `OwnCarTraces`, and `DataWindow`
+ * renders that component conditionally (`{tab === "traces" && ...}`), so leaving
+ * the tab UNMOUNTED it and destroyed the buffer. Coming back inside the same lap
+ * built a fresh empty one and the six panels restarted from whatever distance the
+ * car happened to be at, with the rest of the lap gone.
+ *
+ * Nothing could rebuild it: the wire carries only the span since the last tick
+ * (`_telemetry_span_bounds`), there is no history on it, and there is no
+ * addressable telemetry on disk. The buffer is the only copy.
+ *
+ * So the hook is called from `DataWindow`, which is mounted for every tick
+ * whichever tab is showing, and ingestion continues while the traces tab is away.
+ *
+ * Not solved by keeping the panel mounted and hiding it with CSS: the tab strip
+ * exists precisely because the column cannot afford both worlds at once (with the
+ * ring still mounted its cells clip 1,101 of 1,140), and an ECharts instance
+ * re-rendering off-screen at 10 Hz is the cost the tabs were introduced to avoid.
+ */
+
+import { useMemo, useRef } from "react";
+import type { Tick } from "../../lib/bridge";
+import type { Discontinuity } from "../../lib/frameClock";
+import { TraceAccumulator, deltaSeries, type SortedTrace } from "./traceBuffer";
+
+export interface TraceFrame {
+  main: SortedTrace;
+  rival: SortedTrace;
+  delta: ReturnType<typeof deltaSeries>;
+}
+
+export function useTraceFrame(tick: Tick | null, discontinuity: Discontinuity): TraceFrame | null {
+  const accumulator = useRef(new TraceAccumulator());
+
+  // Keyed on the sequence, so one tick is folded in once per tick even though
+  // StrictMode runs this factory twice - `ingest` is idempotent for exactly that
+  // reason.
+  return useMemo(() => {
+    if (!tick) return null;
+    const { telemetry } = tick.arcade;
+    // The producer's own eviction signals, plus the clock's - `FrameClock` sees a
+    // backwards jump smaller than one broadcast that the flags miss.
+    const evict =
+      telemetry.rewound || telemetry.dropped > 0 || discontinuity.kind !== "continuous";
+    accumulator.current.ingest(telemetry.main, telemetry.rival, evict);
+    const main = accumulator.current.mainTrace;
+    const rival = accumulator.current.rivalTrace;
+    return { main, rival, delta: deltaSeries(main, rival) };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tick?.seq]);
+}


### PR DESCRIPTION
## What

The own-car trace buffers move from `OwnCarTraces` up into `DataWindow`, so leaving the TRACES tab and coming back keeps the lap.

## Why

Three facts and the bug is what they add up to:

1. `DataWindow.tsx:126` renders the panel as `{tab === "traces" && (...)}`, so switching tab **unmounts** it.
2. `OwnCarTraces.tsx:60` held the buffer as `useRef(new TraceAccumulator())`, inside that component. Unmounting destroyed it; returning constructed an empty one.
3. The wire carries only the span since the last tick (`_telemetry_span_bounds`), so a fresh accumulator has nothing to rebuild the rest of the lap from. There is no history on the wire and no addressable telemetry on disk.

Observed on a Melbourne 2025 replay: a full lap drawn from about 1,400 m, then a tab switch and a return during a later lap leaving the six panels drawing from about 900 m only, with the axis still spanning the full 5 km and the first 900 m blank.

The other two tabs never had this because they do not accumulate: `RacePaceGrid` and `RaceTraceChart` both read `bulk`, which is host-side state and survives any number of unmounts.

## How

- `useTraceFrame.ts` (new) holds the accumulator and the per-tick ingest, unchanged in behaviour. It exists for **where it is called from**, not for what it does, and its docstring says so.
- `DataWindow` calls it. That component is mounted for every tick whichever tab is showing, so ingestion continues while the panel is away.
- `OwnCarTraces` takes the frame as a prop. It still owns the X lock, the cursor, the header and the frozen question, which are all properties of the tick rather than of the buffer.

Deliberately **not** fixed by keeping the panel mounted and hiding it with CSS. The tab strip exists because the column cannot afford both worlds at once, and the panel's own comment records that with the ring still mounted its cells clip 1,101 of 1,140. An ECharts instance re-rendering off-screen at 10 Hz is the cost the tabs were introduced to avoid.

## Checks

**The guard was driven RED against the defect, not against a mutation of the fix.** Put the accumulator back inside `OwnCarTraces` and ran it:

```
smoke-data FAILED (1):
  - returning to TRACES keeps the whole lap, not just what arrived after (1600 vs 100)
```

That number is the bug: the trace restarting at the span that arrived after the remount. Restored with `cp` and verified byte-identical with `cmp`, not with `git checkout`, which would have reverted the fix in the same file.

The guard asserts the **left edge** of the data, not that the chart has points. After a remount it has plenty of points; what it lacks is the beginning. It also checks that leaving the tab really unmounts the panel, because otherwise the whole scenario proves nothing.

- `smoke-data` **230 to 233 checks**; `smoke-agents` 65, unchanged.
- `tests/surfaces/` 267 passed.
- `tsc -b` 0 errors, verified with `grep -c "error TS"` before believing any smoke result.
- `ruff format --check .` repo-wide, 184 files already formatted.

**Real path**, against the live producer and the real window rather than the harness. On lap 41, moved to RACE PACE for five seconds and came back:

```
on TRACES, after accumulating: {"lap":"LAP 41","min":0,"max":174,"n":696}
away on RACE PACE for 5 s, panel mounted: 0
back on TRACES:                {"lap":"LAP 41","min":0,"max":426,"n":2632}
```

Same lap, the left edge still 0 m, and the buffer grew from 696 to 2,632 points while the panel was unmounted. Screenshotted and looked at: the six panels draw the lap from its start.

## Sequence note

#1050 changes who owns this accumulator again, moving it to per-driver buffers with selection at render. Whoever takes that issue should re-read this one rather than assume the ownership is settled.

Closes #1056
