### PR TITLE
perf(arcade): build and encode the broadcast off the pyglet thread

### DIFF
--- a/src/arcade/app.py
+++ b/src/arcade/app.py
@@ -621,19 +621,44 @@ class F1ArcadeView(arcade.View):
         if self._stream_server.client_count() == 0:
             return  # no subscriber, skip the serialisation cost
         self._broadcast_seq += 1
-        payload = {
-            "schema_version": STREAM_SCHEMA_VERSION,
-            "seq": self._broadcast_seq,
-            "arcade": self._build_arcade_snapshot(frame_idx, span_start, rewound, dropped),
-            "strategy": self._strategy_state.snapshot_dict(STREAM_HISTORY_TAIL),
-            "playback": {
-                "speed": self.playback_speed,
-                "paused": self._is_paused,
-                "frame_index": frame_idx,
-                "total_frames": self._session.total_frames,
-            },
-        }
-        self._stream_server.broadcast(payload)
+        # Everything the payload needs from the render thread is read HERE and
+        # passed by value, because the closure below runs later and elsewhere.
+        # `self.playback_speed` read inside it would be whatever the user had
+        # selected by the time the sender got round to the job, not the speed
+        # this tick was produced at, and `self._frame_index` would be a float
+        # that has moved on.
+        seq = self._broadcast_seq
+        speed = self.playback_speed
+        paused = self._is_paused
+        total_frames = self._session.total_frames
+        strategy_state = self._strategy_state
+
+        def build_payload() -> dict:
+            """Assemble one tick. Runs on the stream server's sender thread.
+
+            Safe off the pyglet thread because of what it reads: `SessionData`
+            and `RaceGapCalculator` are immutable once constructed, the palette
+            is a dict lookup, `_rank_drivers` is a static function of its
+            arguments, and `snapshot_dict` takes `StrategyState`'s own lock.
+            Everything else is a local captured above.
+
+            It is a closure rather than a payload because building it is the
+            expensive part: 3.19 ms on a steady 8x tick and 5.41 ms on a seek,
+            measured on the real replay, against a 16.7 ms frame budget."""
+            return {
+                "schema_version": STREAM_SCHEMA_VERSION,
+                "seq": seq,
+                "arcade": self._build_arcade_snapshot(frame_idx, span_start, rewound, dropped),
+                "strategy": strategy_state.snapshot_dict(STREAM_HISTORY_TAIL),
+                "playback": {
+                    "speed": speed,
+                    "paused": paused,
+                    "frame_index": frame_idx,
+                    "total_frames": total_frames,
+                },
+            }
+
+        self._stream_server.broadcast(build_payload)
 
     def _build_arcade_snapshot(
         self, frame_idx: int, span_start: int, rewound: bool, dropped: int = 0

--- a/src/arcade/stream.py
+++ b/src/arcade/stream.py
@@ -48,16 +48,25 @@ import select
 import socket
 import threading
 import time
+from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 
 # How long a client may take to accept a broadcast before it is treated as
-# dead. `sendall` is called from the pyglet main thread, so a subscriber that
-# stops reading blocks the replay window itself, not just its own view. The
-# span change made that worse rather than better: a bigger message fills the
-# socket buffer in fewer broadcasts, cutting the measured time-to-freeze from
-# about 130 s to 0.7 s. A real dashboard on localhost accepts a 30 KB message
-# in microseconds, so anything past 50 ms is not slow, it is gone.
+# dead. It bounds what ONE subscriber can cost the sender thread, which is
+# also the thread that builds and encodes the next payload, so a stalled
+# client delays the next tick rather than blocking the replay window. (This
+# comment used to say `sendall` ran on the pyglet main thread and froze the
+# window itself. That stopped being true in `d24a59e1`, which moved the write
+# to `_send_loop`; the rewrite reached `broadcast`'s docstring and not this
+# constant.)
+#
+# The threshold that matters is bytes buffered rather than seconds: a bigger
+# message fills a stalled subscriber's socket buffer in fewer broadcasts, so
+# it is pruned sooner. Measured against a peer that never reads, the time to
+# prune fell from 1.26 s with two telemetry spans to 0.50 s with twenty.
+# A real dashboard on localhost accepts a 30 KB message in microseconds, so
+# anything past 50 ms is not slow, it is gone.
 CLIENT_SEND_TIMEOUT_S = 0.05
 # A transient `accept()` error is retried rather than treated as shutdown, but
 # a listening socket that keeps failing is not going to recover, and a hot
@@ -147,14 +156,15 @@ def _blame(value, path: str = "") -> str:
 
 
 class TelemetryStreamServer:
-    """Non-blocking TCP server that broadcasts JSON dicts to all clients.
+    """Non-blocking TCP server that broadcasts JSON payloads to all clients.
 
-    Runs in a daemon thread, accepts up to many simultaneous connections,
-    writes `json.dumps(data).encode() + b"\\n"` to every live socket on
-    `broadcast()`. Dead sockets are pruned on the next broadcast; no
-    heartbeat needed because the replay pushes at ≥5 Hz. Designed to be
-    started inside `F1ArcadeView._init_strategy_layer` and torn down in
-    `on_hide_view`."""
+    Two daemon threads: one accepts connections, one drains the outbox.
+    `broadcast()` takes a FACTORY and queues it; the sender thread runs it,
+    encodes the result as `json.dumps(...).encode() + b"\\n"` and writes that
+    to every live socket, so the caller never builds, encodes or sends. Dead
+    sockets are pruned on the next broadcast; no heartbeat needed because the
+    replay pushes at >=5 Hz. Designed to be started inside
+    `F1ArcadeView._init_strategy_layer` and torn down in `on_hide_view`."""
 
     def __init__(self, host: str = "127.0.0.1", port: int = 9998) -> None:
         self.host = host
@@ -166,7 +176,7 @@ class TelemetryStreamServer:
         # Depth 1 with drop-oldest. Each payload is a COMPLETE snapshot, not a
         # delta, so a consumer that falls behind wants the newest one and
         # nothing else; `seq` is what makes the discard visible to it.
-        self._outbox: queue.Queue[bytes] = queue.Queue(maxsize=1)
+        self._outbox: queue.Queue[Callable[[], dict]] = queue.Queue(maxsize=1)
 
     def start(self) -> None:
         """Bind the listening socket and spawn the accept thread."""
@@ -204,26 +214,49 @@ class TelemetryStreamServer:
             self._clients.clear()
         logger.info("TelemetryStreamServer stopped")
 
-    def broadcast(self, data: dict) -> None:
-        """Queue one JSON-encoded payload for every connected client.
+    def broadcast(self, build: Callable[[], dict]) -> None:
+        """Queue one payload for every connected client, BUILT off this thread.
 
-        **Returns without touching a socket.** `sendall` blocks, and this is
-        called from the pyglet main thread on `on_update`, so a subscriber
-        that stops reading used to freeze the replay window itself — not its
-        own view, the whole race. The span change made that far likelier by
-        enlarging the message: the measured time-to-freeze against a stalled
-        client fell from about 130 s to 0.7 s, and the product always opens
-        two subscribers.
+        Takes a factory rather than a dict, and that is the whole point. The
+        caller is the pyglet frame loop, and assembling a tick is not cheap:
+        measured on the real Melbourne 2025 replay, `_broadcast_if_due` cost
+        its caller 3.19 ms on a steady 8x tick and 5.41 ms on a seek, of which
+        the recursive `asdict` over the decision history is 2.48 ms and the
+        JSON encode 1.81 ms. Schema v2's twenty telemetry spans take the seek
+        tick to 32 ms, about two dropped frames at 60 FPS. Handing over a
+        closure moves all of it to the sender thread that already existed for
+        `sendall`, and leaves the frame loop paying one queue put.
 
-        The encode stays here, on the caller's thread: it is sub-millisecond,
-        it keeps wire order deterministic, and it keeps the "which field was
-        NaN" log next to the tick that produced it."""
+        **Returns without touching a socket, and without calling `build`.**
+
+        What supersede-drop discards is now the JOB rather than the bytes, one
+        stage earlier and with the same policy: each payload is a complete
+        snapshot, so a consumer that falls behind wants the newest and nothing
+        else. A tick that misses its slot is never built at all."""
         if not self._running:
             return
         with self._clients_lock:
             if not self._clients:
                 return
-        payload = _json_safe(data)
+        self._enqueue(build)
+
+    def _encode(self, build: Callable[[], dict]) -> bytes | None:
+        """Run one payload factory and encode the result, or say why not.
+
+        Both halves are guarded because both run on the sender daemon now, and
+        a daemon thread that raises dies silently: the replay window keeps
+        running, subscribers keep their sockets open, and nothing is ever sent
+        again. `_accept_loop` below carries the same lesson for the same
+        reason. That is why the factory's guard is deliberately broad, and why
+        it logs rather than passing: the payload is assembled from twenty
+        drivers' telemetry and five agents' dataclasses, so enumerating what it
+        can raise means enumerating all of that.
+        """
+        try:
+            data = build()
+        except Exception:
+            logger.exception("Broadcast dropped, the payload factory raised")
+            return None
         try:
             # allow_nan=False is what makes the "nothing non-finite reaches
             # the wire" promise above a mechanism rather than a claim. The
@@ -231,22 +264,27 @@ class TelemetryStreamServer:
             # Python's own parser reads it back, and JSON.parse rejects the
             # whole message. A web consumer would have lost every tick that
             # carried one model output it could not compute.
-            message = json.dumps(payload, separators=(",", ":"), allow_nan=False).encode() + b"\n"
+            payload = _json_safe(data)
+            return json.dumps(payload, separators=(",", ":"), allow_nan=False).encode() + b"\n"
         except (TypeError, ValueError) as exc:
             # Dropping the message is the point: an unparseable one is worse
             # than a missing one, and `seq` makes the hole visible. Blame the
             # ORIGINAL, not the sanitised copy: the copy cannot contain a
             # non-finite value by construction, so pointing the log at it
-            # would print nothing every time.
-            logger.warning("Broadcast dropped, payload not JSON-safe: %s | %s", exc, _blame(data))
-            return
+            # would print nothing every time. The seq goes in the line because
+            # the log no longer sits next to the tick that produced it.
+            logger.warning(
+                "Broadcast dropped, payload not JSON-safe: seq=%s %s | %s",
+                data.get("seq") if isinstance(data, dict) else None,
+                exc,
+                _blame(data),
+            )
+            return None
 
-        self._enqueue(message)
-
-    def _enqueue(self, message: bytes) -> None:
-        """Hand the message to the sender thread, discarding a stale one."""
+    def _enqueue(self, job: Callable[[], dict]) -> None:
+        """Hand the job to the sender thread, discarding a stale one."""
         try:
-            self._outbox.put_nowait(message)
+            self._outbox.put_nowait(job)
             return
         except queue.Full:
             pass
@@ -256,19 +294,27 @@ class TelemetryStreamServer:
             # The sender drained it between the two calls; nothing to discard.
             pass
         try:
-            self._outbox.put_nowait(message)
+            self._outbox.put_nowait(job)
         except queue.Full:
             # It refilled again, which means the sender is keeping up with a
             # newer payload than this one. Dropping this is the right outcome.
             logger.debug("Broadcast outbox full, dropping a superseded payload")
 
     def _send_loop(self) -> None:
-        """Drain the outbox onto the sockets, off the pyglet thread."""
+        """Build, encode and write, off the pyglet thread.
+
+        The build and the encode moved here from the caller in #1049; the
+        write has been here since `d24a59e1`. One thread does all three, in
+        wire order, so a payload cannot overtake an older one.
+        """
         while self._running:
             try:
-                message = self._outbox.get(timeout=0.5)
+                job = self._outbox.get(timeout=0.5)
             except queue.Empty:
                 continue  # the timeout is what lets `stop()` end this thread
+            message = self._encode(job)
+            if message is None:
+                continue  # `_encode` logged why; `seq` makes the hole visible
             dead: list[socket.socket] = []
             with self._clients_lock:
                 clients_snapshot = list(self._clients)

--- a/tests/surfaces/test_arcade_stream_server.py
+++ b/tests/surfaces/test_arcade_stream_server.py
@@ -1,15 +1,16 @@
 """The broadcast server must never block the caller (`src/arcade/stream.py`).
 
 `broadcast()` is called from the pyglet main thread on every due
-`on_update`. `sendall` blocks. A subscriber that stops reading therefore
-used to freeze the replay window itself, and the sprint's span change made
-that far likelier by enlarging the message: the measured time-to-freeze
-fell from about 130 s to 0.7 s, with the product always opening two
-subscribers.
+`on_update`, and it takes a FACTORY: the caller neither builds the payload
+nor encodes it nor sends it, because all three used to cost the frame loop
+milliseconds it does not have (#1049). `sendall` blocks too, which is why
+the write moved to the sender thread first.
 
-These tests pin the two properties that make that impossible: the caller
-returns promptly whatever the socket does, and a consumer that falls
-behind loses stale payloads rather than the newest one.
+These tests pin the properties that make a stall impossible: the caller
+returns promptly whatever the socket does AND without running the factory,
+a consumer that falls behind loses stale payloads rather than the newest
+one, and a factory that raises costs its own tick rather than the thread
+every later tick depends on.
 """
 
 from __future__ import annotations
@@ -54,7 +55,10 @@ def test_broadcast_returns_immediately_even_when_a_client_has_stalled():
         assert stalled.started.wait(timeout=2.0) or True  # let the sender pick one up
         started = time.perf_counter()
         for seq in range(20):
-            server.broadcast({"seq": seq})
+            # `seq=seq` is not decoration: the factory runs on another thread
+            # after this loop has finished, so a closure over the loop
+            # variable would encode 19 twenty times.
+            server.broadcast(lambda seq=seq: {"seq": seq})
         elapsed = time.perf_counter() - started
 
         # 20 ticks is two seconds of real playback; anything near the 5 s the
@@ -62,6 +66,68 @@ def test_broadcast_returns_immediately_even_when_a_client_has_stalled():
         assert elapsed < 0.5, f"broadcast blocked the caller for {elapsed:.2f}s"
     finally:
         stalled.close()
+        server._running = False
+
+
+def test_broadcast_does_not_BUILD_the_payload_on_the_caller_s_thread():
+    """The EFFECT #1049 is about, asserted on the thread the work ran on.
+
+    A test that only compared the bytes before and after would pass with the
+    build still inline, because moving work between threads does not change
+    what it produces. So the factory records who called it, and the assertion
+    is that it was not the caller.
+
+    The 3.19 ms a steady 8x tick used to cost the frame loop is the reason;
+    a seek tick under schema v2 is 32 ms, about two dropped frames at 60 FPS.
+    """
+    ran_on: list[int] = []
+    server = _server_with(type("C", (), {"sendall": lambda self, m: None})())
+    try:
+        caller = threading.get_ident()
+
+        def build() -> dict:
+            ran_on.append(threading.get_ident())
+            return {"seq": 1}
+
+        server.broadcast(build)
+        assert ran_on == [], "the factory ran before broadcast() returned"
+
+        deadline = time.time() + 5
+        while not ran_on and time.time() < deadline:
+            time.sleep(0.01)
+        assert ran_on, "the factory never ran at all"
+        assert ran_on[0] != caller, "the payload was still built on the caller's thread"
+    finally:
+        server._running = False
+
+
+def test_a_factory_that_raises_costs_its_tick_and_not_the_sender_thread():
+    """A daemon that dies is silent, and takes every later tick with it.
+
+    `_send_loop` is where the factory now runs, and it is the one body in this
+    module that had no guard: an exception there ends the only thread that
+    writes to a socket, while the replay window keeps running and every
+    subscriber keeps a connection that will never carry another byte.
+    `_accept_loop` already pays for this lesson.
+    """
+    sent: list[bytes] = []
+    server = _server_with(type("C", (), {"sendall": lambda self, m: sent.append(m)})())
+    try:
+
+        def explode() -> dict:
+            raise ValueError("a model output nobody guarded")
+
+        server.broadcast(explode)
+        time.sleep(0.3)
+        assert sent == [], "the raising tick must not reach a socket"
+
+        server.broadcast(lambda: {"seq": 2})
+        deadline = time.time() + 5
+        while not sent and time.time() < deadline:
+            time.sleep(0.01)
+        assert sent, "the sender thread died with the tick that raised"
+        assert json.loads(sent[0])["seq"] == 2
+    finally:
         server._running = False
 
 
@@ -82,7 +148,7 @@ def test_a_consumer_that_falls_behind_loses_the_STALE_payloads():
     server = _server_with(_SlowClient())
     try:
         for seq in range(50):
-            server.broadcast({"seq": seq})
+            server.broadcast(lambda seq=seq: {"seq": seq})
         gate.set()
         time.sleep(0.4)
 
@@ -100,7 +166,7 @@ def test_nothing_non_finite_reaches_a_socket():
     sent: list[bytes] = []
     server = _server_with(type("C", (), {"sendall": lambda self, m: sent.append(m)})())
     try:
-        server.broadcast({"seq": 1, "model": {"lap_time_s": float("nan")}})
+        server.broadcast(lambda: {"seq": 1, "model": {"lap_time_s": float("nan")}})
         time.sleep(0.3)
 
         assert sent, "a NaN must cost its field, not the whole message"
@@ -245,7 +311,7 @@ def test_a_pruned_subscriber_is_closed_so_it_can_notice_and_reconnect():
         payload = {"filler": "x" * 20000}
         deadline = time.time() + 15
         while server.client_count() > 0 and time.time() < deadline:
-            server.broadcast(payload)
+            server.broadcast(lambda: payload)
             time.sleep(0.02)
         assert server.client_count() == 0, "the server never pruned the stalled subscriber"
 

--- a/tests/surfaces/test_arcade_wire_contract.py
+++ b/tests/surfaces/test_arcade_wire_contract.py
@@ -159,7 +159,13 @@ def _view(session: SessionData, state: StrategyState, rival: str | None, clients
         _year=2025,
         _gaps=RaceGapCalculator(session),
         _color_for=lambda code: (255, 255, 255),
-        _stream_server=SimpleNamespace(client_count=lambda: clients, broadcast=_sent.append),
+        # `broadcast` takes a FACTORY since #1049, so the stub has to RUN it.
+        # `broadcast=_sent.append` would append the uncalled closure and every
+        # assertion below would shape a function instead of the payload.
+        _stream_server=SimpleNamespace(
+            client_count=lambda: clients,
+            broadcast=lambda build: _sent.append(build()),
+        ),
         _strategy_state=state,
         # `_broadcast_if_due` increments the tick then broadcasts when it
         # wraps to 0, so -1 makes the very next call due.
@@ -679,7 +685,7 @@ def _sent_bytes(payload: dict) -> list[bytes]:
     # the wire, because that is the thing under test.
     sender = threading.Thread(target=server._send_loop, daemon=True)
     sender.start()
-    server.broadcast(payload)
+    server.broadcast(lambda: payload)
     deadline = time.perf_counter() + 2.0
     while not written and time.perf_counter() < deadline:
         time.sleep(0.01)


### PR DESCRIPTION
## What

`broadcast()` takes a zero-argument factory instead of a dict. The sender thread that already existed for `sendall` runs it, encodes the result and writes it, so the pyglet frame loop is left with the throttle, the span bounds, the marker advance and the `seq` increment.

## Why

Time spent inside `_broadcast_if_due` by its caller, which is the pyglet thread. Measured on the real Melbourne 2025 replay through the real encode, with the full 30-entry history tail:

| tick | before | after |
|---|---|---|
| steady 8x | 3.187 ms | 0.003 ms |
| seek | 5.405 ms | 0.003 ms |

Where the 3.187 ms sat, with two spans on the wire: `snapshot_dict(30)` 2.48 ms, `_json_safe` plus `json.dumps` 0.44 ms, the arcade snapshot 0.19 ms. Moving only the encode would have saved 14 % of that row, and 35 % of the twenty-span row #1048 turns it into (1.81 of 5.12 ms), while leaving the largest item on the render thread in both. That is why the whole assembly moved rather than just the part #936 named.

*(Corrected after the exit gate: the 35 % figure originally sat under the two-span decomposition, where the encode is 0.44 ms. It belongs to the twenty-span row. The decision it justifies is unchanged, because `snapshot_dict` is the largest item in every row.)*

Under schema v2 (#1048) the same tick carries twenty telemetry spans instead of two, taking a seek to 32 ms, about two dropped frames at 60 FPS. That is why this lands first.

## How

- `src/arcade/stream.py`: `broadcast(build)` queues the callable; `_encode` runs it and encodes it; `_send_loop` calls `_encode` and writes. The outbox is `queue.Queue[Callable[[], dict]]`, same depth, same supersede-drop policy, one stage earlier: a tick that misses its slot is now never built at all.
- `src/arcade/app.py`: `_broadcast_if_due` reads `playback_speed`, `_is_paused`, `total_frames` and the seq into locals and closes over them. Reading them inside the closure would sample them whenever the sender got round to the job rather than when the tick happened.
- The factory call is guarded. `_send_loop` was the one body in the module without a guard, and a daemon that raises there dies silently: the replay window keeps running, subscribers keep sockets open, and nothing is ever sent again. `_accept_loop` already carries the same lesson eight lines away.

Also changed, found while measuring: `CLIENT_SEND_TIMEOUT_S`'s comment still said `sendall` runs on the pyglet main thread. That stopped being true in `d24a59e1`, which moved the write to `_send_loop`; the rewrite reached `broadcast`'s docstring and not the constant above it. The prune threshold is bytes buffered rather than seconds, and measured against a peer that never reads it falls from 1.26 s with two telemetry spans to 0.50 s with twenty.

## Out of scope

The eviction signals `rewound` and `dropped` ride on one tick, and both the supersede-drop and the host's single latest-payload slot can discard it before a window reads it. Pre-existing, unchanged here, tracked as #1060 and sequenced into R2 with #1050.

## Checks

- `tests/surfaces/` 271 passed, up from 269 by the two new guards.
- Both new guards driven RED first. Mutating `broadcast` to build inline makes the thread guard fail with the caller's own thread id in the list; removing the try/except around the factory makes the raising-factory guard fail with the sender thread dead (`PytestUnhandledThreadExceptionWarning`). The fix was restored from a copy and compared with `cmp`, not with `git checkout`.
- The real path: `scripts/dev_pitwall_producer.py` on the real Melbourne session with a socket client attached. 12 contiguous messages, `seq` 1 to 12, 211,314 bytes, 20 drivers on the wire, strategy block populated.
- Paced at 60 FPS for 6 s at 8x with the full tail, the sender keeps up completely: 32 of 32 due ticks reach the socket, worst caller time 0.136 ms.
- `ruff check` and `ruff format --check .` clean.

Closes #1049

