### PR TITLE
chore(arcade): say what the strategy layer drops, and stop dropping it silently

### DIFF
--- a/src/arcade/strategy.py
+++ b/src/arcade/strategy.py
@@ -108,6 +108,29 @@ class PerAgentOutputsDTO:
 
 @dataclass(frozen=True)
 class LapDecisionDTO:
+    """One lap's decision, as the wire carries it.
+
+    **What this deliberately does NOT copy from ``StrategyRecommendation``, and
+    why (#1046).** That object has fourteen fields and this takes ten. The four
+    it leaves behind used to stop here silently, which reads as an oversight
+    rather than a decision:
+
+    - ``contingencies`` and ``key_risks`` are decision CONTENT and have a claim on
+      the window. They are held back only because adding them is a schema change,
+      so they ride with #1048's bump rather than being a second migration of a
+      frozen contract. ``contingencies`` is the one the orchestrator memory audit
+      calls load-bearing, and it is invisible in ``reasoning``, which is why it was
+      given its own field instead of being left to the model's prose.
+    - ``expected_stint_end`` stays out. The PLAN timeline already draws the stint
+      boundary from ``pit_lap_target``, and a second source for one number on one
+      surface is the twin shape this repo pays for most.
+    - ``target_lap_time_s`` stays out. Under a safety car the rail sets it to
+      ``None`` by Art. 55.7, because N06 predicts green-flag pace and publishing a
+      target above the delta sends the driver at a penalty. A field whose absence
+      is the load-bearing case needs a designed rendering before it is worth
+      carrying, and nothing on either window asks for it.
+    """
+
     lap_number: int = 0
     compound: str = ""
     tyre_life: int = 0

--- a/src/arcade/strategy_pipeline.py
+++ b/src/arcade/strategy_pipeline.py
@@ -16,11 +16,14 @@ surfaces; nothing to keep in sync by hand.
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 import pandas as pd
 
 from src.strategy.inference.engine import run_lap
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:  # pragma: no cover — only for type hints
     from src.agents.strategy_orchestrator import RaceState, StrategyRecommendation
