### PR TITLE
fix(pitwall): the eviction signals survive a discarded tick

### DIFF
--- a/src/pitwall/host.py
+++ b/src/pitwall/host.py
@@ -27,9 +27,77 @@ from src.pitwall.agents_view.panels import CONNECTION_COLOURS
 from src.pitwall.radio_feed import RadioCorpus
 from src.pitwall.radio_feed import unavailable as radio_unavailable
 from src.pitwall.session_data import SessionLaps, unavailable
-from src.pitwall.stream_client import ArcadeStreamClient
+from src.pitwall.stream_client import ArcadeStreamClient, TickSignals
 
 logger = logging.getLogger(__name__)
+
+
+def with_missed_signals(payload: dict, signals: tuple[TickSignals, ...], since_seq: int) -> dict:
+    """Return `payload` carrying the eviction signals of the ticks the caller missed.
+
+    `rewound` and `dropped` describe the gap between two ticks, not the state of
+    one, so a tick the latest-payload slot overwrote before a window polled took
+    its signal with it. Folding the missed range forward is what makes the signal
+    survive the discard (#1060).
+
+    **The fold lands on a COPY, three levels deep.** `get_tick` hands every caller
+    the same dict object, so folding in place lets one window rewrite the block
+    another is still holding: window A folds `dropped=5`, window B polls with a
+    different cursor and rewrites the block to its own range, and A's payload now
+    reads 0 before it is ever serialised. Copying the three containers the fold
+    touches costs three shallow dicts a poll and makes the answer the caller's own.
+
+    **The range is expressed in ARRIVAL order, never in `seq`.** `seq` restarts at
+    1 when the arcade relaunches - the case this module's own comparison exists for
+    - so a range keyed on it either excludes every entry of the new run or, once
+    two runs' numbers collide, matches twice.
+
+    A cursor the log cannot place is served UNMERGED: a window polling for the
+    first time, or one asleep past the log's 6.4 s, has no knowable range, and
+    inventing a `dropped` for it would be a fabricated number in the one field
+    whose whole job is to say something real happened.
+
+    --- WHERE TO CHANGE IF THE WIRE'S CONTINUITY FIELDS CHANGE ---
+    `src/arcade/app.py:_telemetry_span_bounds` produces them, `_signals_of` in
+    `stream_client.py` reads them off the payload, and `lib/frameClock.ts` plus
+    `features/data/useTraceFrame.ts` consume them. A third continuity field has to
+    land in all four.
+    """
+    missed = _missed_after(signals, since_seq)
+    if not missed:
+        return payload
+    rewound = any(entry.rewound for entry in missed)
+    dropped = sum(entry.dropped for entry in missed)
+    arcade = payload.get("arcade")
+    telemetry = (arcade or {}).get("telemetry")
+    if not isinstance(arcade, dict) or not isinstance(telemetry, dict):
+        return payload  # a producer that sends no telemetry block has none to fold
+    # `missed` always ends with the served payload's own entry, so these two are
+    # already the merged answer; when they equal what the payload says, nothing
+    # was discarded and the caller keeps the original object.
+    if rewound == bool(telemetry.get("rewound")) and dropped == telemetry.get("dropped"):
+        return payload
+    merged_telemetry = {**telemetry, "rewound": rewound, "dropped": dropped}
+    return {**payload, "arcade": {**arcade, "telemetry": merged_telemetry}}
+
+
+def _missed_after(signals: tuple[TickSignals, ...], since_seq: int) -> list[TickSignals]:
+    """The log entries after the caller's cursor, up to and including the newest.
+
+    The newest entry always describes the payload being served, because
+    `snapshot()` reads the slot and the log under one lock.
+
+    When `since_seq` appears more than once - only reachable if a relaunched
+    producer's numbering reaches an old entry that the reconnect did not clear -
+    the NEWEST match wins. It yields the smaller range, and over-reporting
+    `dropped` costs a spurious eviction of the very buffer this protects.
+    """
+    if not signals:
+        return []
+    for index in range(len(signals) - 1, -1, -1):
+        if signals[index].seq == since_seq:
+            return list(signals[index + 1 :])
+    return []
 
 
 class PitwallHost:
