### PR TITLE
feat(pitwall): the tower row pins the broadcast rival

### DIFF
--- a/src/pitwall/ui/scripts/shot-data.mjs
+++ b/src/pitwall/ui/scripts/shot-data.mjs
@@ -33,8 +33,13 @@ import { serveDist } from "./serve-dist.mjs";
 import { watchPage } from "./page-guard.mjs";
 
 const UI_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const TICKS = JSON.parse(readFileSync(process.argv[2], "utf-8"));
-const OUT = resolve(process.argv[3] ?? resolve(UI_DIR, "data.png"));
+const ARGV = process.argv.slice(2).filter((a) => !a.startsWith("--"));
+// `--pin=VER` clicks that tower row before the shot, so a capture can show the
+// selector's own state (#1051). Without it the window is captured following the
+// producer's rival, which is what every earlier DATA shot shows.
+const PIN = (process.argv.find((a) => a.startsWith("--pin=")) ?? "").slice(6) || null;
+const TICKS = JSON.parse(readFileSync(ARGV[0], "utf-8"));
+const OUT = resolve(ARGV[1] ?? resolve(UI_DIR, "data.png"));
 // The client area the product really hands this page, NOT the `WindowSpec`
 // size. `place()` opens DATA at 1500x870 on the reference desktop and the OS
 // keeps 14 px of frame and 37 px of title bar, so the page gets 1486x833. The
@@ -42,8 +47,8 @@ const OUT = resolve(process.argv[3] ?? resolve(UI_DIR, "data.png"));
 // wider than the window it claimed to show. `smoke-data.mjs` was already close
 // to the real client, which is how the two disagreed.
 const CLIENT = { width: 1486, height: 833 };
-const WIDTH = Number(process.argv[4] ?? CLIENT.width);
-const HEIGHT = Number(process.argv[5] ?? CLIENT.height);
+const WIDTH = Number(ARGV[2] ?? CLIENT.width);
+const HEIGHT = Number(ARGV[3] ?? CLIENT.height);
 
 const ticks = Array.isArray(TICKS) ? TICKS : [TICKS];
 const server = await serveDist(resolve(UI_DIR, "dist"));
@@ -94,9 +99,28 @@ await page.waitForFunction(() => window.__cursor + 1 >= window.__ticks.length, n
 });
 await page.waitForTimeout(250);
 
+if (PIN !== null) {
+  // Clicked, not injected: the point of capturing the pin is that the CONTROL
+  // works, and setting React state from outside would photograph a state no
+  // reader can reach.
+  await page.locator(".tower-row").filter({ hasText: PIN }).first().click();
+  await page.waitForTimeout(400);
+  const pinned = await page.evaluate(() =>
+    [...document.querySelectorAll(".tower-row[aria-selected='true']")].map((row) =>
+      row.querySelector(".col-drv").textContent.trim(),
+    ),
+  );
+  if (pinned.length !== 1 || pinned[0] !== PIN) {
+    failures.push(`--pin=${PIN} did not take (aria-selected: ${JSON.stringify(pinned)})`);
+  }
+}
+
 const consumed = await page.evaluate(() => window.__cursor + 1);
 await page.screenshot({ path: OUT, fullPage: false });
-console.log(`shot-data: ${consumed}/${ticks.length} ticks replayed -> ${OUT}`);
+console.log(
+  `shot-data: ${consumed}/${ticks.length} ticks replayed` +
+    `${PIN ? `, pinned ${PIN}` : ""} -> ${OUT}`,
+);
 
 await context.close();
 await browser.close();

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -4147,6 +4147,271 @@ check(
   await ctx.close();
 }
 