@@ -40,11 +43,27 @@ def run_strategy_pipeline(
     formatters that already call this positionally keep working unchanged. The
     ``agent_outputs`` dict carries the same keys as before (``pace_out``/
     ``tire_out``/``situation_out``/``radio_out``/``pit_out``/
-    ``regulation_context``/``rag``/``active``) plus ``guardrail_reason``; the
-    engine's third return value (stage timings) is dropped here (a future arcade
-    change may forward it on the TCP stream).
+    ``regulation_context``/``rag``/``active``) plus ``guardrail_reason``.
+
+    **The stage timings are LOGGED, not returned and not broadcast (#1045).**
+    This docstring used to say they were dropped here and that "a future arcade
+    change may forward it on the TCP stream", which stayed a promise rather than
+    a plan while the measurement was paid for on every lap and thrown away on the
+    same line. All three callers of ``run_lap`` discarded it, so nothing has ever
+    consumed it.
+
+    They go to the log rather than to the wire because they are DIAGNOSTIC: a pit
+    wall does not show model latency, this window has no diagnostics tier, and
+    putting six numbers on a surface built for a decision is how a panel becomes a
+    drawer. In a log they cost nothing per tick and they are there when a lap is
+    slow, which is the only moment anyone wants them.
+
+    DEBUG and not INFO: this runs once per lap of every arcade race.
     """
-    rec, agent_outputs, _timings = run_lap(
+    rec, agent_outputs, timings = run_lap(
         race_state, laps_df, lap_state, profile="rich", memory=memory
     )
+    if logger.isEnabledFor(logging.DEBUG):
+        breakdown = " ".join(f"{stage}={seconds:.3f}s" for stage, seconds in timings.items())
+        logger.debug("lap %s pipeline stages: %s", getattr(race_state, "lap", "?"), breakdown)
     return rec, agent_outputs

--- a/tests/surfaces/test_arcade_wire_contract.py
+++ b/tests/surfaces/test_arcade_wire_contract.py
@@ -869,3 +869,71 @@ def test_a_lap_with_no_track_status_entry_is_unknown_and_not_green():
 
     assert track_status_label("") is None, "unknown is None, never GREEN"
     assert track_status_label("1") is not None, "a real clear IS green and says so"
+
+
+def test_every_recommendation_field_the_wire_drops_was_decided_about():
+    """A field that stops at the DTO boundary must be a decision, not an oversight.
+
+    `StrategyRecommendation` has fourteen fields and `LapDecisionDTO` copies ten.
+    The rest used to vanish silently, so a new field added to the orchestrator
+    would join them without anybody noticing it never reached a surface. This is
+    the guard against that: the difference between the two sets is FROZEN, and a
+    fifteenth field fails here until someone writes down where it goes.
+
+    Read with `ast` for the reason `_dataclass_field_names` gives: importing
+    `src/arcade/strategy_pipeline.py` pulls torch, langchain and three transformer
+    checkpoints, measured at 18.4 s, and CI has no model weights at all.
+    """
+    recommendation = _dataclass_field_names(
+        "src/agents/strategy_orchestrator.py", "StrategyRecommendation"
+    )
+    dto = _dataclass_field_names("src/arcade/strategy.py", "LapDecisionDTO")
+
+    assert recommendation - dto == {
+        # Decision content, held back only because adding it is a schema change;
+        # rides with #1048's bump rather than migrating a frozen contract twice.
+        "contingencies",
+        "key_risks",
+        # The PLAN timeline already draws the stint boundary from `pit_lap_target`.
+        # A second source for one number on one surface is the twin shape.
+        "expected_stint_end",
+        # `None` by Art. 55.7 under a safety car, and the absence is the
+        # load-bearing case. Nothing on either window asks for it yet.
+        "target_lap_time_s",
+        # NOT dropped: it reaches the wire through `PerAgentOutputsDTO`, which is
+        # why it is listed here rather than treated as missing.
+        "regulation_context",
+    }, "a recommendation field changed sides without a decision being recorded (#1046)"
+
+    # And the other direction, so the frozen set cannot be satisfied by the DTO
+    # quietly losing a field it is supposed to carry.
+    assert {"action", "confidence", "reasoning", "scenario_scores"} <= dto
+
+
+def test_the_pipeline_delegate_no_longer_throws_the_stage_timings_away():
+    """`run_lap`'s third value reaches a logger instead of the floor (#1045).
+
+    It used to be bound to `_timings` and dropped on the same line that computed
+    it, under a docstring promising a future change would put it on the wire.
+    Nothing consumed it at any of the three call sites.
+
+    Asserted on the SOURCE, and that limitation is real: exercising the function
+    means importing the agent stack (18.4 s, three checkpoints) and then running
+    the `rich` profile, which spends LLM calls. What the source can say is that
+    the value is bound to a real name and that the name reaches a logging call.
+    """
+    tree = ast.parse((REPO_ROOT / "src/arcade/strategy_pipeline.py").read_text(encoding="utf-8"))
+    func = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "run_strategy_pipeline"
+    )
+    body = ast.dump(func)
+    assert "_timings" not in body, "the third value is still bound to a discard name"
+    assert "timings" in body, "the third value is not bound at all"
+    logged = [
+        node
+        for node in ast.walk(func)
+        if isinstance(node, ast.Attribute) and node.attr in {"debug", "info", "warning"}
+    ]
+    assert logged, "the timings are bound and then still go nowhere"


### PR DESCRIPTION
## What

The arcade's strategy layer stops discarding two things silently: the pipeline's stage timings, and four `StrategyRecommendation` fields.

Closes #1045 and #1046. One PR because they are the same concept at one boundary, not two features.

## Why

**The timings.** `run_lap` returns `(rec, agent_outputs, timings)` with `{always_on, routing, conditional, mc, synthesis, total}` in seconds, measured by `_StageTimer` on every lap. `strategy_pipeline.py:47` bound the third value to `_timings` and dropped it on the same line, under a docstring saying "a future arcade change may forward it on the TCP stream". That stayed a promise. All three call sites of `run_lap` discard it, so nothing has ever consumed it.

**The four fields.** `StrategyRecommendation` has fourteen fields, `LapDecisionDTO` copies ten, and the rest vanished at the boundary with nothing recorded. A field added to the orchestrator would join them unnoticed.

## The decisions, adopted

| field | where it goes | why |
|---|---|---|
| stage timings | the **log**, at DEBUG | Diagnostic. A pit wall does not show model latency and this window has no diagnostics tier; six numbers on a surface built for a decision is how a panel becomes a drawer. In a log they cost nothing per tick and are there when a lap is slow, which is the only moment anyone wants them. |
| `contingencies`, `key_risks` | **the wire, with #1048** | Decision content with a claim on the window. Held back only because adding them is a schema change, and #1048 is already migrating the telemetry block and three frozen contract tests. `contingencies` is what the orchestrator memory audit calls load-bearing, and it is invisible in `reasoning`, which is why it has its own field. |
| `expected_stint_end` | **stays out** | The PLAN timeline already draws the stint boundary from `pit_lap_target`. A second source for one number on one surface is the twin shape this repo pays for most. |
| `target_lap_time_s` | **stays out** | `None` by Art. 55.7 under a safety car, because N06 predicts green-flag pace and publishing a target above the delta sends the driver at a penalty. A field whose absence is the load-bearing case needs a designed rendering, and nothing on either window asks for it. |

`regulation_context` is the fifth name in the set difference and is **not** dropped: it reaches the wire through `PerAgentOutputsDTO`. The guard lists it for that reason rather than treating it as missing.

## Checks

Both guards driven RED, each against the thing it guards rather than against a mutation of the fix.

- Put `_timings` back as a discard: `AssertionError: the third value is still bound to a discard name`.
- Added a fifteenth field to `StrategyRecommendation`: `AssertionError: a recommendation field changed sides without a decision being recorded (#1046)`.
- All three touched files restored with `cp` and verified byte-identical with `cmp`.

- `tests/surfaces/` **269 passed**, up from 267.
- `ruff 0.15.22 check .` clean; `format --check .` repo-wide, 184 files already formatted.

**The log line, from the real function body.** The `rich` profile spends LLM calls and importing this module costs 18.4 s and three transformer checkpoints, so the ENGINE was replaced and everything else is the shipped code:

```
DEBUG src.arcade.strategy_pipeline: lap 23 pipeline stages: always_on=0.412s routing=0.009s conditional=0.188s mc=0.071s synthesis=1.904s total=2.584s
```

No LLM spend.

## Stated limitation

The timings guard asserts on the SOURCE, parsed with `ast`, not on a captured log record. Exercising the function in `tests/surfaces/` would mean importing the agent stack, which CI has no model weights for, and then running the profile that spends LLM calls. What the source can say is that the value is bound to a real name and that the name reaches a logging call; the effect itself is the run pasted above, done by hand.

The field-set guard has no such limitation: it reads both dataclasses with `ast` and freezes the difference.