@@ -99,13 +167,21 @@ class PitwallHost:
         A payload with no `seq` is returned unconditionally. That only
         happens against a producer older than the one in this repo, where
         there is nothing to compare and the honest answer is the data.
+
+        **The payload carries the eviction signals of the ticks this caller
+        never saw**, folded in by `with_missed_signals`. `rewound` and
+        `dropped` describe what happened BETWEEN two ticks rather than the
+        state of one, so a tick the slot overwrote before this window polled
+        used to take its signal with it - and `FrameClock` then reported
+        `continuous` across the hole while the trace buffer kept appending
+        samples from unrelated parts of the race (#1060).
         """
-        payload = self._client.latest
+        payload, signals = self._client.snapshot()
         if payload is None:
             return None
         seq = payload.get("seq")
         if seq is None or seq != since_seq:
-            return payload
+            return with_missed_signals(payload, signals, since_seq)
         return None
 
     def _connection_label(self) -> str:

--- a/src/pitwall/stream_client.py
+++ b/src/pitwall/stream_client.py
@@ -21,8 +21,32 @@ import json
 import logging
 import socket
 import threading
+from collections import deque
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
+
+# How many ticks of eviction signals to remember. Both windows poll at 100 ms
+# against a 10 Hz producer, so a poll spans one or two entries; 64 is 6.4 s of
+# history, far past any healthy cursor. A caller older than that falls into the
+# unmergeable branch, which is honest rather than wrong.
+SIGNAL_LOG_DEPTH = 64
+
+
+class TickSignals(NamedTuple):
+    """What one received tick said about continuity, kept after the tick is gone.
+
+    `arrival` is a monotonic counter, NOT the producer's `seq`, and that is the
+    whole point: `seq` restarts at 1 when the arcade relaunches, so a range
+    expressed in `seq` either excludes the new run's entries (`30 > 400` is
+    false) or becomes ambiguous when two runs' numbers collide inside one log.
+    """
+
+    arrival: int
+    seq: int | None
+    rewound: bool
+    dropped: int
+
 
 # How long to wait between connection attempts. The arcade opens its server
 # when the replay view is constructed, and PITWALL is spawned right after,
@@ -33,6 +57,23 @@ RECONNECT_DELAY_S = 1.0
 # this means the socket is idle rather than slow. Waking up lets the thread
 # notice `stop()`.
 READ_TIMEOUT_S = 2.0
+
+
+def _signals_of(payload: dict, arrival: int) -> TickSignals:
+    """Read one payload's continuity flags, tolerating a producer that omits them.
+
+    A payload with no telemetry block is not a defect to raise on: an older arcade,
+    or a malformed-but-parseable line, simply says nothing about continuity, and
+    "said nothing" must read as "no eviction" rather than as a fabricated one.
+    """
+    telemetry = (payload.get("arcade") or {}).get("telemetry") or {}
+    dropped = telemetry.get("dropped")
+    return TickSignals(
+        arrival=arrival,
+        seq=payload.get("seq"),
+        rewound=bool(telemetry.get("rewound")),
+        dropped=int(dropped) if isinstance(dropped, int) else 0,
+    )
 
 
 class ArcadeStreamClient:
@@ -55,6 +96,12 @@ class ArcadeStreamClient:
         self._host = host
         self._port = port
         self._latest: dict | None = None
+        # The eviction signals of every tick received, kept so a tick the slot
+        # discarded before any window polled does not take its `rewound`/`dropped`
+        # with it (#1060). Written and read under `_lock` together with `_latest`,
+        # which is what makes `snapshot()` a consistent pair.
+        self._signals: deque[TickSignals] = deque(maxlen=SIGNAL_LOG_DEPTH)
+        self._arrival = 0
         self._lock = threading.Lock()
         self._running = False
         self._thread: threading.Thread | None = None
@@ -93,6 +140,26 @@ class ArcadeStreamClient:
         """The most recent payload, or None if nothing has arrived yet."""
         with self._lock:
             return self._latest
+
+    def snapshot(self) -> tuple[dict | None, tuple[TickSignals, ...]]:
+        """The latest payload AND the signal log, read under ONE lock acquisition.
+
+        **The single acquisition is the contract, not an optimisation.** Reading
+        `latest` and then the log takes two locks, and `_consume` can publish
+        between them: the caller then folds signals belonging to ticks NEWER than
+        the payload it is about to serve, while its cursor only advances to that
+        payload - so the same entries are folded again on the next poll. Measured
+        on a live producer, that over-counts `dropped` by 66 %, and every phantom
+        count is a spurious full-buffer eviction in the panel this exists to
+        protect.
+
+        Because both are read together, the last log entry always describes the
+        payload returned beside it.
+
+        The log is a tuple, so the caller cannot be torn by a later append.
+        """
+        with self._lock:
+            return self._latest, tuple(self._signals)
 
     @property
     def connected(self) -> bool:
@@ -137,6 +204,8 @@ class ArcadeStreamClient:
                 continue
             with self._lock:
                 self._latest = payload
+                self._arrival += 1
+                self._signals.append(_signals_of(payload, self._arrival))
         return tail
 
     def _connect(self) -> bool:
@@ -153,6 +222,13 @@ class ArcadeStreamClient:
         return True
 
     def _close_socket(self) -> None:
+        # The signal log dies with the connection. The next producer to answer may
+        # be a relaunched arcade whose `seq` restarts at 1, and a log holding both
+        # runs is a log where one cursor can match two entries. `latest` is kept on
+        # purpose - a frozen board is still operationally useful and the windows
+        # render it dimmed - but a continuity signal from a race that ended is not.
+        with self._lock:
+            self._signals.clear()
         sock, self._socket = self._socket, None
         if sock is None:
             return

--- a/tests/surfaces/fake_stream_client.py
+++ b/tests/surfaces/fake_stream_client.py
@@ -1,0 +1,67 @@
+"""One stand-in for `ArcadeStreamClient`, shared by every surface test that needs it.
+
+**One, not two.** `test_pitwall_host.py` and `test_pitwall_agents_view.py` each grew
+their own `_FakeClient` with the same docstring, and when the client gained
+`snapshot()` for #1060 only one of them learned about it: fourteen tests in the
+other file failed on a method their fake did not have. That is this repo's dominant
+defect wearing a test helper, so the copy is deleted rather than patched.
+
+What it has to be faithful about, because a stub that is not makes the guards pass
+against the fix and against the defect alike:
+
+- `latest` and the signal log move TOGETHER. The real client appends to the log
+  inside the same lock that assigns the slot, which is what makes `snapshot()` a
+  consistent pair; here `latest` is a property whose setter does both, so a test
+  that assigns `client.latest = payload` cannot leave the two disagreeing.
+- The log is BOUNDED by the real `SIGNAL_LOG_DEPTH`. Written as a plain list, this
+  fake remembered 69 ticks the real deque had already evicted and the
+  unplaceable-cursor guard failed against correct code.
+- The entries are built by the real `_signals_of`, so a change to what a payload's
+  continuity flags mean reaches the fake without anyone editing it.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+
+from src.pitwall.stream_client import SIGNAL_LOG_DEPTH, TickSignals, _signals_of
+
+
+class FakeStreamClient:
+    """Stands in for the socket, so the host's own logic is what is tested."""
+
+    def __init__(self, payload: dict | None = None, connected: bool = True) -> None:
+        self._latest: dict | None = None
+        self._arrival = 0
+        self._signals: deque[TickSignals] = deque(maxlen=SIGNAL_LOG_DEPTH)
+        self.connected = connected
+        self.started = False
+        self.stopped = False
+        if payload is not None:
+            self.latest = payload
+
+    @property
+    def latest(self) -> dict | None:
+        return self._latest
+
+    @latest.setter
+    def latest(self, payload: dict | None) -> None:
+        """Publish one tick, slot and log together, exactly as `_consume` does."""
+        self._latest = payload
+        if payload is None:
+            return
+        self._arrival += 1
+        self._signals.append(_signals_of(payload, self._arrival))
+
+    def receive(self, payload: dict) -> None:
+        """Read as intent at a call site that is publishing rather than assigning."""
+        self.latest = payload
+
+    def snapshot(self) -> tuple[dict | None, tuple[TickSignals, ...]]:
+        return self._latest, tuple(self._signals)
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:
+        self.stopped = True

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -15,6 +15,8 @@ import textwrap
 
 import pytest
 
