### PR TITLE
feat(pitwall): per-driver trace accumulation, selection at render

### DIFF
--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -114,6 +114,10 @@ function tick(
     drivers = null,
     order = null,
     colors = null,
+    // Per-driver spans, verbatim. `main`/`rivalSpan` cover the two-car scenarios
+    // this harness was built for; a scenario about WHICH car is charted needs to
+    // fill a third, so it hands the whole map instead.
+    spans = null,
   } = {},
 ) {
   const field = drivers ?? { NOR: driver(mainDriver), PIA: driver() };
@@ -149,12 +153,14 @@ function tick(
       // because that is what a DATA scenario is about, and files them under
       // the codes the window looks them up by.
       telemetry: {
-        drivers: Object.fromEntries(
-          Object.keys(field).map((code) => [
-            code,
-            spanFor(code, rival, main, rivalSpan),
-          ]),
-        ),
+        drivers:
+          spans ??
+          Object.fromEntries(
+            Object.keys(field).map((code) => [
+              code,
+              spanFor(code, rival, main, rivalSpan),
+            ]),
+          ),
         rewound,
         dropped,
       },
@@ -4005,6 +4011,139 @@ check(
     after === before,
     `returning to TRACES keeps the whole lap, not just what arrived after (${after} vs ${before})`,
   );
+  await ctx.close();
+}
+
+// --- Scenario: the rival changes MID-LAP, and no sample of the old one survives -
+//
+// The accumulator used to key two buffers by ROLE. That was safe only while the
+// producer could not change its mind - `_driver_rival` is assigned once, at
+// construction - and re-pointing the rival mid-lap left the previous car's
+// samples sitting in the same distance-keyed map, so `deltaSeries` interpolated
+// across the seam and drew a delta against a car that was half one driver and
+// half another (#1050).
+//
+// Every driver here carries a DISTINGUISHABLE signature, in both channels the
+// assertions read. R1's exit gate measured why: a fixture that hands every car
+// identical values makes an identity claim unfalsifiable, and a producer serving
+// all twenty the same car's frames passed 277 tests.
+{
+  const SWITCH_LAP = 24;
+  // main t: 100->10 ... 600->15, one second per hundred metres.
+  const lapSpan = (xs, tAt, speedBase) =>
+    xs.map((dist, i) => ({
+      lap: SWITCH_LAP,
+      t: tAt(dist),
+      dist,
+      speed: speedBase + i,
+      throttle: 50,
+      brake: 0,
+      gear: 6,
+      drs: 8,
+    }));
+  const FIRST = [100, 200, 300];
+  const SECOND = [400, 500, 600];
+  const mainT = (dist) => 10 + (dist - 100) / 100;
+  // PIA sits +2.0 s behind the main car for the whole lap, VER +5.0 s. The two
+  // offsets are what make a surviving PIA sample visible in the delta.
+  const piaT = (dist) => mainT(dist) + 2;
+  const verT = (dist) => mainT(dist) + 5;
+
+  const field = { NOR: driver(), PIA: driver(), VER: driver() };
+  const beforeSwitch = tick(1, {
+    rival: "PIA",
+    drivers: field,
+    spans: {
+      NOR: lapSpan(FIRST, mainT, 200),
+      PIA: lapSpan(FIRST, piaT, 300),
+      VER: lapSpan(FIRST, verT, 400),
+    },
+  });
+  const afterSwitch = tick(2, {
+    rival: "VER",
+    drivers: field,
+    spans: {
+      NOR: lapSpan(SECOND, mainT, 203),
+      PIA: lapSpan(SECOND, piaT, 303),
+      VER: lapSpan(SECOND, verT, 403),
+    },
+  });
+
+  const ctx = await browser.newContext({ viewport: CLIENT });
+  const page = await ctx.newPage();
+  watchPage(page, failures);
+  await page.addInitScript((payloads) => {
+    window.__ticks = payloads;
+    window.__cursor = 0;
+    window.pywebview = {
+      api: {
+        get_tick: async (sinceSeq) => {
+          if (window.__ticks[window.__cursor].seq === sinceSeq) {
+            if (window.__cursor + 1 >= window.__ticks.length) return null;
+            window.__cursor += 1;
+          }
+          return window.__ticks[window.__cursor];
+        },
+        get_bulk: async () => null,
+        get_live_lap: async () => null,
+        get_connection: async () => ({ label: "Connected", colour: "#10b981" }),
+      },
+    };
+  }, [beforeSwitch, afterSwitch]);
+
+  await page.goto(url, { waitUntil: "domcontentloaded" });
+  await page.waitForSelector(".trace-stack-plot canvas", { timeout: 5000 });
+  // Long enough for BOTH ticks to be polled and folded in, which is the whole
+  // scenario: one tick alone cannot mix two cars.
+  await page.waitForTimeout(600);
+
+  const series = (lane, car) =>
+    page.evaluate(
+      ([which, side]) => {
+        const el = document.querySelector(".trace-stack-plot");
+        const found = el.__pitwallChart
+          .getOption()
+          .series.find((s) => s.name === `${which}-${side}`);
+        return found ? found.data : null;
+      },
+      [lane, car],
+    );
+
+  const switched = await series("delta", "rival");
+  const values = switched.map(([, value]) => value);
+  check(
+    values.length === 6,
+    `the newly pinned car is charted back to the start of the lap, not from the switch (${values.length} of 6)`,
+  );
+  check(
+    values.every((value) => Math.abs(value - 5) < 1e-9),
+    `every delta point is VER's +5.0 s (${JSON.stringify(values)})`,
+  );
+  check(
+    !values.some((value) => Math.abs(value - 2) < 1e-9),
+    `no sample of the PREVIOUS rival survives in the delta (${JSON.stringify(values)})`,
+  );
+
+  // The identity check the delta cannot make on its own: read the OWNER off the
+  // plotted values. VER's speeds run 400.., PIA's 300.., so a chart still holding
+  // the old rival's samples shows it here even if the arithmetic happened to agree.
+  const speeds = (await series("speed", "rival")).map(([, value]) => value);
+  check(
+    speeds.length === 6 && speeds.every((value) => value >= 400),
+    `the rival speed trace is VER's throughout (${JSON.stringify(speeds)})`,
+  );
+  check(
+    !speeds.some((value) => value >= 300 && value < 400),
+    `not one of PIA's speed samples is left in it (${JSON.stringify(speeds)})`,
+  );
+
+  // The main car is untouched by the switch.
+  const mainSpeeds = (await series("speed", "main")).map(([, value]) => value);
+  check(
+    mainSpeeds.length === 6 && mainSpeeds.every((value) => value < 300),
+    `the main trace keeps its own six samples (${JSON.stringify(mainSpeeds)})`,
+  );
+
   await ctx.close();
 }
 

--- a/src/pitwall/ui/src/features/data/DataWindow.tsx
+++ b/src/pitwall/ui/src/features/data/DataWindow.tsx
@@ -60,7 +60,15 @@ export function DataWindow() {
   // the wire carries only the span since the last tick and cannot backfill. This
   // component sees every tick whichever tab is showing, so ingestion continues
   // while the panel is away.
-  const traceFrame = useTraceFrame(tick, discontinuity);
+  // **Resolved ONCE, here, and passed down.** The rival has four consumers on
+  // this window - this hook's selection, the header chip, the BROADCAST tag's
+  // blind-note, and the ring's label placement - and each used to read
+  // `tick.arcade.driver_rival` for itself. Four independent reads agree only
+  // while there is one possible answer; the moment the tower can pin a car
+  // (#1051) any consumer left reading the tick shows a different rival from the
+  // rest, inside one window. One value passed down cannot disagree with itself.
+  const rival = tick?.arcade.driver_rival ?? null;
+  const traceFrame = useTraceFrame(tick, discontinuity, rival);
   const connection = useConnection();
   const bulk = useBulk();
   const liveLap = useLiveLap();
@@ -134,10 +142,10 @@ export function DataWindow() {
               {tab === "traces" && (
                 <div className="band4">
                   {traceFrame && (
-                    <OwnCarTraces tick={tick} frame={traceFrame} frozen={frozen} />
+                    <OwnCarTraces tick={tick} frame={traceFrame} rival={rival} frozen={frozen} />
                   )}
                   <div className="side-column">
-                    <TrackRing arcade={tick.arcade} />
+                    <TrackRing arcade={tick.arcade} rival={rival} />
                     <RadioFeed bulk={bulk} driverMain={tick.arcade.driver_main} />
                   </div>
                 </div>

--- a/src/pitwall/ui/src/features/data/OwnCarTraces.tsx
+++ b/src/pitwall/ui/src/features/data/OwnCarTraces.tsx
@@ -58,13 +58,22 @@ interface OwnCarTracesProps {
    * nothing on the wire able to rebuild it.
    */
   frame: TraceFrame;
+  /**
+   * The car being compared against, resolved by `DataWindow`.
+   *
+   * A prop rather than `arcade.driver_rival` read here, and the same for the
+   * header below. This file held TWO independent reads of that field, so
+   * converting one would have left the header saying `vs PIA · BROADCAST`, and
+   * computing its NO-POSITION warning against PIA, above a chart plotting the
+   * pinned car.
+   */
+  rival: string | null;
   /** The producer is gone; these buffers will not fill. */
   frozen?: boolean;
 }
 
-export function OwnCarTraces({ tick, frame, frozen = false }: OwnCarTracesProps) {
+export function OwnCarTraces({ tick, frame, rival, frozen = false }: OwnCarTracesProps) {
   const { arcade } = tick;
-  const rivalCode = arcade.driver_rival;
 
   // The X lock is derived here because `circuit_length_m` rides on every tick, so
   // unlike Qt there is no first-time flag to hold. The BUFFERS are not derived
@@ -98,13 +107,13 @@ export function OwnCarTraces({ tick, frame, frozen = false }: OwnCarTracesProps)
 
   return (
     <section className="traces card">
-      <TracesHeader tick={tick} />
+      <TracesHeader tick={tick} rival={rival} />
       <TraceStack
         main={frame.main}
         rival={frame.rival}
         delta={frame.delta}
         xMax={xMax}
-        rivalCode={rivalCode}
+        rivalCode={rival}
         cursorX={cursorX}
         // ONE caption over the whole stack, where the 2x2 printed the same sentence
         // four times. It claims starvation only when the MAIN trace is starved: a
@@ -119,9 +128,8 @@ export function OwnCarTraces({ tick, frame, frozen = false }: OwnCarTracesProps)
 }
 
 /** `LAP 24  NOR vs PIA`, plus the note for a car the telemetry never placed. */
-function TracesHeader({ tick }: { tick: Tick }) {
+function TracesHeader({ tick, rival: rivalCode }: { tick: Tick; rival: string | null }) {
   const { arcade } = tick;
-  const rivalCode = arcade.driver_rival;
   // BOTH charted drivers, not just the main one. Reading the main alone left
   // a header saying nothing was wrong above an empty rival trace when the
   // blind car was the one being compared against (#856).

--- a/src/pitwall/ui/src/features/data/TrackRing.tsx
+++ b/src/pitwall/ui/src/features/data/TrackRing.tsx
@@ -63,7 +63,7 @@ function rgb(colour: [number, number, number] | undefined): string {
   return colour ? `rgb(${colour[0]}, ${colour[1]}, ${colour[2]})` : "var(--qt-fg-2)";
 }
 
-export function TrackRing({ arcade }: { arcade: ArcadeState }) {
+export function TrackRing({ arcade, rival }: { arcade: ArcadeState; rival: string | null }) {
   // The two labelled cars go on OPPOSITE sides of their dots. They are the
   // main driver and the car chosen to compare against, so they are routinely
   // seconds apart - on the session this was built against, NOR and PIA sit
@@ -72,7 +72,7 @@ export function TrackRing({ arcade }: { arcade: ArcadeState }) {
   // deterministic, so the same car is always in the same place.
   const labelSide = (code: string): "above" | "below" | null => {
     if (code === arcade.driver_main) return "above";
-    if (code === arcade.driver_rival) return "below";
+    if (code === rival) return "below";
     return null;
   };
 

--- a/src/pitwall/ui/src/features/data/traceBuffer.ts
+++ b/src/pitwall/ui/src/features/data/traceBuffer.ts
@@ -52,47 +52,82 @@ export interface SortedTrace {
 
 const EMPTY: SortedTrace = { xs: [], rows: [] };
 
+/**
+ * One buffer per DRIVER, with the comparison chosen at render (#1050).
+ *
+ * It used to key two buffers by ROLE - `main` and `rival` - and that was safe
+ * only because the producer cannot change its mind: `_driver_rival` is assigned
+ * once, at construction (`src/arcade/app.py:236`). The tower's pin introduces the
+ * mid-lap switch, and re-pointing a role-keyed buffer leaves the old car's
+ * samples in the same distance-keyed map: `deltaSeries` then interpolates across
+ * the seam and draws a delta against a car that is half one driver and half
+ * another.
+ *
+ * Accumulating every driver removes the question. The newly pinned car's trace is
+ * already populated back to the start of the main driver's current lap, because
+ * it was being kept all along, and the lap is the buffer's whole horizon anyway -
+ * the wire carries only the span since the last tick and cannot backfill.
+ *
+ * Cost: twenty spans of `FPS x speed / 10 Hz` samples, so about 400 `Map.set`
+ * calls a tick at 8x against 40 before, and 5,000 on a capped forward jump. On
+ * integer keys that is sub-millisecond beside the ECharts render it feeds.
+ */
 export class TraceAccumulator {
-  private main = new Map<number, TraceRow>();
-  private rival = new Map<number, TraceRow>();
+  private buffers = new Map<string, Map<number, TraceRow>>();
   private currentLap: number | null = null;
 
   /** Fold one tick's spans in. Safe to call twice with the same tick. */
-  ingest(main: TelemetrySample[], rival: TelemetrySample[], evict: boolean): void {
+  ingest(spans: Record<string, TelemetrySample[]>, mainCode: string, evict: boolean): void {
     if (evict) this.clear();
 
-    // Per sample, not per tick: at 8x a single span crosses the start line.
-    for (const sample of main) {
+    // The MAIN driver's span runs first and to completion, then everyone else is
+    // compared against the lap it left behind. That ordering is inherited rather
+    // than incidental: reading it as "store a sample while its driver is on the
+    // current lap" is a different algorithm, interleaved in time, and the two
+    // agree only because the lap-change clear wipes the old lap anyway.
+    for (const sample of spans[mainCode] ?? []) {
       const lap = Math.trunc(sample.lap || 0);
       if (lap !== this.currentLap) {
         this.currentLap = lap;
-        this.main.clear();
-        this.rival.clear();
+        this.buffers.clear();
       }
-      store(this.main, sample);
+      store(this.bufferFor(mainCode), sample);
     }
 
-    for (const sample of rival) {
-      if (Math.trunc(sample.lap || 0) === this.currentLap) store(this.rival, sample);
+    for (const [code, span] of Object.entries(spans)) {
+      if (code === mainCode) continue;
+      for (const sample of span) {
+        // Same rule the single rival has always been held to: a car on another
+        // lap carries an unrelated `t`, and mixing those into one distance-keyed
+        // store spikes the delta interpolation by 4-6 s.
+        if (Math.trunc(sample.lap || 0) === this.currentLap) store(this.bufferFor(code), sample);
+      }
     }
   }
 
   clear(): void {
-    this.main.clear();
-    this.rival.clear();
+    this.buffers.clear();
     this.currentLap = null;
   }
 
-  get mainTrace(): SortedTrace {
-    return sorted(this.main);
-  }
-
-  get rivalTrace(): SortedTrace {
-    return sorted(this.rival);
+  /** One driver's accumulated lap, or the empty trace for a car with nothing. */
+  trace(code: string | null): SortedTrace {
+    if (code === null) return EMPTY;
+    const buffer = this.buffers.get(code);
+    return buffer === undefined ? EMPTY : sorted(buffer);
   }
 
   get lap(): number | null {
     return this.currentLap;
+  }
+
+  private bufferFor(code: string): Map<number, TraceRow> {
+    let buffer = this.buffers.get(code);
+    if (buffer === undefined) {
+      buffer = new Map<number, TraceRow>();
+      this.buffers.set(code, buffer);
+    }
+    return buffer;
   }
 }
 

--- a/src/pitwall/ui/src/features/data/useTraceFrame.ts
+++ b/src/pitwall/ui/src/features/data/useTraceFrame.ts
@@ -32,36 +32,44 @@ export interface TraceFrame {
   delta: ReturnType<typeof deltaSeries>;
 }
 
-export function useTraceFrame(tick: Tick | null, discontinuity: Discontinuity): TraceFrame | null {
+export function useTraceFrame(
+  tick: Tick | null,
+  discontinuity: Discontinuity,
+  /**
+   * The car to compare against, ALREADY RESOLVED by the caller.
+   *
+   * Not `tick.arcade.driver_rival` read here. This hook is one of the four sites
+   * that choose the rival, and the pin has to reach every one of them or the
+   * window shows two: a version that kept reading the tick here would have left
+   * the header, the chip and the ring following the pin while the CHART kept
+   * plotting the broadcast rival (#1051).
+   */
+  rivalCode: string | null,
+): TraceFrame | null {
   const accumulator = useRef(new TraceAccumulator());
 
-  // Keyed on the sequence, so one tick is folded in once per tick even though
-  // StrictMode runs this factory twice - `ingest` is idempotent for exactly that
-  // reason.
+  // Keyed on the sequence AND the pinned code. The sequence folds each tick in
+  // once even though StrictMode runs this factory twice (`ingest` is idempotent
+  // for exactly that reason, including the evict path: a clear plus a re-fold of
+  // the same spans reproduces the state). The code is here for the SELECTION,
+  // which is the half that changes without a new tick.
   return useMemo(() => {
     if (!tick) return null;
-    const { telemetry, driver_main, driver_rival } = tick.arcade;
+    const { telemetry, driver_main } = tick.arcade;
     // The producer's own eviction signals, plus the clock's - `FrameClock` sees a
     // backwards jump smaller than one broadcast that the flags miss.
     const evict =
       telemetry.rewound || telemetry.dropped > 0 || discontinuity.kind !== "continuous";
-    // Schema v2 puts a span under every driver code, so the pair this panel
-    // charts is a LOOKUP rather than two fixed keys (#1048). `?? []` is not
-    // defensive padding: single-driver mode has no rival at all, and the
-    // accumulator's rival map is meant to stay empty then.
-    //
-    // Selecting here rather than accumulating per driver is deliberate for
-    // now: switching the pinned car mid-lap would mix two cars' samples in one
-    // distance-keyed map, and the fix for that is per-driver buffers with the
-    // choice applied at render (#1050), which is R2's subject.
-    accumulator.current.ingest(
-      telemetry.drivers[driver_main] ?? [],
-      driver_rival ? (telemetry.drivers[driver_rival] ?? []) : [],
-      evict,
-    );
-    const main = accumulator.current.mainTrace;
-    const rival = accumulator.current.rivalTrace;
+    // Every driver on the wire is accumulated; the comparison is a LOOKUP at
+    // render (#1050). Selecting at ingest was safe only while the producer could
+    // not switch rivals, and the tower's pin is exactly that switch.
+    accumulator.current.ingest(telemetry.drivers, driver_main, evict);
+    const main = accumulator.current.trace(driver_main);
+    // Null in single-driver mode, which is a real state and not padding: the
+    // rival trace is meant to be empty there, and `TraceStack` renders its own
+    // placeholder for it.
+    const rival = accumulator.current.trace(rivalCode);
     return { main, rival, delta: deltaSeries(main, rival) };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tick?.seq]);
+  }, [tick?.seq, rivalCode]);
 }


### PR DESCRIPTION
## What

The trace accumulator keeps one buffer per DRIVER, and the car being compared against is chosen at render.

## Why

It kept two buffers keyed by ROLE. That was safe only because the producer cannot change its mind: `_driver_rival` is assigned once, at construction (`src/arcade/app.py:236`). Re-pointing the rival mid-lap left the previous car's samples sitting in the same distance-keyed map, so `deltaSeries` interpolated across the seam and drew a delta against a car that was half one driver and half another.

**Driven RED first.** Against the role-keyed accumulator the new scenario produces the chimera exactly:

```
delta         [2, 2, 2, 5, 5, 5]                 three of PIA's samples, three of VER's
rival speed   [300, 301, 302, 403, 404, 405]
```

After the change both are VER's alone: every delta point +5.0 s, every rival speed sample in the 400s.

## How

Every driver on the wire is accumulated; the comparison is a lookup. The newly chosen car is already charted back to the start of the main driver's current lap, because it was being kept all along, and the lap is the buffer's whole horizon anyway (the wire carries only the span since the last tick and cannot backfill).

**The lap rule is preserved including its ordering.** The main driver's span runs first and to completion, then every other driver is compared against the lap it left behind. Reading it as "store a sample while its driver is on the current lap" is a different algorithm, interleaved in time; the two agree only because the lap-change clear wipes the old lap anyway.

**The rival is resolved once, in `DataWindow`, and passed down.** It had FOUR consumers, not the three the plan claimed:

| site | what it does |
|---|---|
| `useTraceFrame.ts:43` | selects the span that becomes the chart |
| `OwnCarTraces.tsx:67` | passes `rivalCode` to `TraceStack` |
| `OwnCarTraces.tsx:124` (`TracesHeader`, same file) | the chip, the BROADCAST tag, the blind note |
| `TrackRing.tsx:75` | which side the label goes |

`TraceStack` was on the plan's list and reads nothing, it already took a prop. `useTraceFrame` was missing from it and is the one that decides what the chart plots, so a guard over the named three would have gone green with the chart still following the broadcast rival while the header, the chip and the ring followed the pin. `OwnCarTraces.tsx` is two components with two independent reads; converting one would have left `vs PIA · BROADCAST` above a chart plotting another car.

Enumerated by typed AST over the 45-file program, non-emptiness asserted before the list was believed.

Every driver in the new fixture carries a distinguishable signature in both channels the assertions read. R1's exit gate measured why: identical fixture values make an identity claim unfalsifiable, and a producer serving all twenty the same car's frames passed 277 tests.

## Out of scope

The pin itself is #1051. This PR changes where the value comes from, not what it can be, so the rendered window is unchanged.

## Cost

About 400 `Map.set` calls a tick at 8x against 40 before, and 5,000 on a capped forward jump. Sub-millisecond on integer keys, beside the ECharts render it feeds.

## Checks

- `smoke-data` **239 checks**, up from 233 · `smoke-agents` 65 · `tests/surfaces/` 285.
- The mid-lap-switch scenario driven RED against the code it replaces, files restored from copies and verified byte-identical with `cmp`.
- `#1056` untouched and still covered: the accumulator ref stays in the hook `DataWindow` calls unconditionally, above the tab conditional, so leaving TRACES still keeps the rest of the lap. That scenario is in the smoke and passes.
- `tsc` clean (checked with `grep -c "error TS"` before believing any smoke result), `ruff` check and format clean.

Closes #1050
