### PR TITLE
feat(arcade): settle the wire's field set under schema v2

### DIFF
--- a/docs/pages/arcade-dashboard.md
+++ b/docs/pages/arcade-dashboard.md
@@ -94,7 +94,9 @@ The 2x2 grid of telemetry plots. Lives in its own module so `TelemetryWindow` ca
 
 ## Wire protocol
 
-The arcade broadcasts one JSON dict per frame, roughly 10 Hz, as a newline-terminated payload. The shape below is the shape the **Qt** dashboard consumes; the wire has since grown the fields PITWALL needs, listed after it.
+The arcade broadcasts one JSON dict per frame, roughly 10 Hz, as a newline-terminated payload.
+
+**The JSON below is a historical example and no longer describes the wire.** It is the shape the Qt dashboard consumed before that dashboard was retired in `7ea6a7a6`: a single telemetry sample per car under the role keys `main` and `rival`, plus `session`, `driver`, `driver2` and `delta_s` keys the producer does not emit. The current contract is the table under it, and the frozen shape lives in `tests/surfaces/test_arcade_wire_contract.py`.
 
 ```json
 {

--- a/documents/dev_docs/diagrams/tcp_broadcast_dataflow.drawio
+++ b/documents/dev_docs/diagrams/tcp_broadcast_dataflow.drawio
@@ -90,7 +90,7 @@
         <mxCell id="dash-subs" value="Strategy Dashboard &#8212; MainWindow (QMainWindow)&#10;TelemetryStreamClient (QThread)&#10;socket.recv() &#8594; split by \n &#8594; pyqtSignal(dict)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1A2138;strokeColor=#F59E0B;fontColor=#E6E8EF;fontSize=11;fontStyle=1;strokeWidth=2;" vertex="1" parent="1">
           <mxGeometry x="140" y="640" width="560" height="100" as="geometry"/>
         </mxCell>
-        <mxCell id="tel-subs" value="Live Telemetry &#8212; TelemetryWindow (QMainWindow)&#10;TelemetryStreamClient (QThread) &#8212; separate socket connection&#10;consumes only arcade.telemetry.{main, rival}" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1A2138;strokeColor=#06B6D4;fontColor=#E6E8EF;fontSize=11;fontStyle=1;strokeWidth=2;" vertex="1" parent="1">
+        <mxCell id="tel-subs" value="RETIRED (7ea6a7a6) &#8212; Qt TelemetryWindow (QMainWindow)&#10;TelemetryStreamClient (QThread) &#8212; separate socket connection&#10;consumed arcade.telemetry.{main, rival}, the shape schema v2 replaced&#10;with a span per driver under arcade.telemetry.drivers" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1A2138;strokeColor=#06B6D4;fontColor=#E6E8EF;fontSize=11;fontStyle=1;strokeWidth=2;" vertex="1" parent="1">
           <mxGeometry x="740" y="640" width="560" height="100" as="geometry"/>
         </mxCell>
 

--- a/documents/research/ECOSYSTEM_DATA_CONTRACTS.md
+++ b/documents/research/ECOSYSTEM_DATA_CONTRACTS.md
@@ -182,8 +182,8 @@ final `error` with `lap=0` instead of crashing the response.
 
 | Event `type` | Payload model (simulator.py) | Fields |
 |---|---|---|
-| `start` | `StartEvent` (line 89) | `gp, year, driver, driver2?, team, lap_start, lap_end, total_laps, no_llm, provider, timestamp` (total_laps authoritative; lap_start/end = effective window) |
-| `lap` | `LapDecision` (line 110) | `lap_number, compound, tyre_life, position, lap_time_s?, gap_ahead_s, action, confidence, reasoning, scenario_scores: dict[str,float], pace_mode?, risk_posture?, pit_lap_target?, compound_next?, undercut_target?, agent_alerts: list[str], guardrail_reason?` |
+| `start` | `StartEvent` (line 89) | `gp, year, driver, team, lap_start, lap_end, total_laps, no_llm, provider, timestamp` (`driver2?` removed by `F1_Telemetry_Manager#219`: it reached the stream and no consumer read it) (total_laps authoritative; lap_start/end = effective window) |
+| `lap` | `LapDecision` (line 110) | `lap_number, compound, tyre_life, position, lap_time_s?, gap_ahead_s, action, confidence, reasoning, scenario_scores: dict[str,float], pace_mode?, risk_posture?, pit_lap_target?, compound_next?, undercut_target?, guardrail_reason?` (`agent_alerts` removed by `F1_Telemetry_Manager#219`: it was a lossy copy of `per_agent.radio.alerts` for a retired Qt dashboard) |
 | `error` | `ErrorEvent` (line 140) | `lap, message` (stream continues; consumer renders a partial race) |
 | `summary` | `RunSummary` (line 151) | `status, positions, actions, agents_fired, stint, timing, gap_ahead, mc_confidence_series: list[float], best_decision, worst_decision, time_compression: float, reasoning_tokens: dict[str,int]` |
 

--- a/scripts/dev_pitwall_producer.py
+++ b/scripts/dev_pitwall_producer.py
@@ -79,7 +79,19 @@ def decision(lap: int, action: str, confidence: float) -> LapDecisionDTO:
         pit_lap_target=lap + 1,
         compound_next="HARD",
         undercut_target="RUS",