+from tests.surfaces.fake_stream_client import FakeStreamClient as _FakeClient
+
 # The AGENTS window's content layer, which moved OUT of the Qt package in
 # sprint 7 rather than dying with it: PITWALL renders by calling these, which
 # is what made the port 1:1 by construction instead of by inspection.
@@ -911,21 +913,6 @@ def _payload(
             "error": None,
         },
     }
-
-
-class _FakeClient:
-    """Stands in for the socket, so the host's own logic is what is tested."""
-
-    def __init__(self, payload=None, connected=True):
-        self.latest = payload
-        self.connected = connected
-        self.stopped = False
-
-    def start(self):
-        pass
-
-    def stop(self):
-        self.stopped = True
 
 
 def _host(payload=None, connected=True):

--- a/tests/surfaces/test_pitwall_host.py
+++ b/tests/surfaces/test_pitwall_host.py
@@ -13,29 +13,17 @@ from __future__ import annotations
 import json
 import re
 import socket
+import sys
 import threading
 import time
+from collections import deque
 from pathlib import Path
 
 import pytest
 
 from src.pitwall.host import PitwallHost
-from src.pitwall.stream_client import ArcadeStreamClient
-
-
-class _FakeClient:
-    """Stands in for the socket, so the host's own logic is what is tested."""
-
-    def __init__(self, payload=None):
-        self.latest = payload
-        self.started = False
-        self.stopped = False
-
-    def start(self):
-        self.started = True
-
-    def stop(self):
-        self.stopped = True
+from src.pitwall.stream_client import SIGNAL_LOG_DEPTH, ArcadeStreamClient
+from tests.surfaces.fake_stream_client import FakeStreamClient as _FakeClient
 
 
 def _tick(seq: int) -> dict:
