### PR TITLE
feat(arcade): publish a telemetry span per driver, schema v2

### DIFF
--- a/docs/pages/arcade-dashboard.md
+++ b/docs/pages/arcade-dashboard.md
@@ -145,7 +145,7 @@ Every one of these is additive — the Qt dashboard ignores them and is unaffect
 | `arcade.drivers.<code>.active` / `.rel_dist` / `.has_position` | on track, fraction of the current lap, and whether the car was ever placed at all |
 | `arcade.driver_colors` | per-driver RGB from the arcade's own palette, published so no consumer hardcodes a sixth copy of it |
 | `arcade.track_status` | FastF1 TrackStatus digits for the lap on screen |
-| `arcade.telemetry.main` / `.rival` | a **span** of samples since the last tick, oldest first — not one point. At 8x, one point per tick discarded 95 % of the trace |
+| `arcade.telemetry.drivers` | a **span** of samples since the last tick, oldest first, per driver code — not one point, and not just the pinned pair. At 8x, one point per tick discarded 95 % of the trace. Schema v2 replaced the role keys `main`/`rival` with the whole grid so a consumer can chart any car without asking the producer to publish it; read the old pair as `drivers[driver_main]` and `drivers[driver_rival]` |
 | `arcade.telemetry.rewound` / `.dropped` | the eviction signals: a backwards seek, and frames a forward jump could not carry |
 | `arcade.global_t_min` / `.location` | the session-time origin, and FastF1's authoritative Location for resolving the race directory |
 | `schema_version` / `seq` | the payload version, and a strictly increasing sequence per message SENT — which is what lets two consumers on independent timers agree on a frame |

--- a/documents/research/PITWALL_REALISM_AND_TELEMETRY_SURFACE.md
+++ b/documents/research/PITWALL_REALISM_AND_TELEMETRY_SURFACE.md
@@ -162,8 +162,17 @@ readings, `fuel_load`, and the in/out-lap pair live only in `get_driver_state`
 
 One SURFACE-level qualification, not a contract leak: in Head-to-Head mode the Arcade
 telemetry window renders the rival's throttle/brake/speed traces