+// --- Scenario: the tower row pins the broadcast rival (#1051) ----------------
+//
+// The pin has to reach ALL FOUR consumers of the chosen rival or one window
+// shows two: the chart's selection (`useTraceFrame`), the header chip, the
+// header's blind-note, and the ring's label placement. The assertions below run
+// over the WHOLE driver enumeration rather than one example, because a bug that
+// happens to work for the second car in the order is the one that ships.
+//
+// Every driver carries its own speed band, so "which car is plotted" is read off
+// the SERVED value rather than inferred from the code the header prints.
+{
+  const LAP = 30;
+  const FIELD = ["NOR", "PIA", "VER", "LEC", "RUS"];
+  const RETIRED = "SAI";
+  // A car that is RUNNING and sends nothing on this lap - the common case once
+  // the tower can pin anyone, measured at five of seven on real Melbourne ticks.
+  const FAR = "HAM";
+  const bandFor = (code) => (FIELD.indexOf(code) + 3) * 100;
+  const XS = [100, 200, 300, 400];
+  const spanOf = (code) =>
+    XS.map((dist, i) => ({
+      lap: LAP,
+      t: 10 + (dist - 100) / 100 + FIELD.indexOf(code),
+      dist,
+      speed: bandFor(code) + i,
+      throttle: 50,
+      brake: 0,
+      gear: 6,
+      drs: 8,
+    }));
+
+  const field = Object.fromEntries([
+    ...FIELD.map((code) => [code, driver({ lap: LAP })]),
+    // A car that stopped. It renders in the tower and must NOT be a keyboard
+    // stop or a pin target: the pin releases on retirement, so allowing it
+    // would be a state the next tick undoes.
+    [RETIRED, driver({ lap: LAP, active: false, has_finished: false })],
+    [FAR, driver({ lap: LAP })],
+  ]);
+  const spans = Object.fromEntries([
+    ...FIELD.map((code) => [code, spanOf(code)]),
+    [RETIRED, []],
+    [FAR, []],
+  ]);
+  // The retired car sits BETWEEN two selectable rows, not at the end. At the end
+  // nothing can be observed to skip over it: ArrowDown from the row before would
+  // land on the same place either way. Here PIA -> VER only works if SAI is
+  // skipped, so the keyboard block below doubles as the skip guard.
+  const order = ["NOR", "PIA", RETIRED, "VER", "LEC", "RUS", FAR];
+  const pinTick = (seq, extra = {}) =>
+    tick(seq, { rival: "PIA", drivers: field, spans, order, ...extra });
+
+  const ctx = await browser.newContext({ viewport: CLIENT });
+  const page = await ctx.newPage();
+  watchPage(page, failures);
+  await page.addInitScript((payloads) => {
+    window.__ticks = payloads;
+    window.__cursor = 0;
+    window.pywebview = {
+      api: {
+        get_tick: async (sinceSeq) => {
+          if (window.__ticks[window.__cursor].seq === sinceSeq) {
+            if (window.__cursor + 1 >= window.__ticks.length) return null;
+            window.__cursor += 1;
+          }
+          return window.__ticks[window.__cursor];
+        },
+        get_bulk: async () => null,
+        get_live_lap: async () => null,
+        get_connection: async () => ({ label: "Connected", colour: "#10b981" }),
+      },
+    };
+  }, [pinTick(1)]);
+
+  await page.goto(url, { waitUntil: "domcontentloaded" });
+  await page.waitForSelector(".trace-stack-plot canvas", { timeout: 5000 });
+  await page.waitForTimeout(400);
+
+  /** What every consumer of the chosen rival currently says, in one read. */
+  const trio = () =>
+    page.evaluate(() => {
+      const el = document.querySelector(".trace-stack-plot");
+      const series = el.__pitwallChart.getOption().series.find((s) => s.name === "speed-rival");
+      const chip = document.querySelector(".driver-chip-rival");
+      return {
+        // The plotted car, read off its values rather than off a label.
+        speeds: series ? series.data.map(([, value]) => value) : [],
+        chip: chip ? chip.textContent.trim() : null,
+        ringLabels: [...document.querySelectorAll(".ring-code")].map((n) => n.textContent),
+        pinnedRows: [...document.querySelectorAll(".tower-row[aria-selected='true']")].map((row) =>
+          row.querySelector(".col-drv").textContent.trim(),
+        ),
+      };
+    });
+
+  const rowFor = (code) => page.locator(".tower-row").filter({ hasText: code }).first();
+
+  // Every driver in the enumeration, pinned in turn, checked on all four.
+  for (const code of FIELD.filter((c) => c !== "NOR")) {
+    await rowFor(code).click();
+    await page.waitForTimeout(250);
+    const state = await trio();
+    const band = bandFor(code);
+    check(
+      state.speeds.length > 0 && state.speeds.every((v) => v >= band && v < band + 100),
+      `pinning ${code} plots ${code}'s own samples (${JSON.stringify(state.speeds)})`,
+    );
+    check(
+      state.chip !== null && state.chip.startsWith(code) && state.chip.includes("BROADCAST"),
+      `pinning ${code} labels the chip ${code} BROADCAST (${state.chip})`,
+    );
+    check(
+      state.ringLabels.length === 2 && state.ringLabels.includes(code),
+      `pinning ${code} moves the ring's second label to it (${JSON.stringify(state.ringLabels)})`,
+    );
+    check(
+      state.pinnedRows.length === 1 && state.pinnedRows[0] === code,
+      `exactly one row carries aria-selected, and it is ${code} (${JSON.stringify(state.pinnedRows)})`,
+    );
+  }
+
+  // --- The keyboard contract, driven with REAL key presses --------------------
+  const focused = () =>
+    page.evaluate(() => {
+      const row = document.activeElement?.closest?.(".tower-row");
+      return row ? row.querySelector(".col-drv").textContent.trim() : null;
+    });
+
+  // **Start from a KNOWN candidate, and never from the last row.** The handler
+  // moves the CANDIDATE, not whatever row happens to hold focus, and the
+  // enumeration loop above left RUS pinned - the last selectable row, where
+  // ArrowDown clamps to itself. An earlier version of this block focused LEC and
+  // asserted the arrows landed on RUS and back; both checks passed against a
+  // mutant that moved the candidate by ZERO, because the candidate was already
+  // where the assertions expected it to end up.
+  await rowFor("PIA").click();
+  await page.waitForTimeout(250);
+  const stops = await page.evaluate(
+    () => document.querySelectorAll('.tower-row[tabindex="0"]').length,
+  );
+  check(stops === 1, `the tower is ONE tab stop under a roving tabindex (${stops})`);
+
+  await rowFor("PIA").focus();
+  check((await focused()) === "PIA", "the candidate row takes focus");
+  await page.keyboard.press("ArrowDown");
+  await page.waitForTimeout(150);
+  check((await focused()) === "VER", "ArrowDown moves the candidate one row down");
+  await page.keyboard.press("ArrowDown");
+  await page.waitForTimeout(150);
+  check((await focused()) === "LEC", "and again, so the move is not a one-off clamp");
+  await page.keyboard.press("ArrowUp");
+  await page.waitForTimeout(150);
+  check((await focused()) === "VER", "ArrowUp moves it back");
+  await page.keyboard.press("Enter");
+  await page.waitForTimeout(300);
+  check((await trio()).pinnedRows[0] === "VER", "Enter pins the candidate row");
+  await page.keyboard.press("Escape");
+  await page.waitForTimeout(300);
+  const cleared = await trio();
+  check(cleared.pinnedRows.length === 0, "Escape clears the pin");
+  check(
+    cleared.chip !== null && cleared.chip.startsWith("PIA"),
+    `and the window falls back to the producer's own rival (${cleared.chip})`,
+  );
+
+  // --- A retired car is not selectable ----------------------------------------
+  //
+  // **Not asserted through `tabindex`.** Every row that is not the candidate
+  // carries `tabindex="-1"`, selectable or not, so that attribute is invariant
+  // across exactly the thing being distinguished: a mutant making retired rows
+  // selectable left it at "-1" and the check passed. What separates them is the
+  // ABSENCE of `aria-selected` and the fact that the row does nothing when
+  // clicked - plus the skip, which the ArrowDown above already measures because
+  // the retired car sits BETWEEN two selectable rows in the order.
+  const retiredAria = await page.evaluate(
+    (code) =>
+      [...document.querySelectorAll(".tower-row")]
+        .find((row) => row.querySelector(".col-drv").textContent.trim() === code)
+        ?.hasAttribute("aria-selected"),
+    RETIRED,
+  );
+  check(
+    retiredAria === false,
+    `a retired row carries no aria-selected at all, rather than "false" (${retiredAria})`,
+  );
+
+  // --- A pinned car with nothing on this lap SAYS so ---------------------------
+  //
+  // Measured on real Melbourne ticks at lap 23 with NOR as the main car: of the
+  // seven cars that can be pinned, five contribute ZERO samples and one
+  // contributes eleven. Four silent axes under a control the reader has just
+  // used read as a broken window, so the header names the reason.
+  await rowFor(FAR).click();
+  await page.waitForTimeout(350);
+  const lapLine = await page.locator(".traces-lap").innerText();
+  check(
+    lapLine.includes(`${FAR} NOT ON THIS LAP YET`),
+    `a pinned car with no samples on this lap says so (${lapLine.trim()})`,
+  );
+  const rusSeries = (await trio()).speeds;
+  check(
+    rusSeries.length === 0,
+    `and it really has nothing to draw (${JSON.stringify(rusSeries)})`,
+  );
+  await page.keyboard.press("Escape");
+  await page.waitForTimeout(300);
+  const backToPia = await page.locator(".traces-lap").innerText();
+  check(
+    !backToPia.includes("NOT ON THIS LAP YET"),
+    `and the note clears with the pin (${backToPia.trim()})`,
+  );
+
+  const beforeClick = (await trio()).chip;
+  await rowFor(RETIRED).click();
+  await page.waitForTimeout(250);
+  check(
+    (await trio()).chip === beforeClick,
+    `clicking a retired row pins nothing (${(await trio()).chip} vs ${beforeClick})`,
+  );
+
+  // --- The pin SURVIVES a rewind ---------------------------------------------
+  // The eviction clears the accumulated samples, which is right; it must not
+  // clear the reader's CHOICE, which is not tick state.
+  await rowFor("VER").click();
+  await page.waitForTimeout(250);
+  await page.evaluate((payload) => {
+    window.__ticks.push(payload);
+  }, pinTick(2, { rewound: true }));
+  await page.waitForTimeout(500);
+  const afterRewind = await trio();
+  check(
+    afterRewind.pinnedRows.length === 1 && afterRewind.pinnedRows[0] === "VER",
+    `the pin survives a rewind (${JSON.stringify(afterRewind.pinnedRows)})`,
+  );
+
+  // --- The pin CLEARS when its car retires ------------------------------------
+  const retiredField = { ...field, VER: driver({ lap: LAP, active: false, has_finished: false }) };
+  await page.evaluate((payload) => {
+    window.__ticks.push(payload);
+  }, tick(3, { rival: "PIA", drivers: retiredField, spans, order }));
+  await page.waitForTimeout(600);
+  const afterRetire = await trio();
+  // **`pinnedRows` alone cannot see this, and a mutation proved it.** A retired
+  // row is not selectable, so it carries no `aria-selected` at all - a pin still
+  // HELD on it therefore reads as "no row is pinned" to that probe, which is the
+  // empty set answering a question about presence. The chip and the plotted
+  // values are what actually show whether the pin released.
+  check(
+    afterRetire.pinnedRows.length === 0,
+    `no row claims the pin once its car retires (${JSON.stringify(afterRetire.pinnedRows)})`,
+  );
+  check(
+    afterRetire.chip !== null && afterRetire.chip.startsWith("PIA"),
+    `band 4 goes back to naming the producer's rival (${afterRetire.chip})`,
+  );
+  const pia = bandFor("PIA");
+  check(
+    afterRetire.speeds.length > 0 &&
+      afterRetire.speeds.every((v) => v >= pia && v < pia + 100),
+    `and PLOTS it, read off the served values (${JSON.stringify(afterRetire.speeds)})`,
+  );
+
+  await ctx.close();
+}
+
 await browser.close();
 server.close();
 