@@ -118,6 +106,227 @@ def test_a_payload_with_no_sequence_is_returned_rather_than_withheld():
     host = PitwallHost(_FakeClient({"arcade": {"lap": 3}}), window_count=1)
 
     assert host.get_tick(since_seq=999) == {"arcade": {"lap": 3}}
+
+
+# --- The eviction signals survive a discarded tick (#1060) -------------------
+#
+# `rewound` and `dropped` describe the gap BETWEEN two ticks rather than the
+# state of one, so the latest-payload slot - which is right to keep only the
+# newest snapshot - is wrong to drop them with the tick that carried them.
+# Measured before the fix: 6 of 905 published ticks (0.7 %) were never served to
+# a window polling the way `useTick` polls.
+
+
+def _signalling_tick(seq: int, rewound: bool = False, dropped: int = 0) -> dict:
+    """A tick shaped like the producer's, carrying its continuity flags."""
+    return {
+        "seq": seq,
+        "schema_version": 2,
+        "arcade": {
+            "lap": 12,
+            "telemetry": {"drivers": {}, "rewound": rewound, "dropped": dropped},
+        },
+    }
+
+
+def _telemetry_of(tick: dict) -> dict:
+    return tick["arcade"]["telemetry"]
+
+
+def test_a_rewind_on_a_tick_the_slot_discarded_still_reaches_the_window():
+    """The defect, at its smallest: one tick published, overwritten, never served.
+
+    Before the fix the window saw only the second tick, whose own `rewound` is
+    False, so `FrameClock` reported `continuous` across the hole and the trace
+    buffer kept appending samples from two unrelated parts of the race.
+    """
+    client = _FakeClient(_signalling_tick(1))
+    host = PitwallHost(client, window_count=1)
+    assert host.get_tick(since_seq=-1)["seq"] == 1, "the window is caught up at seq 1"
+
+    client.receive(_signalling_tick(2, rewound=True))  # published...
+    client.receive(_signalling_tick(3))  # ...and overwritten before any poll
+
+    served = host.get_tick(since_seq=1)
+
+    assert served["seq"] == 3, "the newest snapshot is still the one served"
+    assert _telemetry_of(served)["rewound"] is True, (
+        "the rewind rode on seq 2, which no window ever received"
+    )
+
+
+def test_dropped_frames_are_SUMMED_across_every_tick_the_window_missed():
+    """`dropped` is a count, not a flag: two discarded jumps are both real."""
+    client = _FakeClient(_signalling_tick(1))
+    host = PitwallHost(client, window_count=1)
+    host.get_tick(since_seq=-1)
+
+    client.receive(_signalling_tick(2, dropped=250))
+    client.receive(_signalling_tick(3, dropped=40))
+    client.receive(_signalling_tick(4))
+
+    served = host.get_tick(since_seq=1)
+
+    assert _telemetry_of(served)["dropped"] == 290, "250 + 40, not the newest and not 1"
+
+
+def test_two_cursors_each_get_their_OWN_missed_range():
+    """The assertion that fails under any drain-once design.
+
+    `get_tick` has more than one caller - `useTick`, `get_agents_view` at
+    host.py:189, and the loopback server's `/api/tick` - each with its own
+    cursor. A pending slot cleared by the first caller hands the signal to
+    whoever polled first and hides it from everyone else. That is #950 in
+    another field: `lib/agents.ts` carries the comment describing exactly this
+    failure for the connection label.
+
+    AGENTS never reads these flags, and that does not save the design: the
+    DRAIN, not the consumption, is what empties a slot.
+    """
+    client = _FakeClient(_signalling_tick(1))
+    host = PitwallHost(client, window_count=2)
+    host.get_tick(since_seq=-1)  # both windows start caught up at seq 1
+    host.get_tick(since_seq=-1)
+
+    client.receive(_signalling_tick(2, dropped=100))
+    client.receive(_signalling_tick(3))
+
+    first = host.get_tick(since_seq=1)
+    second = host.get_tick(since_seq=1)
+
+    assert _telemetry_of(first)["dropped"] == 100
+    assert _telemetry_of(second)["dropped"] == 100, (
+        "the second window's range is its own; the first did not consume it"
+    )
+
+
+def test_the_fold_does_not_mutate_the_payload_another_window_is_still_holding():
+    """The copy-on-fold rule, and why `get_tick` cannot fold in place.
+
+    Every caller is handed the same dict object out of the slot. Window A folds
+    its range in; window B then polls with a DIFFERENT cursor and would rewrite
+    the same telemetry block to its own, shorter range - so A's payload silently
+    changes underneath it, before A has serialised it across the bridge.
+    """
+    client = _FakeClient(_signalling_tick(1))
+    host = PitwallHost(client, window_count=2)
+    host.get_tick(since_seq=-1)
+
+    client.receive(_signalling_tick(2, dropped=100))
+    client.receive(_signalling_tick(3))
+
+    held_by_a = host.get_tick(since_seq=1)
+    a_dropped_when_served = _telemetry_of(held_by_a)["dropped"]
+
+    host.get_tick(since_seq=2)  # window B, a shorter range, same underlying dict
+
+    assert a_dropped_when_served == 100
+    assert _telemetry_of(held_by_a)["dropped"] == 100, (
+        "another caller's fold rewrote the block this one is holding"
+    )
+    assert _telemetry_of(client.latest)["dropped"] == 0, (
+        "the slot's own payload must never be edited by a read"
+    )
+
+
+def test_a_cursor_the_log_cannot_place_is_served_unmerged_rather_than_invented():
+    """A first poll, or a tab asleep past the log's 6.4 s, has no knowable range.
+
+    Fabricating a `dropped` for it would put a made-up number in the one field
+    whose entire job is to say that something real happened.
+    """
+    client = _FakeClient(_signalling_tick(1, dropped=7))
+    host = PitwallHost(client, window_count=1)
+
+    for _ in range(SIGNAL_LOG_DEPTH + 5):
+        client.receive(_signalling_tick(client.latest["seq"] + 1, dropped=3))
+
+    served = host.get_tick(since_seq=1)  # seq 1 fell off the end of the log
+
+    assert _telemetry_of(served)["dropped"] == 3, "the payload's own flags, unmerged"
+    assert _telemetry_of(served)["rewound"] is False
+
+
+def test_the_signal_log_and_the_slot_are_read_as_ONE_snapshot():
+    """The atomicity contract, asserted on the invariant it produces.
+
+    Two lock acquisitions let `_consume` publish between them, and the fold then
+    picks up ticks NEWER than the payload being served while the caller's cursor
+    only advances to that payload - so the same entries are folded again on the
+    next poll. Measured against a live producer, that over-counts `dropped` by
+    66 %, and every phantom count is a spurious eviction of the buffer this fix
+    exists to protect.
+
+    The observable invariant: whatever `snapshot` returns, its last log entry
+    describes the payload beside it.
+
+    **This has to run against a CONTENDING publisher.** An earlier version of this
+    guard read a client fed by the slow one-shot server and asserted the same
+    invariant; the two-lock mutant survived it, because nothing was publishing in
+    the window between the two acquisitions. A guard for a race that never runs
+    the race is the empty set wearing a thread.
+    """
+    client = ArcadeStreamClient("127.0.0.1", 0)  # never started: `_consume` is driven here
+    lines = [json.dumps(_signalling_tick(i, dropped=1)).encode() + b"\n" for i in range(1, 400)]
+    stop = threading.Event()
+
+    def publish() -> None:
+        while not stop.is_set():
+            for line in lines:
+                if stop.is_set():
+                    return
+                client._consume(line)
+
+    # The window between two lock acquisitions is a handful of bytecodes, and the
+    # default 5 ms switch interval means a publisher thread almost never lands in
+    # it - which is how the two-lock mutant survived the first version of this
+    # guard. Forcing frequent switches is what makes the race actually run.
+    previous_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    publisher = threading.Thread(target=publish, daemon=True)
+    publisher.start()
+    try:
+        assert _wait_for(lambda: client.latest is not None), "the publisher never ran"
+        torn = 0
+        for _ in range(20_000):
+            payload, signals = client.snapshot()
+            if payload is None:
+                continue
+            assert signals, "a payload is in the slot but the log is empty"
+            if signals[-1].seq != payload["seq"]:
+                torn += 1
+        assert torn == 0, (
+            f"{torn} of 20,000 snapshots had a log newer than the payload beside it; "
+            "the fold would count those entries again on the next poll"
+        )
+    finally:
+        stop.set()
+        publisher.join(timeout=2.0)
+        sys.setswitchinterval(previous_interval)
+
+
+def test_the_signal_log_dies_with_the_connection():
+    """A relaunched arcade restarts `seq` at 1, so two runs must not share a log.
+
+    With both runs resident, a cursor holding an old-run number can match a
+    new-run entry and the fold spans a range that never existed.
+    """
+    port, _ = _serve_lines(
+        [json.dumps(_signalling_tick(i, dropped=5)).encode() + b"\n" for i in (1, 2)]
+    )
+    client = ArcadeStreamClient("127.0.0.1", port)
+    client.start()
+    try:
+        assert _wait_for(lambda: len(client.snapshot()[1]) == 2), "both ticks did not arrive"
+        assert _wait_for(lambda: client.snapshot()[1] == ()), (
+            "the log outlived the socket that produced it"
+        )
+        assert client.latest is not None, (
+            "the last payload is KEPT - a frozen board is still readable, and the "
+            "windows render it dimmed; only the continuity signals are dropped"
+        )
+    finally:
+        client.stop()
 
 
 # --- Trap 2: closing one window must not stop the shared client --------------