-        agent_alerts=["tyre cliff in 2 laps", "DRS window opens on the main straight"],
+        # Both landed on the DTO with schema v2 (#1046). They are here because a
+        # fixture that omits a field the real producer sends is the drift #853
+        # was about: the window gets developed against a payload thinner than
+        # the one it will receive.
+        contingencies=[
+            {
+                "trigger": "if RUS pits within two laps",
+                "switch_to": "PIT_NOW",
+                "priority": "HIGH",
+                "rationale": "the undercut window shuts once he clears traffic",
+            }
+        ],
+        key_risks=["rejoin into traffic", "the cliff arrives before the stop"],
         # `None`, not the STRING "none". A non-empty string is truthy, so the
         # window rendered `⚠ Guardrail: none` in the alarm colour on every lap
         # of every dev run - a red warning whose content is that there is
@@ -124,8 +136,6 @@ def decision(lap: int, action: str, confidence: float) -> LapDecisionDTO:
                 "threat_level": "MEDIUM",
                 "gap_ahead_s": 1.42,
                 "pace_delta_s": -0.12,
-                "sc_currently_active": False,
-                "vsc_active": False,
                 "reasoning": "DRS threat building: the gap to PIA has closed for three laps.",
             },
             radio={
@@ -211,7 +221,6 @@ state.start = StartEventDTO(
     gp="Melbourne",
     year=2025,
     driver="NOR",
-    driver2="PIA",
     team="McLaren",
     lap_start=1,
     lap_end=57,

--- a/src/arcade/app.py
+++ b/src/arcade/app.py
@@ -202,8 +202,9 @@ def _frame_to_telemetry(frame, circuit_length_m: float, has_position: bool = Tru
         # `config.DRS_OPEN_CODES`; `OwnCarTraces` refuses to fork it into
         # TypeScript, which is why its DRS lane could not exist until the producer
         # published the answer instead of the code - the same treatment
-        # `track_status_label` already gets. Both spans, main and rival, flow
-        # through this one function, so the rival's lane is fed by the same line.
+        # `track_status_label` already gets. EVERY driver's span flows through this
+        # one function, so no car's lane can be fed by a different rule. (It said
+        # "both spans, main and rival" until schema v2 put twenty on the wire.)
         # No schema bump: `stream.py`'s own contract says adding a key an old
         # consumer can ignore does not bump it.
         "drs_open": int(frame.drs) in DRS_OPEN_CODES,
@@ -781,8 +782,11 @@ class F1ArcadeView(arcade.View):
         #
         # **A retired car still carries a span**, because its frame array runs
         # the full length of the race and the values simply stop changing. On
-        # Melbourne 2025 that is three lap-1 retirements, 14.5 % of a seek
-        # message. They stay: `active` and `has_position` are published beside
+        # Melbourne 2025 that is three lap-1 retirements, 14.5 % of the arcade
+        # block on a seek tick and about 13.8 % of the whole message once the
+        # strategy block rides along. What each of them costs per tick moves with
+        # playback: a span is `FPS x speed / 10 Hz` samples, so 2-3 at 1x and 20
+        # at 8x, not a fixed handful. They stay: `active` and `has_position` are published beside
         # them for exactly this, and a key set that came and went as cars
         # retired would be a second rule again. **A consumer gates a span on
         # `drivers[code].active` and `.has_position`** rather than on whether

--- a/src/arcade/strategy.py
+++ b/src/arcade/strategy.py
@@ -65,10 +65,19 @@ class SimulateRequestDTO:
 
 @dataclass(frozen=True)
 class StartEventDTO:
+    """The run's fixed metadata, emitted once before the first lap.
+
+    ``driver2`` used to sit here, carrying the launch rival's code onto the
+    wire, and nothing on either window rendered it (#1052). The rival identity
+    a consumer needs is `arcade.driver_rival` on every tick, which since
+    schema v2 names one of twenty spans rather than one of two roles. The
+    request still carries a `driver2`: that is the arcade's own pick, an input
+    rather than a published fact.
+    """
+
     gp: str = ""
     year: int = 0
     driver: str = ""
-    driver2: str | None = None
     team: str = ""
     lap_start: int = 1
     lap_end: int = 0
@@ -115,12 +124,13 @@ class LapDecisionDTO:
     it leaves behind used to stop here silently, which reads as an oversight
     rather than a decision:
 
-    - ``contingencies`` and ``key_risks`` are decision CONTENT and have a claim on
-      the window. They are held back only because adding them is a schema change,
-      so they ride with #1048's bump rather than being a second migration of a
-      frozen contract. ``contingencies`` is the one the orchestrator memory audit
-      calls load-bearing, and it is invisible in ``reasoning``, which is why it was
-      given its own field instead of being left to the model's prose.
+    - ``contingencies`` and ``key_risks`` ARRIVED with #1048's schema bump, which is
+      what this paragraph used to promise. ``contingencies`` is the one the
+      orchestrator memory audit calls load-bearing, and it is invisible in
+      ``reasoning``, which is why it was given its own field instead of being left
+      to the model's prose. They are carried as plain dicts and strings rather than
+      as the orchestrator's ``Contingency`` model: the wire is JSON and the DTO is
+      what ``asdict`` walks.
     - ``expected_stint_end`` stays out. The PLAN timeline already draws the stint
       boundary from ``pit_lap_target``, and a second source for one number on one
       surface is the twin shape this repo pays for most.
@@ -129,6 +139,11 @@ class LapDecisionDTO:
       target above the delta sends the driver at a penalty. A field whose absence
       is the load-bearing case needs a designed rendering before it is worth
       carrying, and nothing on either window asks for it.
+
+    **And what it stopped carrying.** ``agent_alerts`` was a list of intent
+    strings flattened out of ``radio_out.alerts`` for a Qt dashboard retired in
+    ``7ea6a7a6``; it was a lossy copy of ``per_agent.radio.alerts``, which the same
+    tick carries in full and which the RADIO console actually renders (#1040).
     """
 
     lap_number: int = 0
@@ -147,7 +162,12 @@ class LapDecisionDTO:
     pit_lap_target: int | None = None
     compound_next: str | None = None
     undercut_target: str | None = None
-    agent_alerts: list[str] = field(default_factory=list)
+    # Conditional branches the orchestrator planned for upcoming laps, as plain
+    # dicts (`trigger`, `switch_to`, `priority`, `rationale`), plus the risks it
+    # chose to flag. Both are decision content that stopped at this boundary
+    # until schema v2 (#1046).
+    contingencies: list[dict[str, Any]] = field(default_factory=list)
+    key_risks: list[str] = field(default_factory=list)
     guardrail_reason: str | None = None
     # Raw per-agent outputs (populated by the arcade-local pipeline so the
     # dashboard can render predicted vs actual, CI bounds, cliff percentiles
@@ -561,7 +581,6 @@ class SimConnector(threading.Thread):
                 gp=self._request.gp,
                 year=self._request.year,
                 driver=self._request.driver,
-                driver2=self._request.driver2,
                 team=self._request.team,
                 lap_start=lap_start,
                 lap_end=lap_end,
@@ -750,19 +769,69 @@ def _dump_dataclass(obj: Any) -> dict[str, Any] | None:
     return obj if isinstance(obj, dict) else None
 
 
+# N27 computes these two from the RCM stream for the lap it was asked about.
+# The tick already carries `track_status_label`, decoded from FastF1 TrackStatus
+# for the lap on screen by the arcade's own priority rule, and BOTH windows
+# render that one. Publishing the agent's pair as well would put two sources for
+# one fact on one desk, free to disagree, which is the shape this repo pays for
+# most - so the wire carries the decoded signal and the agent keeps its own
+# copy for its own reasoning (#1043).
+#
+# They are filtered HERE rather than deleted from `RaceSituationOutput`, because
+# the pair is read across `src/agents/`: N27's own `sc_active` property, N28's
+# routing branches, and the orchestrator's safety-car handling including the
+# rail that nulls `target_lap_time_s` under Art. 55.7.
+_SITUATION_FIELDS_OFF_THE_WIRE = ("sc_currently_active", "vsc_active")
+
+
+def _situation_for_the_wire(situation_out: Any) -> dict[str, Any] | None:
+    """Dump N27's output minus the neutralisation booleans the tick decodes itself."""
+    dumped = _dump_dataclass(situation_out)
+    if dumped is None:
+        return None
+    return {k: v for k, v in dumped.items() if k not in _SITUATION_FIELDS_OFF_THE_WIRE}
+
+
 def _build_per_agent(agent_outputs: dict[str, Any]) -> PerAgentOutputsDTO:
     """Package the pipeline's intermediate outputs into a DTO the
     ``StrategyState`` can broadcast to the dashboard."""
     return PerAgentOutputsDTO(
         pace=_dump_dataclass(agent_outputs.get("pace_out")),
         tire=_dump_dataclass(agent_outputs.get("tire_out")),
-        situation=_dump_dataclass(agent_outputs.get("situation_out")),
+        situation=_situation_for_the_wire(agent_outputs.get("situation_out")),
         radio=_dump_dataclass(agent_outputs.get("radio_out")),
         pit=_dump_dataclass(agent_outputs.get("pit_out")),
         regulation_context=str(agent_outputs.get("regulation_context") or ""),
         rag=agent_outputs.get("rag"),
         active=list(agent_outputs.get("active") or []),
     )
+
+
+def _contingency_dicts(contingencies: Any) -> list[dict[str, Any]]:
+    """Flatten the orchestrator's ``Contingency`` models into wire dicts.
+
+    Four keys each: ``trigger``, ``switch_to``, ``priority``, ``rationale``.
+    Named rather than inlined because the orchestrator can hand this back as
+    Pydantic models OR, on the dict-shaped result path, as dicts already, and a
+    comprehension that assumed one of the two would produce a payload of empty
+    objects on the other without failing anywhere.
+    """
+    packed: list[dict[str, Any]] = []
+    for item in contingencies or []:
+        if isinstance(item, dict):
+            source = item
+        else:
+            source = {
+                key: getattr(item, key, None)
+                for key in ("trigger", "switch_to", "priority", "rationale")
+            }
+        packed.append(
+            {
+                key: str(source.get(key) or "")
+                for key in ("trigger", "switch_to", "priority", "rationale")
+            }
+        )
+    return packed
 
 
 def _build_decision(
@@ -776,24 +845,14 @@ def _build_decision(
     """Merge the synthesised ``StrategyRecommendation`` + raw agent outputs
     into the DTO consumed by ``StrategyState.history`` / the dashboard.
 
-    ``agent_alerts`` is rebuilt from ``radio_out.alerts`` the same way
-    ``simulator._parse_lap_decision`` does it (string-or-dict tolerant)
-    so the dashboard's alerts feed stays schema-stable across paths.
+    ``contingencies`` is flattened to plain dicts because the wire is JSON and
+    ``asdict`` walks this DTO: the orchestrator holds them as ``Contingency``
+    models, which would not survive the trip typed anyway.
 
     ``memory_block`` / ``plan_changed`` come from ``DecisionMemory`` and are
     just carried onto the DTO here; the caller (``_step_once``) is the one
     that decides when each is captured relative to ``record()``.
     """
-    radio_out = agent_outputs.get("radio_out")
-    agent_alerts: list[str] = []
-    if radio_out is not None:
-        raw_alerts = getattr(radio_out, "alerts", []) or []
-        for a in raw_alerts:
-            if isinstance(a, dict):
-                agent_alerts.append(str(a.get("intent") or a.get("event_type") or "alert"))
-            else:
-                agent_alerts.append(str(a))
-
     return LapDecisionDTO(
         lap_number=race_state.lap,
         compound=str(race_state.compound),
@@ -815,7 +874,8 @@ def _build_decision(
         pit_lap_target=getattr(rec, "pit_lap_target", None),
         compound_next=getattr(rec, "compound_next", None),
         undercut_target=getattr(rec, "undercut_target", None),
-        agent_alerts=agent_alerts,
+        contingencies=_contingency_dicts(getattr(rec, "contingencies", None)),
+        key_risks=[str(risk) for risk in (getattr(rec, "key_risks", None) or [])],
         guardrail_reason=None,
         per_agent=_build_per_agent(agent_outputs),
         memory_block=memory_block,

--- a/src/arcade/strategy.py
+++ b/src/arcade/strategy.py
@@ -811,10 +811,17 @@ def _contingency_dicts(contingencies: Any) -> list[dict[str, Any]]:
     """Flatten the orchestrator's ``Contingency`` models into wire dicts.
 
     Four keys each: ``trigger``, ``switch_to``, ``priority``, ``rationale``.
-    Named rather than inlined because the orchestrator can hand this back as
-    Pydantic models OR, on the dict-shaped result path, as dicts already, and a
-    comprehension that assumed one of the two would produce a payload of empty
-    objects on the other without failing anywhere.
+
+    Both ITEM shapes are handled because the list can hold either, and a
+    comprehension that assumed one would produce a payload of empty objects on
+    the other without failing anywhere.
+
+    **The fork that matters is one level up and it is the caller's**, not this
+    function's. ``_build_decision`` reads every optional field with ``getattr``,
+    so a dict-shaped ``rec`` would yield ``None`` for all of them, silently. That
+    shape does not reach the arcade today - ``run_lap``'s contract is a real
+    ``StrategyRecommendation`` on both the rich and the no-llm paths - and the
+    day one does, the hole is at the call site rather than here.
     """
     packed: list[dict[str, Any]] = []
     for item in contingencies or []:

--- a/src/arcade/stream.py
+++ b/src/arcade/stream.py
@@ -219,13 +219,16 @@ class TelemetryStreamServer:
 
         Takes a factory rather than a dict, and that is the whole point. The
         caller is the pyglet frame loop, and assembling a tick is not cheap:
-        measured on the real Melbourne 2025 replay, `_broadcast_if_due` cost
-        its caller 3.19 ms on a steady 8x tick and 5.41 ms on a seek, of which
-        the recursive `asdict` over the decision history is 2.48 ms and the
-        JSON encode 1.81 ms. Schema v2's twenty telemetry spans take the seek
-        tick to 32 ms, about two dropped frames at 60 FPS. Handing over a
-        closure moves all of it to the sender thread that already existed for
-        `sendall`, and leaves the frame loop paying one queue put.
+        measured on the real Melbourne 2025 replay with two spans on the wire,
+        `_broadcast_if_due` cost its caller 3.19 ms on a steady 8x tick and
+        5.41 ms on a seek. Of that 3.19, the recursive `asdict` over the
+        decision history is 2.48 ms, the JSON encode 0.44 ms and the arcade
+        snapshot 0.19 ms - which is why the whole assembly moved rather than
+        the encode alone. Under schema v2's twenty spans the same decomposition
+        reads 2.48 / 1.81 / 0.83 on a steady tick and takes a seek to 32 ms,
+        about two dropped frames at 60 FPS. Handing over a closure moves all of
+        it to the sender thread that already existed for `sendall`, and leaves
+        the frame loop paying one queue put.
 
         **Returns without touching a socket, and without calling `build`.**
 

--- a/tests/surfaces/test_arcade_telemetry_span.py
+++ b/tests/surfaces/test_arcade_telemetry_span.py
@@ -163,13 +163,22 @@ def test_the_first_tick_sends_one_sample_not_the_whole_race():
 # --- Packing the span -------------------------------------------------------
 
 
-def _frames(n: int) -> list[FrameData]:
+def _frames(n: int, signature: float = 0.0) -> list[FrameData]:
+    """`n` frames on the global clock, optionally stamped so the OWNER is readable.
+
+    `t` is `i * DT` for every driver, because that is what resampling onto one
+    timeline means, so an index recovered from `t` cannot say whose array it came
+    from. `signature` shifts `speed` by a per-driver amount, which is the only
+    thing in a served sample that a test can use to tell two cars apart. Without
+    it every fixture in this file hands all drivers byte-identical arrays, and a
+    producer serving the WRONG driver's frames is invisible to every assertion.
+    """
     return [
         FrameData(
             t=i * DT,
             x=0.0,
             y=0.0,
-            speed=200.0 + i,
+            speed=200.0 + i + signature,
             gear=6,
             drs=0,
             throttle=80.0,
@@ -327,13 +336,19 @@ def _sweep_the_served_spans(speeds_and_ticks, seek_at: int | None = None):
     so the index is recoverable from the wire itself rather than from the
     arithmetic that was supposed to produce it.
 
-    Returns `(sent_by_driver, dropped_total)`.
+    Returns `(sent_by_driver, dropped_total, signature_slots_seen_per_driver)`.
     """
     session = SessionData(
         gp_name="Australia",
         location="Melbourne",
         year=2025,
-        frames_by_driver={code: _frames(4000) for code in _GRID},
+        # Each car's speed is offset by 1000 * its grid slot, so a sample says who
+        # it belongs to. Identical arrays would make the swap class below
+        # unfalsifiable: `t` is the global clock, so an index recovered from it is
+        # the same whichever array the span was filled from.
+        frames_by_driver={
+            code: _frames(4000, signature=1000.0 * slot) for slot, code in enumerate(_GRID)
+        },
         circuit_length_m=CIRCUIT_LENGTH_M,
         total_frames=4000,
     )
@@ -347,6 +362,7 @@ def _sweep_the_served_spans(speeds_and_ticks, seek_at: int | None = None):
     )
 
     sent: dict[str, list[int]] = {code: [] for code in _GRID}
+    served_by: dict[str, set[int]] = {code: set() for code in _GRID}
     dropped_total = 0
     frame_index = 0.0
     last_sent = -1
@@ -368,7 +384,14 @@ def _sweep_the_served_spans(speeds_and_ticks, seek_at: int | None = None):
             )["telemetry"]["drivers"]
             for code, samples in spans.items():
                 sent[code].extend(round(sample["t"] / DT) for sample in samples)
-    return sent, dropped_total
+                # Whose array the span was actually filled from. The index above
+                # cannot answer that, and a producer keying the comprehension on
+                # the wrong code would pass every count-based assertion.
+                served_by[code].update(
+                    round(sample["speed"] - 200.0 - round(sample["t"] / DT)) // 1000
+                    for sample in samples
+                )
+    return sent, dropped_total, served_by
 
 
 def test_every_frame_the_clock_crosses_reaches_EVERY_driver_exactly_once():
@@ -381,8 +404,25 @@ def test_every_frame_the_clock_crosses_reaches_EVERY_driver_exactly_once():
     driver another's frames. This asserts on what the payload actually
     carried, at 1x, 2x and 8x in sequence, and requires the four drivers to
     have received exactly the same frames.
+
+    **The third class needs a second metric, and did not have one.** Recovering
+    the frame index from `t` cannot see a wrong-key defect at all, because `t` is
+    the global clock and every driver's array carries the same value at the same
+    index; and every fixture in this file used to hand all drivers byte-identical
+    arrays, so nothing else could see it either. Measured by the exit gate: a
+    producer serving every driver the FIRST driver's frames passed all 277 tests.
+    The speed signature and the `served_by` assertion are what close that.
     """
-    sent, dropped = _sweep_the_served_spans([(1.0, 30), (2.0, 30), (8.0, 30)])
+    sent, dropped, served_by = _sweep_the_served_spans([(1.0, 30), (2.0, 30), (8.0, 30)])
+
+    # Identity FIRST, because the index assertions below cannot see it: `t` is the
+    # global clock, so a span filled from another car's array recovers the same
+    # index list. Each driver's samples must carry that driver's own speed offset
+    # and no other's (#1048 exit gate, finding 1).
+    for slot, code in enumerate(_GRID):
+        assert served_by[code] == {slot}, (
+            f"{code} was served frames belonging to grid slot(s) {served_by[code]}"
+        )
 
     assert dropped == 0, "smooth playback must never reach the span cap"
     reference = sent["NOR"]
@@ -401,7 +441,7 @@ def test_a_seek_is_capped_and_counted_for_every_driver_alike():
     assertion is that the count is non-zero, that no driver silently spliced
     across it, and that the twenty spans agree about where the hole is.
     """
-    sent, dropped = _sweep_the_served_spans([(1.0, 20), (8.0, 20)], seek_at=10)
+    sent, dropped, _ = _sweep_the_served_spans([(1.0, 20), (8.0, 20)], seek_at=10)
 
     assert dropped > 0, "the seek did not outrun the span cap"
     reference = sent["NOR"]
@@ -439,7 +479,7 @@ def test_the_per_driver_sweep_actually_bites_on_a_planted_duplicate(monkeypatch)
         return packed
 
     monkeypatch.setattr(app_module, "_frames_to_telemetry_span", duplicating)
-    sent, _ = _sweep_the_served_spans([(1.0, 10)])
+    sent, _, _ = _sweep_the_served_spans([(1.0, 10)])
 
     reference = sent["NOR"]
     assert len(reference) == len(set(reference)), "the mutation was supposed to spare NOR"

--- a/tests/surfaces/test_arcade_wire_contract.py
+++ b/tests/surfaces/test_arcade_wire_contract.py
@@ -966,6 +966,61 @@ def test_every_recommendation_field_the_wire_drops_was_decided_about():
     assert {"action", "confidence", "reasoning", "scenario_scores"} <= dto
 
 
+def test_the_producer_really_copies_the_contingencies_it_was_handed():
+    """`_build_decision` is what fills the wire, and nothing executed it (#1046).
+
+    Every other guard for these two fields reads a hand-built `LapDecisionDTO`:
+    the golden's `_decision()` writes them directly, and the dev producer writes
+    dicts straight into the DTO. So the extraction itself was uncovered, and the
+    exit gate measured what that costs: replacing the real copy with
+    `contingencies=[]` leaves all 277 tests green while every rich lap ships the
+    field empty.
+
+    It cannot be closed by running the pipeline. The rich profile spends LLM
+    calls, and on the free profile `no_llm.py` builds `contingencies=[]` by
+    design, so no affordable run reds it. A stand-in recommendation does.
+
+    The four keys are checked against `Contingency`'s own declaration rather than
+    against this file's idea of them: hardcoded on both sides, a rename would ship
+    four empty strings on every lap and stay green - the same drift the situation
+    filter's guard below is written to stop.
+    """
+    from src.arcade.strategy import _build_decision
+
+    declared = _dataclass_field_names("src/agents/strategy_orchestrator.py", "Contingency")
+    assert declared, "Contingency has no annotated fields; the flattener guards nothing"
+
+    class _Contingency:
+        def __init__(self, **values):
+            for key, value in values.items():
+                setattr(self, key, value)
+
+    payload = {name: f"{name}-value" for name in sorted(declared)}
+    rec = SimpleNamespace(
+        action="PIT_NOW",
+        confidence=0.71,
+        reasoning="undercut window open",
+        scenario_scores={"PIT_NOW": 0.71},
+        contingencies=[_Contingency(**payload), dict(payload)],
+        key_risks=["rejoin into traffic", "the cliff arrives first"],
+    )
+    race_state = SimpleNamespace(
+        lap=12, compound="MEDIUM", tyre_life=9, position=4, gap_ahead_s=1.42
+    )
+
+    decision = _build_decision(rec, race_state, 81.2, {})
+
+    assert decision.key_risks == ["rejoin into traffic", "the cliff arrives first"]
+    assert len(decision.contingencies) == 2, "an item shape was dropped on the floor"
+    # Both item shapes, because the orchestrator's list can hold either, and both
+    # must survive with every declared key carrying its value rather than "".
+    for item in decision.contingencies:
+        assert set(item) == declared, f"the wire dict does not match Contingency: {item}"
+        assert all(item[name] == f"{name}-value" for name in declared), (
+            f"a declared field was flattened to an empty string: {item}"
+        )
+
+
 def test_the_two_neutralisation_booleans_are_filtered_out_of_the_situation_dump():
     """N27 still computes them; the wire stops carrying them (#1043).
 

--- a/tests/surfaces/test_arcade_wire_contract.py
+++ b/tests/surfaces/test_arcade_wire_contract.py
@@ -123,7 +123,15 @@ def _decision() -> LapDecisionDTO:
         pit_lap_target=13,
         compound_next="HARD",
         undercut_target="RUS",
-        agent_alerts=["tyre cliff in 2 laps"],
+        contingencies=[
+            {
+                "trigger": "if RUS pits within two laps",
+                "switch_to": "PIT_NOW",
+                "priority": "HIGH",
+                "rationale": "the undercut window shuts once he clears traffic",
+            }
+        ],
+        key_risks=["rejoin into traffic"],
         guardrail_reason="none",
         # Real field names, taken from the agents' own output dataclasses and
         # guarded by `test_the_per_agent_fixture_uses_the_producers_real_field_names`.
@@ -215,7 +223,6 @@ def _payload() -> dict:
         gp="Melbourne",
         year=2025,
         driver="NOR",
-        driver2="PIA",
         team="McLaren",
         lap_start=1,
         lap_end=57,
@@ -315,10 +322,18 @@ GOLDEN_SHAPE = {
         "history_tail": [
             {
                 "action": "str",
-                "agent_alerts": ["str"],
                 "compound": "str",
                 "compound_next": "str",
                 "confidence": "float",
+                "contingencies": [
+                    {
+                        "priority": "str",
+                        "rationale": "str",
+                        "switch_to": "str",
+                        "trigger": "str",
+                    }
+                ],
+                "key_risks": ["str"],
                 "gap_ahead_s": "float",
                 "guardrail_reason": "str",
                 "lap_number": "int",
@@ -337,10 +352,18 @@ GOLDEN_SHAPE = {
         ],
         "latest": {
             "action": "str",
-            "agent_alerts": ["str"],
             "compound": "str",
             "compound_next": "str",
             "confidence": "float",
+            "contingencies": [
+                {
+                    "priority": "str",
+                    "rationale": "str",
+                    "switch_to": "str",
+                    "trigger": "str",
+                }
+            ],
+            "key_risks": ["str"],
             "gap_ahead_s": "float",
             "guardrail_reason": "str",
             "lap_number": "int",
@@ -389,7 +412,6 @@ GOLDEN_SHAPE = {
         },
         "start": {
             "driver": "str",
-            "driver2": "str",
             "gp": "str",
             "lap_end": "int",
             "lap_start": "int",
@@ -924,10 +946,10 @@ def test_every_recommendation_field_the_wire_drops_was_decided_about():
     dto = _dataclass_field_names("src/arcade/strategy.py", "LapDecisionDTO")
 
     assert recommendation - dto == {
-        # Decision content, held back only because adding it is a schema change;
-        # rides with #1048's bump rather than migrating a frozen contract twice.
-        "contingencies",
-        "key_risks",
+        # `contingencies` and `key_risks` used to sit here. They landed with
+        # #1048's schema bump, which is what holding them back was for, and their
+        # absence from this set is now the record that they did.
+        #
         # The PLAN timeline already draws the stint boundary from `pit_lap_target`.
         # A second source for one number on one surface is the twin shape.
         "expected_stint_end",
@@ -942,6 +964,55 @@ def test_every_recommendation_field_the_wire_drops_was_decided_about():
     # And the other direction, so the frozen set cannot be satisfied by the DTO
     # quietly losing a field it is supposed to carry.
     assert {"action", "confidence", "reasoning", "scenario_scores"} <= dto
+
+
+def test_the_two_neutralisation_booleans_are_filtered_out_of_the_situation_dump():
+    """N27 still computes them; the wire stops carrying them (#1043).
+
+    The golden cannot assert this. Its `situation` block is a hand-written dict
+    that never carried the pair, so it would stay green whether the filter
+    existed or not - a guard about the empty set. This runs the real
+    `_build_per_agent` over an object that DOES carry them.
+
+    Both halves are checked, because filtering a field nobody produces is the
+    same nothing: the `ast` half asserts `RaceSituationOutput` still declares
+    the pair, so the day N27 drops them this test says the filter is now
+    pointless rather than quietly passing forever.
+
+    Why filtered rather than deleted from the agent: the pair is read across
+    `src/agents/` - N27's own `sc_active`, N28's routing, and the orchestrator's
+    safety-car handling including the rail that nulls `target_lap_time_s` under
+    Art. 55.7. What the wire carries instead is `track_status_label`, decoded
+    once by the arcade from FastF1 TrackStatus, which both windows render.
+    """
+    from dataclasses import dataclass
+    from dataclasses import field as dc_field
+
+    from src.arcade.strategy import _SITUATION_FIELDS_OFF_THE_WIRE, _build_per_agent
+
+    declared = _dataclass_field_names("src/agents/race_situation_agent.py", "RaceSituationOutput")
+    assert set(_SITUATION_FIELDS_OFF_THE_WIRE) <= declared, (
+        "the filter names fields N27 no longer produces, so it guards nothing"
+    )
+
+    @dataclass
+    class _SituationLike:
+        threat_level: str = "MEDIUM"
+        sc_prob_3lap: float = 0.08
+        sc_currently_active: bool = True
+        vsc_active: bool = True
+        reasoning: str = "the field is neutralised"
+        alerts: list = dc_field(default_factory=list)
+
+    per_agent = _build_per_agent({"situation_out": _SituationLike()})
+
+    assert per_agent.situation is not None
+    for name in _SITUATION_FIELDS_OFF_THE_WIRE:
+        assert name not in per_agent.situation, f"{name} still reaches the wire"
+    # And the filter took only what it was aimed at.
+    assert per_agent.situation["threat_level"] == "MEDIUM"
+    assert per_agent.situation["sc_prob_3lap"] == 0.08
+    assert per_agent.situation["reasoning"] == "the field is neutralised"
 
 
 def test_the_pipeline_delegate_no_longer_throws_the_stage_timings_away():

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -656,12 +656,13 @@ def test_the_tooltips_return_data_and_never_markup():
 def test_the_agents_header_takes_the_neutralisation_off_the_tick():
     """One source for the race's most decision-changing fact, and an absence stays one.
 
-    The situation agent publishes `sc_currently_active` and `vsc_active` on the
-    same payload. Rendering those would put two sources for one fact on a desk
-    where both windows are open: one is FastF1's TrackStatus for the lap on
-    screen, decoded once by the producer so nobody re-derives it, and the other is
-    a boolean N27 computed for the lap it was asked about. This asserts the header
-    reads the decoded one.
+    The situation agent computes `sc_currently_active` and `vsc_active`, and it
+    used to publish them on this same payload. Rendering those would put two
+    sources for one fact on a desk where both windows are open: one is FastF1's
+    TrackStatus for the lap on screen, decoded once by the producer so nobody
+    re-derives it, and the other is a boolean N27 computed for the lap it was
+    asked about. This asserts the header reads the decoded one, and that the
+    other one is no longer on the wire to be read (#1043).
 
     The second half is the part that costs if it is wrong. The producer sends
     `None` when the loader has no entry for the lap, and that is NOT a green
@@ -684,9 +685,17 @@ def test_the_agents_header_takes_the_neutralisation_off_the_tick():
     assert unknown["track_status"] is None, "an absent status became a claim"
     assert unknown["track_status_colour"] is None
 
-    # And the agent's own pair is NOT what the header reads, which is the whole
-    # point: a payload whose agent says the safety car is out while the tick says
-    # green renders green, because the tick is the source.
+    # The pair no longer reaches the wire at all: it is filtered at the DTO
+    # boundary (#1043), and that absence is guarded against the REAL producer in
+    # `test_arcade_wire_contract.py`, not here - `_payload` is a hand-built dict,
+    # so an absence assertion against it would only say what this file chose to
+    # write.
+    #
+    # The injection below is therefore a key no producer sends any more, and the
+    # test is deliberately kept that way: what it pins is the VIEW BUILDER, which
+    # must not grow a second reader of neutralisation whatever arrives. A payload
+    # whose agent says the safety car is out while the tick says green renders
+    # green, because the tick is the source.
     disagreeing = _payload()
     disagreeing["strategy"]["latest"]["per_agent"]["situation"]["sc_currently_active"] = True
     still = _host(disagreeing).get_agents_view(-1)["header"]
@@ -880,7 +889,7 @@ def _payload(
     seq: int = 7, lap: int = 23, latest: dict | None = None, tail: list | None = None
 ) -> dict:
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "seq": seq,
         "arcade": {
             "gp_name": "Melbourne",


### PR DESCRIPTION
## What

Four field changes that the previous sprint deliberately queued to ride #1048's schema bump, so the frozen contract, its golden test and the TypeScript type migrate once instead of four times. No second version bump: one unreleased schema version, one migration.

| | field | issue |
|---|---|---|
| gone | `LapDecisionDTO.agent_alerts` | #1040 |
| gone | `StartEventDTO.driver2` | #1052 |
| gone | `per_agent.situation.sc_currently_active` / `.vsc_active` | #1043 step 3 |
| arrived | `contingencies`, `key_risks` | #1046 |

## Why each

**`agent_alerts`** was a list of intent strings flattened out of `radio_out.alerts` for the Qt dashboard retired in `7ea6a7a6`. Nothing renders it on either producer path. What is rendered is the source it was flattened from, `per_agent.radio.alerts`, which the same tick carries in full, so the wire was paying for a lossy copy of a field already on it.

**`start.driver2`** carried the launch rival's code and is rendered nowhere. The rival identity a consumer needs is `arcade.driver_rival` on every tick, which since schema v2 names one of twenty spans rather than one of two roles. `SimulateRequestDTO.driver2` stays: that is the arcade's own pick, an input rather than a published fact.

**The two situation booleans**: the tick already carries `track_status_label`, decoded from FastF1 TrackStatus for the lap on screen by the arcade's own priority rule, and both windows render that one. Publishing N27's pair as well would put two sources for one fact on one desk, free to disagree, one decoded for the lap on screen and one computed for the lap the agent was asked about.

**`contingencies` and `key_risks`** are decision content that stopped at the DTO boundary. `contingencies` is the field the orchestrator memory audit calls load-bearing, and it is invisible in `reasoning`, which is why it was given its own field rather than left to the model's prose. They are flattened to plain dicts because the wire is JSON and `asdict` walks this DTO.

## How

The situation pair is **filtered at the DTO dump, never deleted from `RaceSituationOutput`**. The pair is read across `src/agents/`: N27's own `sc_active` property, N28's routing branches, and the orchestrator's safety-car handling including the rail that nulls `target_lap_time_s` under Art. 55.7. The filter sits behind a named constant with the reason next to it.

**The submodule moved first** (`F1_Telemetry_Manager#219`, merged) so the two producer paths do not diverge, and the pointer is bumped here. Its `LapDecision` is not gaining `contingencies` and `key_risks`: separately versioned contract, different consumer, and no decision exists saying the two must carry the same field set. That PR also found `StartEvent` and `LapDecision` are SSE payloads rather than response models, so they were never in the generated OpenAPI types and nothing needed regenerating.

**The dev producer moved in the same commit.** It passed `agent_alerts` and `driver2` as keyword arguments and published the situation pair in its fixture, so it would have died at startup on the first two and under-described the payload on the third. No test forces that file, which is why it is called out here rather than left to be discovered.

## Checks

- `tests/surfaces/` 277 passed, from 276.
- The golden was driven RED by the change itself: eight failures. It compares the shape exactly, so a re-added field fails there; that is the deletion guard.
- The `#1046` dropped-set guard, `test_every_recommendation_field_the_wire_drops_was_decided_about`, stayed red until `contingencies` and `key_risks` came out of its frozen literal. That is the guard working as designed rather than a chore.
- New: `test_the_two_neutralisation_booleans_are_filtered_out_of_the_situation_dump`. The golden could not cover the filter, because its `situation` block is a hand-written dict that never carried the pair and would have been green either way. It checks both halves: that the filter strips them, and that `RaceSituationOutput` still declares them, so filtering a field nobody produces cannot pass as success. Driven red by bypassing the filter, restored from a copy and compared with `cmp`.
- Reframed rather than deleted: `test_pitwall_agents_view.py`'s disagreement check injects `sc_currently_active` by hand into a payload the producer no longer builds. It stays, because what it pins is the view builder refusing to grow a second reader of neutralisation, and the comment now says so; the absence itself is asserted against the real producer in the wire contract test. Its fixture also said `schema_version: 1`, now 2.
- The real path: `scripts/dev_pitwall_producer.py` boots, and a socket client reads a tick with `agent_alerts` absent from both `latest` and the history tail, `start.driver2` absent, `situation` down to `gap_ahead_s / overtake_prob / pace_delta_s / reasoning / sc_prob_3lap / threat_level`, and `contingencies` and `key_risks` populated.
- `ruff check` and `ruff format --check .` clean, `npm run build` 0 TS errors, `smoke-data` 233, `smoke-agents` 65.

Closes #1040
Closes #1043
Closes #1046
Closes #1052


---

## Exit gate

Fable, over the whole R1 range, handed the three design-gate reports so it would not repeat them. Ten claims, no P0, and **no wrong payload byte on any executed path**. Report at `~/.claude/plans/pitwall-r1-the-wire/GATE_EXIT.md`. Two P1s, both guard gaps in this sprint's own work, both fixed in `c9a238b6`:

**The acceptance sweep was blind to a cross-driver swap.** It recovers each sample's frame index from `t`, and `t` is the global clock, so a span filled from another car's array recovers the identical index list; every fixture in the file also handed all drivers byte-identical arrays. The gate measured it: a producer serving every driver the first driver's frames passed all 277 tests. `_frames` now takes a per-driver speed signature, the sweep reads the owner off the served sample, and that mutation is red.

**Nothing executed `_build_decision`.** The two fields #1046 adds were guarded only by hand-built DTOs, so replacing the real copy with `contingencies=[]` left the suite green while every rich lap shipped the field empty. It cannot be closed by running the pipeline: the rich profile spends LLM calls and the free profile builds an empty list by design. A stand-in recommendation does, and the four wire keys are now checked against `Contingency`'s own declaration instead of a second hardcoded copy. Red from both mutations.

Four prose claims of mine were false and are corrected: `broadcast()`'s decomposition mixed the twenty-span encode into the two-span row (0.44, not 1.81; the same number was stapled to the wrong row in #1061's body, fixed there); `_frame_to_telemetry` still said "both spans, main and rival"; the flattener's docstring named a dict-shaped result path that does not reach it; and 14.5 % is of the arcade block rather than the message, with the span length moving as `FPS x speed / 10 Hz` rather than being a fixed five.

Three documents still taught the retired shape, one of them stale from this sprint's own submodule PR: the SSE contract table in `ECOSYSTEM_DATA_CONTRACTS.md`, the Qt node in `tcp_broadcast_dataflow.drawio`, and the JSON example in `arcade-dashboard.md`, which #1062 edited forty lines below without touching the paragraph presenting it as current.

`tests/surfaces/` 278 after the fixes. The real path re-run: 20 spans of 250 samples on a real socket, which is the seek-sized message, with the four fields gone and the two present.