-(`src/arcade/app.py:460-473` broadcasts `telemetry.rival` built by `_frame_to_telemetry`,
-`app.py:65-96`; rendered by the 2x2 grid in `src/arcade/dashboard/telemetry_panel.py:1-27`).
+(the producer broadcasts a rival span built by `_frame_to_telemetry`; the Qt 2x2 grid
+that rendered it was retired in `7ea6a7a6` and PITWALL's DATA window draws it now).
+
+**Schema v2 widened this and the conclusion is unchanged (#1048).** The tick used to
+carry a span for two cars and now carries one for all twenty, so the wire holds
+broadcast-tier telemetry for the whole grid rather than for a pinned pair. That does not
+move the boundary this section is about, because the boundary is the AGENTS' input space:
+the spans reach no model and no prompt, which the rival-selector feasibility gate verified
+by tracing every route from the chosen rival into `src/agents/`. What changed is how many
+cars a SURFACE may draw, and the tiering and labelling requirement in section 3.4 now
+applies to any of them rather than to one.
 Because FastF1 car telemetry IS the broadcast channel, this is broadcast-tier, not
 privileged, so it is defensible; but it is UNLABELED today, and the module docstring's
 own framing ("timing-screen only", `race_state_manager.py:8-9`) would not predict it.

--- a/documents/research/PITWALL_TRACES_SPACE_SPEC.md
+++ b/documents/research/PITWALL_TRACES_SPACE_SPEC.md
@@ -550,10 +550,10 @@ Constraint 7's table: every element reads a field already on the wire, or is pri
 
 | element | source | producer change |
 |---|---|---|
-| SPEED / THROTTLE / BRAKE lanes | `telemetry.main[] / .rival[]` `.speed/.throttle/.brake` | none |
+| SPEED / THROTTLE / BRAKE lanes | `telemetry.drivers[code][]` `.speed/.throttle/.brake` (was `.main[]`/`.rival[]` before schema v2, #1048) | none |
 | Δ TIME lane | computed from `.t` via `deltaSeries` (unchanged) | none |
-| **GEAR lane** | `telemetry.*[].gear` - on the wire since #841, read by nothing today | **none** |
-| **DRS lane** | NEW `telemetry.*[].drs_open` | **§5.2-bis, priced: 3 source files + 2 test files + bridge.ts, ~80 bytes/tick, no schema bump** |
+| **GEAR lane** | `telemetry.drivers[code][].gear` - on the wire since #841, read by nothing today | **none** |
+| **DRS lane** | NEW `telemetry.drivers[code][].drs_open` | **§5.2-bis, priced: 3 source files + 2 test files + bridge.ts, ~80 bytes/tick, no schema bump** |
 | cursor + readouts | `drivers[driver_main].rel_dist` x `circuit_length_m`; newest main-span sample | none |
 | lane colours | `palette.ACCENT` (gear, new site), `palette.INFO` (DRS, new site); rest existing | none (token-test counts move) |
 | BESTS depth | `bulk` (unchanged data); depth is client geometry | none |

--- a/src/arcade/app.py
+++ b/src/arcade/app.py
@@ -120,9 +120,16 @@ def _frames_to_telemetry_span(
 ) -> list[dict]:
     """Pack `frames[span_start : frame_idx + 1]` for the wire, oldest first.
 
-    Bounds are clamped to the array rather than trusted: a driver whose
-    telemetry is shorter than the global timeline would otherwise raise
-    at the end of the race.
+    Bounds are clamped rather than trusted, but not for the reason this
+    docstring used to give. `SessionLoader` resamples every driver onto the
+    one global timeline, so all twenty arrays are exactly `total_frames`
+    long: measured on Melbourne 2025, 154,173 for all of them, no exceptions.
+    Nothing here is ever "shorter than the timeline".
+
+    What the clamp actually guards is the CALLER's arithmetic. `span_start`
+    is `last_sent_idx + 1` and can sit past the end on the last tick of a
+    race, and `frame_idx` is a float clock truncated to an int; the empty
+    slice both produce is the honest answer, and a raise would not be.
     """
     if not frames:
         return []
@@ -751,35 +758,52 @@ class F1ArcadeView(arcade.View):
         main_frames = self._session.frames_by_driver.get(self._driver_main)
         if main_frames and frame_idx < len(main_frames):
             main_frame = main_frames[frame_idx]
-        # Telemetry for the main driver (always) + the rival when two-driver
-        # mode is active, published as {main: [...], rival: [...]} — a SPAN
-        # of samples, oldest first, not the single current point.
+        # A telemetry SPAN per driver, oldest first, not the single current
+        # point: `{drivers: {CODE: [...]}}`.
         #
         # The clock advances `delta_time * FPS * speed` indices per second
         # over 25 Hz data while the broadcast fires at ~10 Hz, so sending one
         # point per tick discarded 60 % of the trace at 1x and 95 % at 8x: a
         # speed trace went from a point every 8 metres to one every 170. The
         # producer already holds the whole array, so the span costs a slice
-        # and no disk read. In single-driver mode `rival` is an empty list
-        # and the delta chart collapses to its "single driver" placeholder.
+        # and no disk read.
+        #
+        # **Keyed off `drivers`, not off `frames_by_driver`** (#1048). It used
+        # to carry two spans under the ROLE keys `main` and `rival`, chosen
+        # once at launch, so a consumer could only ever chart those two cars.
+        # Publishing all twenty is what lets PITWALL pin any row without a
+        # control channel back to the producer, which is a decision this
+        # project does not want to take. Iterating the block built above
+        # rather than the session makes these keys identical to `drivers`,
+        # `driver_colors` and `race_order` by construction: four per-driver
+        # maps on one payload is already three chances to drift, and it does
+        # not need a fourth rule.
+        #
+        # **A retired car still carries a span**, because its frame array runs
+        # the full length of the race and the values simply stop changing. On
+        # Melbourne 2025 that is three lap-1 retirements, 14.5 % of a seek
+        # message. They stay: `active` and `has_position` are published beside
+        # them for exactly this, and a key set that came and went as cars
+        # retired would be a second rule again. **A consumer gates a span on
+        # `drivers[code].active` and `.has_position`** rather than on whether
+        # the span is empty.
         circuit_length = float(self._session.circuit_length_m or 0.0)
-        rival_frames = (
-            self._session.frames_by_driver.get(self._driver_rival) if self._driver_rival else None
-        )
         positions = self._session.has_position
-        main_has_position = bool(positions.get(self._driver_main, True))
-        rival_has_position = bool(positions.get(self._driver_rival, True))
         telemetry = {
-            # `has_position` rides along so the span says the same thing the
+            # `has_position` rides into each span so it says the same thing the
             # drivers block does. Without it the same car reads "no position"
             # in one half of the payload and "at the line" in the other, and
             # the telemetry window keys every sample into distance bucket 0.
-            "main": _frames_to_telemetry_span(
-                main_frames, span_start, frame_idx, circuit_length, main_has_position
-            ),
-            "rival": _frames_to_telemetry_span(
-                rival_frames, span_start, frame_idx, circuit_length, rival_has_position
-            ),
+            "drivers": {
+                code: _frames_to_telemetry_span(
+                    self._session.frames_by_driver[code],
+                    span_start,
+                    frame_idx,
+                    circuit_length,
+                    bool(positions.get(code, True)),
+                )
+                for code in drivers
+            },
             # True when the user seeked backwards. The span is empty and the
             # consumer must drop what it has: a buffer keyed on
             # distance-within-lap holds samples for track the car has not

--- a/src/arcade/config.py
+++ b/src/arcade/config.py
@@ -186,7 +186,13 @@ POOL_SIZE: Final[int] = 1
 # renamed, removed, or changes meaning; adding a key an old consumer can
 # ignore does not need a bump. A consumer that reads a version it does not
 # know should say so rather than silently render a field it guessed at.
-STREAM_SCHEMA_VERSION: Final[int] = 1
+#
+# 2 (#1048): the telemetry block went from two role-keyed spans,
+# `{main: [...], rival: [...]}`, to one span per driver under
+# `{drivers: {CODE: [...]}}`. `rewound` and `dropped` stay where they were:
+# they describe the tick, not a car. Read the pair a v1 consumer wanted as
+# `telemetry.drivers[arcade.driver_main]` and `[arcade.driver_rival]`.
+STREAM_SCHEMA_VERSION: Final[int] = 2
 STREAM_HOST: Final[str] = os.environ.get("F1_STREAM_HOST", "127.0.0.1")
 STREAM_PORT: Final[int] = int(os.environ.get("F1_STREAM_PORT", "9998"))
 # Broadcast every N arcade frames. At 60 FPS on_update, N=6 gives ~10 Hz,

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -88,6 +88,20 @@ function driver(overrides = {}) {
   };
 }
 
+/**
+ * Which span a fixture driver carries: the main's, the rival's, or none.
+ *
+ * The real producer sends a real span for every car including retirements,
+ * which keep a full-length frame array and simply stop moving. The fixture
+ * leaves the rest of the field empty because no scenario here asserts on a
+ * third car's trace; a scenario that starts to will have to fill it.
+ */
+function spanFor(code, rival, main, rivalSpan) {
+  if (code === "NOR") return main;
+  if (code === rival) return rivalSpan;
+  return [];
+}
+
 function tick(
   seq,
   {
@@ -130,7 +144,20 @@ function tick(
       // render as unknown rather than as a green track.
       track_status_label: "GREEN",
       track_status_color: [16, 185, 129],
-      telemetry: { main, rival: rivalSpan, rewound, dropped },
+      // Schema v2 keys the spans by driver code, exactly like the `drivers`
+      // block above (#1048). The harness still takes `main` and `rivalSpan`,
+      // because that is what a DATA scenario is about, and files them under
+      // the codes the window looks them up by.
+      telemetry: {
+        drivers: Object.fromEntries(
+          Object.keys(field).map((code) => [
+            code,
+            spanFor(code, rival, main, rivalSpan),
+          ]),
+        ),
+        rewound,
+        dropped,
+      },
     },
     playback: {
       speed: 1,

--- a/src/pitwall/ui/src/features/data/useTraceFrame.ts
+++ b/src/pitwall/ui/src/features/data/useTraceFrame.ts
@@ -40,12 +40,25 @@ export function useTraceFrame(tick: Tick | null, discontinuity: Discontinuity): 
   // reason.
   return useMemo(() => {
     if (!tick) return null;
-    const { telemetry } = tick.arcade;
+    const { telemetry, driver_main, driver_rival } = tick.arcade;
     // The producer's own eviction signals, plus the clock's - `FrameClock` sees a
     // backwards jump smaller than one broadcast that the flags miss.
     const evict =
       telemetry.rewound || telemetry.dropped > 0 || discontinuity.kind !== "continuous";
-    accumulator.current.ingest(telemetry.main, telemetry.rival, evict);
+    // Schema v2 puts a span under every driver code, so the pair this panel
+    // charts is a LOOKUP rather than two fixed keys (#1048). `?? []` is not
+    // defensive padding: single-driver mode has no rival at all, and the
+    // accumulator's rival map is meant to stay empty then.
+    //
+    // Selecting here rather than accumulating per driver is deliberate for
+    // now: switching the pinned car mid-lap would mix two cars' samples in one
+    // distance-keyed map, and the fix for that is per-driver buffers with the
+    // choice applied at render (#1050), which is R2's subject.
+    accumulator.current.ingest(
+      telemetry.drivers[driver_main] ?? [],
+      driver_rival ? (telemetry.drivers[driver_rival] ?? []) : [],
+      evict,
+    );
     const main = accumulator.current.mainTrace;
     const rival = accumulator.current.rivalTrace;
     return { main, rival, delta: deltaSeries(main, rival) };

--- a/src/pitwall/ui/src/lib/bridge.ts
+++ b/src/pitwall/ui/src/lib/bridge.ts
@@ -91,9 +91,24 @@ export interface ArcadeState {
   /** The label's RGB, from the arcade's own palette. Null exactly when the label is. */
   track_status_color: [number, number, number] | null;
   telemetry: {
-    /** Every sample the replay clock crossed since the previous tick, oldest first. */
-    main: TelemetrySample[];
-    rival: TelemetrySample[];
+    /**
+     * Every sample the replay clock crossed since the previous tick, oldest
+     * first, keyed by driver code (schema v2, #1048).
+     *
+     * The pair a v1 consumer read as `main`/`rival` is
+     * `drivers[driver_main]` and `drivers[driver_rival]`. It carries the whole
+     * grid rather than those two so a client can chart any car without asking
+     * the producer to publish it, which would need a control channel PITWALL
+     * deliberately does not have.
+     *
+     * **The key set is the same as `drivers`, `driver_colors` and
+     * `race_order`**, so a car present in one is present in all four. That
+     * includes RETIRED cars: a retirement keeps its full-length frame array
+     * and simply stops moving, so its span is real samples of a stationary
+     * car, not an empty list. **Gate a span on `drivers[code].active` and
+     * `.has_position`**, never on whether it has samples.
+     */
+    drivers: Record<string, TelemetrySample[]>;
     /** The user seeked backwards: drop what you have, do not append. */
     rewound: boolean;
     /** Frames a forward jump could not carry. Non-zero means a hole in the trace. */

--- a/tests/surfaces/test_arcade_broadcast_wire.py
+++ b/tests/surfaces/test_arcade_broadcast_wire.py
@@ -226,13 +226,15 @@ def test_a_car_with_no_position_data_is_unknown_rather_than_at_the_line():
 
     assert wire["drivers"]["HAD"]["rel_dist"] is None
     assert wire["drivers"][MAIN]["rel_dist"] is not None
-    # The two-car telemetry block takes the same route, so it must agree.
-    # It did not: `has_position` was read for the drivers block only, so the
-    # same car read "no position" in one half of the payload and sat in
-    # distance bucket 0 in the other.
-    telemetry = _snapshot(_session(), frame_idx=3, rival="HAD")["telemetry"]
-    assert telemetry["rival"][0]["dist"] is None
-    assert telemetry["main"][0]["dist"] is not None
+    # The telemetry block takes the same route, so it must agree. It did not:
+    # `has_position` was read for the drivers block only, so the same car read
+    # "no position" in one half of the payload and sat in distance bucket 0 in
+    # the other. Since #1048 the block carries a span per driver, so the read
+    # has to be right for every car rather than for the two that were pinned,
+    # and HAD is asserted here WITHOUT being the rival.
+    spans = _snapshot(_session(), frame_idx=3)["telemetry"]["drivers"]
+    assert spans["HAD"][0]["dist"] is None
+    assert spans[MAIN][0]["dist"] is not None
 
 
 def test_the_arcade_block_carries_nothing_non_finite():

--- a/tests/surfaces/test_arcade_telemetry_span.py
+++ b/tests/surfaces/test_arcade_telemetry_span.py
@@ -269,19 +269,26 @@ def test_the_snapshot_publishes_spans_and_the_rewind_flag():
     )
 
     moving = F1ArcadeView._build_arcade_snapshot(view, 20, 16, False)["telemetry"]
-    assert len(moving["main"]) == 5
-    assert len(moving["rival"]) == 5
+    assert len(moving["drivers"]["NOR"]) == 5
+    assert len(moving["drivers"]["PIA"]) == 5
     assert moving["rewound"] is False
 
     paused = F1ArcadeView._build_arcade_snapshot(view, 20, 21, False)["telemetry"]
-    assert paused["main"] == [] and paused["rival"] == []
+    assert paused["drivers"]["NOR"] == [] and paused["drivers"]["PIA"] == []
 
     rewound = F1ArcadeView._build_arcade_snapshot(view, 20, 21, True)["telemetry"]
-    assert rewound["main"] == []
+    assert rewound["drivers"]["NOR"] == []
     assert rewound["rewound"] is True
 
 
-def test_single_driver_mode_publishes_an_empty_rival_span():
+def test_single_driver_mode_still_publishes_every_car_the_session_has():
+    """No rival pinned is a choice about what to CHART, not about what to send.
+
+    Before #1048 the wire carried two role-keyed spans, so this case had an
+    empty `rival` list. With a span per driver there is no role to leave
+    empty: the block carries whatever cars the session holds, and `driver_rival`
+    being null is the only thing that says nobody is pinned.
+    """
     session = SessionData(
         gp_name="Australia",
         location="Melbourne",
@@ -299,14 +306,203 @@ def test_single_driver_mode_publishes_an_empty_rival_span():
         _color_for=lambda code: (255, 255, 255),
     )
 
-    telemetry = F1ArcadeView._build_arcade_snapshot(view, 20, 16, False)["telemetry"]
+    snapshot = F1ArcadeView._build_arcade_snapshot(view, 20, 16, False)
 
-    assert telemetry["rival"] == []
-    assert len(telemetry["main"]) == 5
+    assert snapshot["driver_rival"] is None
+    assert set(snapshot["telemetry"]["drivers"]) == {"NOR"}
+    assert len(snapshot["telemetry"]["drivers"]["NOR"]) == 5
 
 
-def test_the_payload_growth_stays_small_at_the_fastest_speed():
-    """Two drivers carry traces, so 8x costs about 20 samples a tick, not 200."""
+_GRID = ("NOR", "PIA", "VER", "LEC")
+
+
+def _sweep_the_served_spans(speeds_and_ticks, seek_at: int | None = None):
+    """Drive the real snapshot builder and return the frames each driver got.
+
+    #841's acceptance is "every frame the clock crosses is sent exactly once",
+    and until #1048 it could be checked on the bounds arithmetic alone,
+    because the bounds were the whole story for a pair of role keys. With a
+    span per driver the question is per driver, so this reads the SERVED
+    payload instead: every sample carries `t`, and `t` is `frame_index * DT`,
+    so the index is recoverable from the wire itself rather than from the
+    arithmetic that was supposed to produce it.
+
+    Returns `(sent_by_driver, dropped_total)`.
+    """
+    session = SessionData(
+        gp_name="Australia",
+        location="Melbourne",
+        year=2025,
+        frames_by_driver={code: _frames(4000) for code in _GRID},
+        circuit_length_m=CIRCUIT_LENGTH_M,
+        total_frames=4000,
+    )
+    view = SimpleNamespace(
+        _session=session,
+        _driver_main="NOR",
+        _driver_rival="PIA",
+        _year=2025,
+        _gaps=RaceGapCalculator(session),
+        _color_for=lambda code: (255, 255, 255),
+    )
+
+    sent: dict[str, list[int]] = {code: [] for code in _GRID}
+    dropped_total = 0
+    frame_index = 0.0
+    last_sent = -1
+    tick = 0
+    for speed, n_ticks in speeds_and_ticks:
+        for _ in range(n_ticks):
+            frame_index += TICK_SECONDS * FPS * speed
+            if seek_at is not None and tick == seek_at:
+                frame_index += 2000  # a progress-bar click, past the span cap
+            tick += 1
+            frame_idx = int(frame_index)
+            span_start, rewound, dropped = _telemetry_span_bounds(
+                last_sent, frame_idx, STREAM_MAX_SPAN_FRAMES
+            )
+            last_sent = frame_idx
+            dropped_total += dropped
+            spans = F1ArcadeView._build_arcade_snapshot(
+                view, frame_idx, span_start, rewound, dropped
+            )["telemetry"]["drivers"]
+            for code, samples in spans.items():
+                sent[code].extend(round(sample["t"] / DT) for sample in samples)
+    return sent, dropped_total
+
+
+def test_every_frame_the_clock_crosses_reaches_EVERY_driver_exactly_once():
+    """#841's acceptance, re-stated per driver now that there are twenty.
+
+    The old formulation was a property of `_telemetry_span_bounds`, which
+    every span shares. That is still true and still tested above, but it is
+    no longer sufficient: the bounds can be perfect while the per-driver
+    slice that consumes them drops a car, repeats a sample, or hands one
+    driver another's frames. This asserts on what the payload actually
+    carried, at 1x, 2x and 8x in sequence, and requires the four drivers to
+    have received exactly the same frames.
+    """
+    sent, dropped = _sweep_the_served_spans([(1.0, 30), (2.0, 30), (8.0, 30)])
+
+    assert dropped == 0, "smooth playback must never reach the span cap"
+    reference = sent["NOR"]
+    assert reference, "the sweep sent nothing at all"
+    assert reference == sorted(reference), "samples must arrive oldest first"
+    assert len(reference) == len(set(reference)), "a sample was sent twice"
+    assert reference == list(range(reference[0], reference[-1] + 1)), "a frame was skipped"
+    for code in _GRID:
+        assert sent[code] == reference, f"{code} did not get the same frames as NOR"
+
+
+def test_a_seek_is_capped_and_counted_for_every_driver_alike():
+    """A progress-bar click outruns the span, and every car must say so once.
+
+    The hole is reported by `dropped` rather than by the samples, so the
+    assertion is that the count is non-zero, that no driver silently spliced
+    across it, and that the twenty spans agree about where the hole is.
+    """
+    sent, dropped = _sweep_the_served_spans([(1.0, 20), (8.0, 20)], seek_at=10)
+
+    assert dropped > 0, "the seek did not outrun the span cap"
+    reference = sent["NOR"]
+    assert len(reference) == len(set(reference)), "a sample was sent twice across the seek"
+    assert reference == sorted(reference)
+    for code in _GRID:
+        assert sent[code] == reference, f"{code} disagrees about the seek"
+
+
+def test_the_per_driver_sweep_actually_bites_on_a_planted_duplicate(monkeypatch):
+    """The sweep above passes; this is the proof it can fail.
+
+    A continuity check that has never been seen red closes nothing. The
+    mutation is the cheapest real defect the per-driver slice could have: one
+    car's span re-sending its first sample. It lands on LEC, which is exactly
+    why the sweep compares the drivers against EACH OTHER: LEC's own list is
+    still sorted and still starts and ends where it should, so a per-driver
+    check that only looked at one car at a time would stay green.
+
+    The sweep runs outside any `raises` block on purpose. Wrapping it would
+    let an unrelated error inside it satisfy the test, which is the shape of
+    a guard that passes for the wrong reason.
+    """
+    import src.arcade.app as app_module
+
+    real = app_module._frames_to_telemetry_span
+    calls = {"n": 0}
+
+    def duplicating(frames, span_start, frame_idx, circuit_length_m, has_position=True):
+        packed = real(frames, span_start, frame_idx, circuit_length_m, has_position)
+        calls["n"] += 1
+        # Every fourth call is one driver's span, so exactly one car repeats.
+        if packed and calls["n"] % len(_GRID) == 0:
+            return [packed[0], *packed]
+        return packed
+
+    monkeypatch.setattr(app_module, "_frames_to_telemetry_span", duplicating)
+    sent, _ = _sweep_the_served_spans([(1.0, 10)])
+
+    reference = sent["NOR"]
+    assert len(reference) == len(set(reference)), "the mutation was supposed to spare NOR"
+    corrupted = [code for code in _GRID if sent[code] != reference]
+    assert corrupted == ["LEC"], f"the planted duplicate landed on {corrupted}, not on one car"
+    assert len(sent["LEC"]) != len(set(sent["LEC"])), "the plant did not actually duplicate"
+
+
+def test_the_span_key_set_does_not_depend_on_who_the_rival_is():
+    """The claim #1048 exists to make true, asserted over every choice of rival.
+
+    A client can only pin a row it has samples for, so the failure this
+    forbids is the one the old wire had by design: a car the producer happens
+    not to have chosen carrying nothing. Sweeping every rival (and none) is
+    what separates "the spans are published per driver" from "the spans still
+    follow the pick, and the fixture happened to pin the car we asserted on".
+
+    The key set is also checked against the three OTHER per-driver maps on the
+    payload. Four maps keyed four ways is three chances to drift; the producer
+    builds all four from one dict so that they cannot.
+    """
+    session = SessionData(
+        gp_name="Australia",
+        location="Melbourne",
+        year=2025,
+        frames_by_driver={"NOR": _frames(50), "PIA": _frames(50), "VER": _frames(50)},
+        circuit_length_m=CIRCUIT_LENGTH_M,
+        total_frames=50,
+    )
+    grid = {"NOR", "PIA", "VER"}
+
+    for rival in (None, "PIA", "VER", "NOR"):
+        view = SimpleNamespace(
+            _session=session,
+            _driver_main="NOR",
+            _driver_rival=rival,
+            _year=2025,
+            _gaps=RaceGapCalculator(session),
+            _color_for=lambda code: (255, 255, 255),
+        )
+        snapshot = F1ArcadeView._build_arcade_snapshot(view, 20, 16, False)
+        spans = snapshot["telemetry"]["drivers"]
+
+        assert set(spans) == grid, f"rival={rival} changed which cars carry a span"
+        assert all(len(samples) == 5 for samples in spans.values()), (
+            f"rival={rival} left a car on the grid without samples"
+        )
+        assert set(snapshot["drivers"]) == grid
+        assert set(snapshot["driver_colors"]) == grid
+        assert set(snapshot["race_order"]) == grid
+
+
+def test_the_span_length_stays_bounded_at_the_fastest_speed():
+    """A span is about 20 samples a tick at 8x, not 200, whoever carries it.
+
+    This bounds the span LENGTH, which is what the clock decides. Since #1048
+    the tick carries one per driver, so the block costs twenty of these rather
+    than two: measured on the real Melbourne 2025 replay, a steady 8x tick
+    goes from 20,795 to 61,374 bytes and a full-tail one from 37,852 to
+    78,513, which is 767 KB/s at 10 Hz. The cost that bound the change was
+    never the bytes, it was the encode, and that moved off the render thread
+    in #1049.
+    """
     frames_per_tick = TICK_SECONDS * FPS * max(PLAYBACK_SPEEDS)
 
     assert math.ceil(frames_per_tick) <= 25

--- a/tests/surfaces/test_arcade_wire_contract.py
+++ b/tests/surfaces/test_arcade_wire_contract.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import ast
 import json
+import re
 from functools import partial
 from pathlib import Path
 from types import SimpleNamespace
@@ -41,6 +42,21 @@ from src.arcade.strategy import (  # noqa: E402
 )
 
 CIRCUIT_LENGTH_M = 5278.0
+
+# One telemetry sample's frozen types. Named rather than written out once per
+# driver: v2 puts a span under every code on the grid, and twenty copies of a
+# nine-key literal is twenty chances for one of them to drift.
+_TELEMETRY_SAMPLE_SHAPE = {
+    "brake": "float",
+    "dist": "float",
+    "drs": "int",
+    "drs_open": "bool",
+    "gear": "int",
+    "lap": "int",
+    "speed": "float",
+    "t": "float",
+    "throttle": "float",
+}
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -264,34 +280,18 @@ GOLDEN_SHAPE = {
         "race_order": ["str"],
         "t": "float",
         "telemetry": {
-            "main": [
-                {
-                    "brake": "float",
-                    "dist": "float",
-                    "drs": "int",
-                    "drs_open": "bool",
-                    "gear": "int",
-                    "lap": "int",
-                    "speed": "float",
-                    "t": "float",
-                    "throttle": "float",
-                }
-            ],
+            # One span per driver since schema v2 (#1048), keyed exactly like
+            # the `drivers` block above, `driver_colors` and `race_order`. The
+            # fixture carries two cars, so two keys; what is pinned is that
+            # BOTH appear regardless of which one is the rival, which is the
+            # whole point of the change and is asserted directly in
+            # `test_the_span_key_set_does_not_depend_on_who_the_rival_is`.
+            "drivers": {
+                "NOR": [_TELEMETRY_SAMPLE_SHAPE],
+                "PIA": [_TELEMETRY_SAMPLE_SHAPE],
+            },
             "dropped": "int",
             "rewound": "bool",
-            "rival": [
-                {
-                    "brake": "float",
-                    "dist": "float",
-                    "drs": "int",
-                    "drs_open": "bool",
-                    "gear": "int",
-                    "lap": "int",
-                    "speed": "float",
-                    "t": "float",
-                    "throttle": "float",
-                }
-            ],
         },
         "total_laps": "int",
         "track_status": "str",
@@ -436,7 +436,11 @@ def _minimal_payload() -> dict:
 # type generated from the rich shape alone would get wrong.
 GOLDEN_MINIMAL_DIFFS = {
     "arcade.driver_rival": "NoneType",
-    "arcade.telemetry.rival": [],
+    # `arcade.telemetry.rival: []` used to sit here, and its absence is the
+    # point of #1048: with a span per driver the telemetry block is identical
+    # whether or not a rival is pinned, because the key set is the grid rather
+    # than a pair of roles. If a telemetry entry ever reappears in this dict,
+    # the spans have started depending on the rival again.
     "strategy.start": "NoneType",
     "strategy.latest": "NoneType",
     "strategy.history_tail": [],
@@ -491,6 +495,30 @@ def test_the_states_that_make_a_field_null_are_frozen_too():
 
 def test_the_payload_carries_the_schema_version():
     assert _payload()["schema_version"] == STREAM_SCHEMA_VERSION
+
+
+def test_the_smoke_harness_declares_the_schema_version_the_producer_emits():
+    """The DATA smoke fabricates ticks, and it had drifted ahead of the wire.
+
+    `src/pitwall/ui/scripts/smoke-data.mjs` is the only other thing in this
+    repo that builds a whole tick, and its 233 checks are what the DATA window
+    is developed against. It carried a hardcoded `schema_version: 2` for
+    twelve days while this constant was still 1, which the #1048 bump makes
+    accidentally correct. Nothing tied the two together, so the next bump
+    would drift the same way and the harness would go on describing a payload
+    the producer stopped sending.
+
+    Read as text rather than executed: the harness is an ES module driven by
+    a browser bundle, and this suite has no Node in it.
+    """
+    harness = (REPO_ROOT / "src/pitwall/ui/scripts/smoke-data.mjs").read_text(encoding="utf-8")
+    declared = re.findall(r"schema_version:\s*(\d+)", harness)
+
+    assert declared, "the smoke harness stopped declaring a schema version at all"
+    assert set(declared) == {str(STREAM_SCHEMA_VERSION)}, (
+        f"smoke-data.mjs declares schema_version {sorted(set(declared))}, "
+        f"the producer emits {STREAM_SCHEMA_VERSION}"
+    )
 
 
 # --- the per_agent contract, against the producer rather than against itself -


### PR DESCRIPTION
## What

The tick carried two telemetry spans under the role keys `main` and `rival`. It now carries one per driver under `telemetry.drivers`, keyed by code. `STREAM_SCHEMA_VERSION` goes to 2.

```
v1  telemetry: { main: [...], rival: [...], rewound, dropped }
v2  telemetry: { drivers: { "NOR": [...], ... }, rewound, dropped }
```

The pair a v1 consumer read is `drivers[driver_main]` and `drivers[driver_rival]`. `rewound` and `dropped` stay at block level: they describe the tick, not a car.

## Why

Which car was the rival was chosen once at launch (`app.py:236`, the only assignment) and could not change during a run, so PITWALL could only ever chart those two. Publishing the grid is what lets a client pin any row without a control channel back to the producer, which is the thing this project decided not to build.

## How

The key set is the `drivers` block already built two screens up, not `session.frames_by_driver`. That makes `telemetry.drivers`, `drivers`, `driver_colors` and `race_order` one rule instead of four maps keyed four ways, by construction rather than by measurement.

It also retires a seam the design assumed was real. `drivers` skips a car with `frame_idx >= len(frames)` while `_frames_to_telemetry_span` clamps, so in principle a car whose array ends mid-span is in one block and not the other. Measured on Melbourne 2025: all twenty arrays are exactly 154,173 frames, the session total, so it never happens. The span helper's docstring claimed that mechanism and has been corrected to say what the clamp actually guards.

**A retired car still carries a span.** Its frame array runs the full length of the race and the values stop changing, so SAI, DOO and HAD send five real samples of a stationary car per tick, 14.5 % of a seek message. They stay: a key set that came and went as cars retired would be a second rule again, and `active` and `has_position` are on the wire for exactly this. The consumer contract is now written down in `bridge.ts` and in the producer: gate a span on `drivers[code].active` and `.has_position`, never on whether it is empty.

Client side is the mechanical migration only. `useTraceFrame` looks the pinned pair up instead of reading two fixed keys; per-driver accumulation and the mid-lap switch semantics are #1050, in R2.

## Cost

Measured on the real Melbourne 2025 replay through the real encode:

| population | 2-span | 20-span | ratio | KB/s at 10 Hz |
|---|---|---|---|---|
| 1x, short tail | 16,967 B | 23,177 B | 1.37x | 226 |
| 2x, short tail | 17,418 B | 27,677 B | 1.59x | 270 |
| 8x, short tail | 20,795 B | 61,374 B | 2.95x | 599 |
| 8x, full 30-entry tail | 37,852 B | 78,513 B | 2.07x | 767 |
| seek tick (span cap 250) | 72,773 B | 578,824 B | 7.95x | one-shot |

The span length is `FPS x speed / 10 Hz`, so the multiplier moves with playback speed rather than being the constant #936 quoted. The binding cost was never the bytes, it was the render-thread encode, and that moved off the pyglet thread in #1049 which landed first.

## Out of scope

- Per-driver trace accumulation and what a mid-lap rival switch means: #1050, R2.
- The tower row becoming a pin control: #1051, R2, after #981.
- The eviction signals surviving a discarded tick: #1060, R2.
- `documents/audits/GATE_PITWALL_ARCH_A.md` and the `_qt_legacy` diagram still name the old shape. Both are dated records of a past state rather than pages teaching the current one, so they are left as written.

## Checks

- `tests/surfaces/` 276 passed, from 269 on `dev` before this sprint.
- The three frozen contract tests were driven RED by the change itself: five failures across `test_arcade_wire_contract.py`, `test_arcade_telemetry_span.py` and `test_arcade_broadcast_wire.py`, then migrated. `GOLDEN_MINIMAL_DIFFS` loses its `arcade.telemetry.rival` entry, and that absence is the assertion: the block is identical whether or not a rival is pinned.
- New guards: the key set swept over every choice of rival including none and checked against the three other per-driver maps; #841's acceptance re-stated per driver against the SERVED payload rather than the bounds arithmetic, at 1x, 2x and 8x plus a seek; and a probe that plants a duplicate in one car's span, which lands on LEC and is caught by the cross-driver comparison rather than by LEC's own list, so it proves that comparison is doing the work.
- `smoke-data.mjs` migrated and shown to bite: mutating the fixture so the main span never lands under its v2 key fails 4 trace assertions. Restored from a copy and compared with `cmp`. 233 checks, `smoke-agents` 65.
- `smoke-data.mjs` had declared `schema_version: 2` for twelve days while the constant was 1. A guard now reads the literal out of the harness and compares it with `STREAM_SCHEMA_VERSION`; driven red by bumping the constant to 3.
- The real path: `scripts/dev_pitwall_producer.py` on the real Melbourne session with a socket client attached. 12 contiguous messages, `schema_version` 2, 20 spans of 5 samples, the four per-driver key sets identical, and SAI, DOO and HAD each carrying 5 samples while inactive. 335,019 bytes against 211,314 at v1 over the same 12 ticks, which is the 1.59x the table predicts at the 2x the dev producer hardcodes.
- The DATA window rendered from 25 of those real ticks through the built bundle: six trace panels drawing both cars, the delta lane populated, the tower listing 20 with the three retirements as OUT, the ring placing all 20. No console errors.
- `ruff check` and `ruff format --check .` clean, `tsc --noEmit` clean, `npm run build` 0 TS errors.

Closes #1048