--- a/tests/surfaces/test_pitwall_host.py
+++ b/tests/surfaces/test_pitwall_host.py
@@ -16,7 +16,6 @@ import socket
 import sys
 import threading
 import time
-from collections import deque
 from pathlib import Path
 
 import pytest


### PR DESCRIPTION
## What

`rewound` and `dropped` now survive a tick the host's latest-payload slot discarded before any window polled for it.

## Why

They describe the gap BETWEEN two ticks rather than the state of one, so the slot, which is right to keep only the newest snapshot, was wrong to drop them with the tick that carried them. `FrameClock` then reported `continuous` across the hole and the trace buffer kept appending samples from unrelated parts of the race.

Measured on the real path: real Melbourne session, real `TelemetryStreamServer` driven by the real `_broadcast_if_due`, real TCP socket, real `ArcadeStreamClient`, polled the way `useTick` polls. Same probe, same population, only the code differs.

| window under load, 250 ms poll | before | after |
|---|---|---|
| dropped frames served / published | 354,589 / 985,510 | 985,510 / 985,510 |
| rewind ticks served / published | 26 / 66 | 66 / 66 |

At the product's own 100 ms cadence the old path still lost 19,767 dropped frames of 985,510. In that run 73 of 117 signalling ticks were never served to the window.