--- a/src/pitwall/ui/src/features/data/DataWindow.tsx
+++ b/src/pitwall/ui/src/features/data/DataWindow.tsx
@@ -21,7 +21,7 @@
  * band-height-budget.md`; the drawn layout is in the project's memory.
  */
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { BestsPanel } from "./BestsPanel";
 import { OwnCarTraces } from "./OwnCarTraces";
@@ -32,6 +32,7 @@ import { RadioFeed } from "./RadioFeed";
 import { StatusStrip } from "./StatusStrip";
 import { TimingTower } from "./TimingTower";
 import { TrackRing } from "./TrackRing";
+import { driverStatus } from "../../lib/driverStatus";
 import { useBulk } from "../../lib/useBulk";
 import { useConnection } from "../../lib/useConnection";
 import { useLiveLap } from "../../lib/useLiveLap";
@@ -67,8 +68,26 @@ export function DataWindow() {
   // while there is one possible answer; the moment the tower can pin a car
   // (#1051) any consumer left reading the tick shows a different rival from the
   // rest, inside one window. One value passed down cannot disagree with itself.
-  const rival = tick?.arcade.driver_rival ?? null;
+  //
+  // `null` means FOLLOW THE PRODUCER, not "no rival". It cannot collide with a
+  // real choice because a driver code on the wire is a non-null non-empty
+  // string, which is the sentinel rule this repo has paid for twice: a defaulted
+  // position of 0 is a place a real car can be, and the leader then "found" the
+  // car that had just crashed.
+  const [pinned, setPinned] = useState<string | null>(null);
+  const rival = pinned ?? tick?.arcade.driver_rival ?? null;
   const traceFrame = useTraceFrame(tick, discontinuity, rival);
+
+  // The pin releases when its car retires, or when the code stops being on the
+  // wire at all - a relaunched arcade pointed at another race is the second
+  // case, and it is why the car is checked for existence before its status.
+  // Holding a pin on a car that is not racing would leave band 4 comparing
+  // against a frozen trace with nothing to say.
+  useEffect(() => {
+    if (pinned === null || !tick) return;
+    const car = tick.arcade.drivers[pinned];
+    if (!car || driverStatus(car) === "out") setPinned(null);
+  }, [pinned, tick]);
   const connection = useConnection();
   const bulk = useBulk();
   const liveLap = useLiveLap();
@@ -110,7 +129,13 @@ export function DataWindow() {
           // unavailable".
           <div className={frozen ? "data-main is-frozen" : "data-main"}>
             <div className="left-column">
-              <TimingTower arcade={tick.arcade} bulk={bulk} live={liveLap} />
+              <TimingTower
+                arcade={tick.arcade}
+                bulk={bulk}
+                live={liveLap}
+                pinned={pinned}
+                onPin={setPinned}
+              />
               <BestsPanel bulk={bulk} />
             </div>
             <div className="right-column">

--- a/src/pitwall/ui/src/features/data/OwnCarTraces.tsx
+++ b/src/pitwall/ui/src/features/data/OwnCarTraces.tsx
@@ -107,7 +107,7 @@ export function OwnCarTraces({ tick, frame, rival, frozen = false }: OwnCarTrace
 
   return (
     <section className="traces card">
-      <TracesHeader tick={tick} rival={rival} />
+      <TracesHeader tick={tick} rival={rival} rivalSamples={frame.rival.xs.length} />
       <TraceStack
         main={frame.main}
         rival={frame.rival}
@@ -127,8 +127,17 @@ export function OwnCarTraces({ tick, frame, rival, frozen = false }: OwnCarTrace
   );
 }
 
-/** `LAP 24  NOR vs PIA`, plus the note for a car the telemetry never placed. */
-function TracesHeader({ tick, rival: rivalCode }: { tick: Tick; rival: string | null }) {
+/** `LAP 24  NOR vs PIA`, plus the notes for a rival the chart cannot draw. */
+function TracesHeader({
+  tick,
+  rival: rivalCode,
+  rivalSamples,
+}: {
+  tick: Tick;
+  rival: string | null;
+  /** How many of the rival's samples landed on the main car's current lap. */
+  rivalSamples: number;
+}) {
   const { arcade } = tick;
   // BOTH charted drivers, not just the main one. Reading the main alone left
   // a header saying nothing was wrong above an empty rival trace when the
@@ -137,11 +146,31 @@ function TracesHeader({ tick, rival: rivalCode }: { tick: Tick; rival: string | 
     (code): code is string => !!code && arcade.drivers[code]?.has_position === false,
   );
 
+  /**
+   * The chosen rival has nothing on this lap, so its four overlays are empty.
+   *
+   * **The selector is what made this reachable, and it is not a defect in it.**
+   * A rival sample is kept only while that car is on the MAIN driver's current
+   * lap - the rule exists because mixing laps puts unrelated `t` next to each
+   * other in a distance-keyed store and spikes the delta interpolation by 4-6 s.
+   * Until the tower could pin a car, the only rival ever charted was the one the
+   * producer chose, and it sits seconds away. Measured on Melbourne lap 23 with
+   * NOR as the main car: PIA (+2.10 s) contributes 233 samples, VER (+10.88 s)
+   * eleven, and RUS, LEC, TSU, ALB and HAM none at all.
+   *
+   * So the note says WHY the lane is blank. Four silent axes under a control the
+   * reader has just used read as a broken window - the same argument this file
+   * already makes for the starved-trace placeholder, and for the blind-note
+   * above. Widening the horizon itself is a separate question (#1066).
+   */
+  const noOverlap = rivalCode !== null && rivalSamples < 2 && !blind.includes(rivalCode);
+
   return (
     <header className="traces-header">
       <span className="traces-lap">
         {arcade.lap ? `LAP ${arcade.lap}` : "LAP —"}
         {blind.length ? `  ·  NO POSITION DATA (${blind.join(", ")})` : ""}
+        {noOverlap ? `  ·  ${rivalCode} NOT ON THIS LAP YET` : ""}
       </span>
       <span className="driver-chip driver-chip-main">{arcade.driver_main || "—"}</span>
       {rivalCode ? (

--- a/src/pitwall/ui/src/features/data/TimingTower.tsx
+++ b/src/pitwall/ui/src/features/data/TimingTower.tsx
@@ -24,6 +24,8 @@
  * once, rather than each of the forty cells repeating it.
  */
 
+import { useEffect, useRef, useState } from "react";
+
 import type { ArcadeState, Bulk, DriverLaps, LapRow, LiveLap } from "../../lib/bridge";
 import { driverStatus, type DriverStatus } from "../../lib/driverStatus";
 import { formatSeconds } from "../../lib/format";
@@ -34,9 +36,24 @@ interface TimingTowerProps {
   arcade: ArcadeState;
   bulk: Bulk | null;
   live: LiveLap | null;
+  /** The pinned rival, or null while the window follows the producer's choice. */
+  pinned: string | null;
+  onPin: (code: string | null) => void;
 }
 
-export function TimingTower({ arcade, bulk, live }: TimingTowerProps) {
+/**
+ * The car's status, with the tower's own missing-car guard.
+ *
+ * `driverStatus` takes a car, and a code in `race_order` can have no entry in
+ * `drivers` - a relaunched arcade pointed at another race with a pin still set is
+ * the reachable case. The bare call reads `undefined.active` there.
+ */
+function statusOf(arcade: ArcadeState, code: string): DriverStatus {
+  const car = arcade.drivers[code];
+  return car ? driverStatus(car) : "out";
+}
+
+export function TimingTower({ arcade, bulk, live, pinned, onPin }: TimingTowerProps) {
   const order = arcade.race_order;
   const leader = order[0];
   // The same reduction the bests panel ranks, from the same module. Two
@@ -44,9 +61,82 @@ export function TimingTower({ arcade, bulk, live }: TimingTowerProps) {
   // painting a purple the panel does not list.
   const bests = sessionBests(bulk);
 
+  // **A retired car is not selectable, and that is one rule rather than two.**
+  // The pin clears when its car retires, so allowing it to be pinned in the
+  // first place would be a state the next tick undoes. Retired rows still
+  // RENDER - a timing screen classifies retirements, it does not hide them -
+  // they simply leave the keyboard order.
+  const selectable = order.filter((code) => statusOf(arcade, code) !== "out");
+  const selectableKey = selectable.join(",");
+  const rows = useRef(new Map<string, HTMLTableRowElement>());
+  const [anchor, setAnchor] = useState<string | null>(null);
+  // Where the single tab stop sits: the reader's own candidate while it is still
+  // selectable, otherwise the pinned row, otherwise the leader.
+  const candidate =
+    anchor !== null && selectable.includes(anchor)
+      ? anchor
+      : pinned !== null && selectable.includes(pinned)
+        ? pinned
+        : (selectable[0] ?? null);
+
+  // **Any row leaving the order moves the anchor, not just the pinned one.**
+  // A merely FOCUSED row can retire on the same tick by the same mechanism, and
+  // an anchor left on it leaves every row at `tabIndex=-1`, so keyboard entry
+  // lands nowhere.
+  //
+  // Focus itself moves ONLY if the vanished row was holding it. The tower is
+  // mounted on every tick whichever tab is showing, so an unconditional move
+  // would yank focus out of whatever the reader is actually using.
+  useEffect(() => {
+    if (anchor === null || selectable.includes(anchor)) return;
+    const wasAt = order.indexOf(anchor);
+    const replacement =
+      selectable.find((code) => order.indexOf(code) >= wasAt) ??
+      selectable[selectable.length - 1] ??
+      null;
+    const held = rows.current.get(anchor);
+    const hadFocus = held !== undefined && document.activeElement === held;
+    setAnchor(replacement);
+    if (hadFocus && replacement !== null) rows.current.get(replacement)?.focus();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [anchor, selectableKey]);
+
+  const moveCandidate = (delta: number) => {
+    if (selectable.length === 0) return;
+    const at = candidate === null ? 0 : Math.max(0, selectable.indexOf(candidate));
+    const next = selectable[Math.min(selectable.length - 1, Math.max(0, at + delta))];
+    setAnchor(next);
+    rows.current.get(next)?.focus();
+  };
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLTableSectionElement>) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      moveCandidate(1);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      moveCandidate(-1);
+    } else if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      // A second Enter on the pinned row releases it, so the keyboard can undo
+      // itself without reaching for Escape.
+      if (candidate !== null) onPin(candidate === pinned ? null : candidate);
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      onPin(null);
+    }
+  };
+
   return (
     <section className="tower card">
-      <table className="tower-table">
+      {/* **`role="grid"`, chosen rather than inherited.** `aria-selected` is not
+       * meaningful on a row outside a grid, and the two roving idioms this repo
+       * already ships (`RaceTraceChart`'s reference strip, the DATA tab strip)
+       * are `<button>` strips that do not transfer to a `<table>` of `<tr>`.
+       * Promoting the table changes its semantics for every screen-reader user,
+       * which is why it is stated here rather than left to fall out of the
+       * `tabIndex` on the rows. */}
+      <table className="tower-table" role="grid" aria-multiselectable="false">
         <thead>
           <tr>
             <th className="col-pos">P</th>
@@ -70,7 +160,7 @@ export function TimingTower({ arcade, bulk, live }: TimingTowerProps) {
             <th className="col-stops">STOPS</th>
           </tr>
         </thead>
-        <tbody>
+        <tbody onKeyDown={onKeyDown}>
           {order.map((code, index) => (
             <TowerRow
               key={code}
@@ -82,6 +172,14 @@ export function TimingTower({ arcade, bulk, live }: TimingTowerProps) {
               bulk={bulk}
               live={live}
               bests={bests}
+              pinned={pinned === code}
+              selectable={selectable.includes(code)}
+              isCandidate={candidate === code}
+              onPin={onPin}
+              register={(element) => {
+                if (element === null) rows.current.delete(code);
+                else rows.current.set(code, element);
+              }}
             />
           ))}
         </tbody>
@@ -100,9 +198,31 @@ interface TowerRowProps {
   bulk: Bulk | null;
   live: LiveLap | null;
   bests: SessionBests;
+  /** This row's car is the one band 4 is comparing against. */
+  pinned: boolean;
+  /** A retired car cannot be pinned, so it is not a keyboard stop either. */
+  selectable: boolean;
+  /** The single tab stop, under the roving tabindex. */
+  isCandidate: boolean;
+  onPin: (code: string | null) => void;
+  register: (element: HTMLTableRowElement | null) => void;
 }
 
-function TowerRow({ code, position, front, leader, arcade, bulk, live, bests }: TowerRowProps) {
+function TowerRow({
+  code,
+  position,
+  front,
+  leader,
+  arcade,
+  bulk,
+  live,
+  bests,
+  pinned,
+  selectable,
+  isCandidate,
+  onPin,
+  register,
+}: TowerRowProps) {
   const car = arcade.drivers[code];
   const status: DriverStatus = car ? driverStatus(car) : "out";
   const laps: DriverLaps | undefined = bulk?.drivers[code];
@@ -119,7 +239,16 @@ function TowerRow({ code, position, front, leader, arcade, bulk, live, bests }: 
   const interval = front === null ? null : gapCell(front, code, arcade, bulk);
 
   return (
-    <tr className={`tower-row is-${status}`}>
+    <tr
+      ref={register}
+      className={`tower-row is-${status}${pinned ? " is-pinned" : ""}`}
+      // `aria-selected` only on rows that can carry the state at all. On a
+      // retired row it would announce "not selected" about a car that can never
+      // be selected, which is noise rather than information.
+      aria-selected={selectable ? pinned : undefined}
+      tabIndex={selectable && isCandidate ? 0 : -1}
+      onClick={selectable ? () => onPin(pinned ? null : code) : undefined}
+    >
       <td className="col-pos">{position}</td>
       <td className="col-num">{laps?.number ?? "—"}</td>
       {/* **The colour moved off the glyphs and onto a swatch beside them.**

--- a/src/pitwall/ui/src/styles/data.css
+++ b/src/pitwall/ui/src/styles/data.css
@@ -542,6 +542,31 @@ td.col-drv {
   opacity: 0.65;
 }
 
+/* The tower doubles as the rival selector (#1051). A selectable row is a tab
+ * stop under a roving tabindex; the pinned one is the car band 4 compares
+ * against.
+ *
+ * The pin reads as a LEFT EDGE plus a lifted ground rather than a colour on the
+ * text. Every cell in the row already carries meaning through colour - purple
+ * and green sectors, the deleted-lap strike, the OUT dimming - so tinting the
+ * text would collide with the timing screen's own code. The edge is the one
+ * channel the row has spare. */
+.tower-row.is-pinned td {
+  background: var(--qt-elevated);
+}
+
+.tower-row.is-pinned td:first-child {
+  box-shadow: inset 2px 0 0 var(--qt-accent);
+}
+
+/* Focus is visible on its own, separately from the pin: the reader moves the
+ * candidate row with Up and Down BEFORE committing it with Enter, and a
+ * candidate nobody can see is a keyboard trap that looks like a dead key. */
+.tower-row:focus {
+  outline: 1px solid var(--qt-accent);
+  outline-offset: -1px;
+}
+
 .tower-row.is-finished .col-last {
   color: var(--qt-fg-2);
 }


### PR DESCRIPTION
## What

Clicking a timing tower row, or pressing Enter on it, makes that car the one band 4 compares against. Escape releases it and the window goes back to following the producer's own choice.

## How

The pinned code is resolved **once** in `DataWindow` and passed to all four consumers of the rival, so they cannot disagree about which car is on screen. `null` means FOLLOW THE PRODUCER rather than "no rival"; it cannot collide with a real choice because a driver code on the wire is a non-null non-empty string.

**`role="grid"`, chosen rather than inherited.** `aria-selected` is not meaningful on a row outside a grid, and the two roving idioms this repo already ships (`RaceTraceChart`'s reference strip, the DATA tab strip) are `<button>` strips that do not transfer to a `<table>` of `<tr>`. Promoting the table changes its semantics for every screen-reader user, so it is stated rather than left to fall out of a `tabIndex`.

**Retired cars are not selectable**, which makes one rule instead of two: the pin releases when its car retires, so allowing it to be pinned would be a state the next tick undoes. Retired rows still render, dimmed, because a timing screen classifies retirements rather than hiding them; they only leave the keyboard order. `statusOf` carries the tower's own missing-car guard, since a code in `race_order` can have no entry in `drivers` once the arcade is relaunched onto another race with a pin still set.

**Focus:** any row leaving the selectable order moves the roving anchor, not just the pinned one, because a merely focused row can retire on the same tick and an anchor left on it leaves every row at `tabIndex=-1` with keyboard entry landing nowhere. Focus itself moves only if the vanished row was holding it, since the tower is mounted on every tick whichever tab is showing.

## Also shipped, because the screenshot found it

A pinned car with nothing on the main driver's current lap now says so in the header. Measured on 45 consecutive real Melbourne ticks at lap 23 with NOR as the main car:

| pinned | rival samples | delta |
|---|---|---|
| PIA (the producer's rival, +2.10 s) | 233 | in range |
| VER (+10.88 s) | 11 | off the locked [-3, 3] |
| RUS, LEC, TSU, ALB, HAM | **0** | nothing to draw |

Five of seven pinnable cars contribute nothing. The cause is the inherited rule that a rival sample is kept only while that car is on the main driver's current lap, which exists because mixing laps spikes the delta interpolation by 4-6 s and is already measured in `traceBuffer.ts`'s own docstring. What changed is who it applies to: until the pin existed, the only rival ever charted was the one the producer chose, seconds away.

Four silent axes under a control the reader has just used read as a broken window, so the header names the reason. Widening the horizon is a product question, filed as **#1066** with four options.

## Checks

- `smoke-data` **272 checks**, up from 239 · `smoke-agents` 65 · `tests/surfaces/` 285 · `tsc` clean · `ruff` check and format clean.
- **Eleven mutants**, each a different wrong implementation, every one driven RED and restored byte-identical: chart/ring/header still reading the tick, no release on retirement, release on rewind, retired rows selectable, ArrowDown inert, ArrowUp inert, Enter swallowed, Escape swallowed, and the no-overlap note suppressed.
- The window was screenshotted from real producer ticks with a pin applied, and read.

**Three of these guards were wrong on the first pass, and the mutations are what said so.** Each was invariant across the thing it claimed to distinguish:

| guard | why it could not fail |
|---|---|
| the arrow keys | asserted where focus landed, but the handler moves the CANDIDATE, which was still the last car pinned by the enumeration loop above: the last selectable row, where ArrowDown clamps to itself |
| release on retirement | read `aria-selected`, which a retired row does not carry at all, so a pin still HELD on it read as "no row is pinned" |
| not a tab stop | read `tabindex="-1"`, which every non-candidate row carries whether selectable or not |

The last needed the fixture changed rather than the assertion: the retired car now sits BETWEEN two selectable rows, because at the end of the order there is nothing to observe skipping over it.

Three earlier mutants also had to be rewritten because they failed `tsc` rather than the guard, so the smoke never ran and `dist/` kept the previous bundle. The harness now reports that as "no evidence" instead of counting it as red.

Closes #1051