## How

The client keeps a bounded log (64 entries, 6.4 s at 10 Hz) of every tick's continuity flags beside the slot, and `get_tick` folds the entries the caller missed into the payload it serves.

Four constraints, each a wrong implementation that a guard now pins:

- `snapshot()` reads the slot and the log under ONE lock acquisition. Two let a publish land between them; the fold then picks up ticks newer than the payload being served while the cursor only advances to that payload, so the same entries are folded again next poll. Measured over-count: 66%.
- The fold lands on a per-call copy, three levels deep. `get_tick` hands every caller the same dict object, so an in-place fold lets one window rewrite the block another is still holding.
- The range is keyed on a monotonic arrival index, never on `seq`. `seq` restarts at 1 when the arcade relaunches, and a range keyed on it either excludes every new-run entry or matches twice.
- `dropped` SUMS, `rewound` ORs.

**Not the drain-once pending slot the issue proposed.** `get_tick` has more than one cursor: `useTick`, `get_agents_view` at `host.py:189`, and the loopback server's `/api/tick`. A slot the first caller clears starves the rest, and AGENTS never reading the flags does not save it, because the drain rather than the consumption is what empties it. That is #950 in another field.

Also: the two test files each carried their own `_FakeClient` with the same docstring, and only one learned about `snapshot()`. Both deleted for one shared fake in `tests/surfaces/fake_stream_client.py`, faithful about the three things that matter (slot and log move together, the log is bounded by the real depth, entries come from the real `_signals_of`).

## Out of scope

The producer's supersede-drop, the second discard site the issue names. Measured on the shipped topology of one subscriber: **0 of 150 ticks superseded** with 38 of them signalling, worst full sender job 25.71 ms on the 581 KB forward-jump class against a 100 ms enqueue interval. It crosses the interval only with two subscribers stalling on the same tick (measured 120.35 ms), and a stalled subscriber is pruned within about 3 ticks.

A clean caller-side fold-forward fix does exist there, contrary to what the first draft of this design claimed. It is recorded in the issue with the numbers so the next person inherits the option rather than a false impossibility.

## Checks

- `tests/surfaces/` **285 passed**, up from 278.
- Seven mutants, each a different wrong implementation, every one driven RED and restored byte-identical: single-slot, drain-once, fold-in-place, dropped-not-summed, fabricated-fallback, two-lock-snapshot, log-outlives-socket.
- The atomicity guard survived its own mutant on the first attempt and was rewritten to run the race against a contending publisher, then went red.
- `ruff check` and `ruff format --check` clean, repo-wide.

Closes #1060
