### PR TITLE
fix(pitwall): band 4 compares two laps, not two instants

### DIFF
--- a/documents/research/PITWALL_DELIVERY_PLAN.md
+++ b/documents/research/PITWALL_DELIVERY_PLAN.md
@@ -97,6 +97,42 @@ scratchpad.
 Deferred beyond this plan, unchanged: #282 (observability contract, independent and also feeds the
 Rival Agent), #286 (rival intent, gated on the Rival Agent), #287 (the parity gate).
 
+### The rival selector — the programme after sprint 9
+
+Scoped 2026-08-21 by a feasibility gate, delivered as three sprints:
+
+| | sprint | issues | what landed |
+|---|---|---|---|
+| **R1** | the wire | #1048, #1049 | twenty telemetry spans a tick instead of two, encoded off the render thread |
+| **R2** | the DATA selector | #1050, #1051, #1060 | per-driver trace accumulation, the tower row pins the rival, the eviction signals survive a discarded tick |
+| **R3** | the re-based delta, and this record | #1066, #1052 | band 4 compares two laps rather than two instants |
+
+**The AGENTS window is deliberately OUT of this programme (#1052).** It is recorded here rather
+than only in the issue because the next person to scope a rival selector will open this plan, and
+the evidence is easy to re-derive wrongly.
+
+Everything rival-flavoured on that surface is computed producer-side, and none of it reads the
+broadcast rival:
+
+- `undercut_target` is the argmax over `P(undercut_success)` across the pit agent's
+  `score_undercut_tool` calls (`src/agents/pit_strategy_agent.py:526-532`), over a candidate set
+  the system prompt defines positionally, "each rival within 5 positions ahead" (`:657`).
+  **It is NOT the positional `rival_ahead` at `:1492`** — assembling it from that was the bug #432
+  fixed, and the fix is documented at `:483-499`.
+- the situation card's gap is the car ahead ON TRACK, paired positionally
+  (`src/agents/race_situation_agent.py:1162`);
+- the reasoning prose is the LLM's, over those same positional inputs;
+- `strategy.start.driver2` carried the launch rival's code onto the wire and rendered nowhere, so
+  R1 deleted it.
+
+A client-side pin therefore changes nothing there, by construction. Producer-side selection is the
+only mechanism that could, and `build_race_state(rival=...)` (`src/agents/race_state_builder.py:283`)
+recomputes `gap_ahead_s` and `pace_delta_s` against a named car but lands them only in the
+orchestrator's synthesis prompt: N27 derives its own pair gap from `laps_df` and N28's candidate
+set is positional, so neither analysis moves. **Selecting a rival there reframes the prose, not the
+analysis.** Making the agents genuinely analyse a chosen rival is `v2.8.0` Rival Agent work in
+`src/agents/`, which is a different thing from a selector and should not be folded in.
+
 ---
 
 ## 2. Sprint 1 — the wire
@@ -568,9 +604,20 @@ over a threshold that could never fire.
   the reveal withholds that driver's later parquet laps. Data-honest - the replay has no telemetry
   to place them - and unreachable on Melbourne, where all twenty run to the line. Written down so
   it is not filed as a reveal bug.
-- **A latent P2 for whoever writes any trace reader**: the arcade's `lap` channel is interpolated,
-  so it can label ~2,000 frames as a lap that has no telemetry behind it. Gate A reproduced the
-  mechanism by executing the code path but could not show it firing on real data.
+- **The latent P2 for trace readers FIRES on real data, and the mechanism named here was wrong.**
+  This entry used to say the arcade's `lap` channel "is interpolated, so it can label ~2,000 frames
+  as a lap that has no telemetry behind it", and that Gate A could reproduce the mechanism by
+  executing the code path but not show it firing. Measured on 621 real Melbourne ticks during R3:
+  **70 events a race across 17 of the 20 drivers.** One frame carries the PREVIOUS lap number with
+  a mid-lap distance, between two correct frames 40 ms apart. HAM at the lap-24 crossing reads lap
+  23 at 2586.2 m, half a lap from where the car is.
+  The channel is not interpolated: `data.py:404` writes a per-lap CONSTANT into each lap's array,
+  `408-411` concatenates every lap and sorts the whole thing by `t`, and FastF1's padded lap
+  windows overlap, so a stale row sorts in between two live ones. The bad `dist` comes from
+  `_lap_fraction_from_distance` opening a spurious few-metre segment around it.
+  It reaches every consumer of `rel_dist`, not only the trace buffer. Band 4 defends itself by
+  skipping a sample whose lap goes backwards (`traceBuffer.ts`, #1066); the producer-side fix is
+  tracked separately.
 - **#199 Phase D.3 gains weight.** `snapshot_dict` re-runs a recursive `asdict` over the 30-entry
   tail ten times a second with a blocking `sendall`, so one stalled subscriber can hitch the pyglet
   frame loop. Inherited, not introduced, but the wire is now load-bearing.

--- a/documents/research/PITWALL_DELIVERY_PLAN.md
+++ b/documents/research/PITWALL_DELIVERY_PLAN.md
@@ -611,10 +611,10 @@ over a threshold that could never fire.
   **70 events a race across 17 of the 20 drivers.** One frame carries the PREVIOUS lap number with
   a mid-lap distance, between two correct frames 40 ms apart. HAM at the lap-24 crossing reads lap
   23 at 2586.2 m, half a lap from where the car is.
-  The channel is not interpolated: `data.py:404` writes a per-lap CONSTANT into each lap's array,
-  `408-411` concatenates every lap and sorts the whole thing by `t`, and FastF1's padded lap
-  windows overlap, so a stale row sorts in between two live ones. The bad `dist` comes from
-  `_lap_fraction_from_distance` opening a spurious few-metre segment around it.
+  The channel is not interpolated: `data.py:402` writes a per-lap CONSTANT into each lap's array,
+  `410-411` concatenates every lap and sorts the whole thing by `t`, and FastF1's padded lap
+  windows overlap, so a stale row sorts in between two live ones and carries its own lap's
+  `dist` with it.
   It reaches every consumer of `rel_dist`, not only the trace buffer. Band 4 defends itself by
   skipping a sample whose lap goes backwards (`traceBuffer.ts`, #1066); the producer-side fix is
   tracked separately.

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -43,12 +43,30 @@ const CIRCUIT_M = 5220;
 /**
  * A span the delta chart can be checked by hand.
  *
- * The rival covers 100-300 m and the main covers 100-500, so three of the
- * five main samples have a rival time to interpolate against and two do not.
- * Times are chosen so the rival is a flat +2.0 s behind: at x=100 the main
- * is at t=10.0 and the rival at t=12.0, and both advance 1 s per 100 m.
+ * The rival covers 0-200 m and the main covers 0-500, so three of the six main
+ * samples have a rival time to interpolate against and three do not.
+ *
+ * **Both cars start at dist 0 and at DIFFERENT times, and they run at different
+ * PACE, and all three of those are load-bearing** (#1066):
+ *
+ * - starting at 0 is what a real buffer does. Measured over the Melbourne
+ *   capture, 24 of 25 line crossings put a sample at `dist == 0.0` exactly, so a
+ *   fixture opening at 100 m models a window mid-warm-up rather than the normal
+ *   state, and it makes the header's off-the-line note fire on every scenario.
+ * - starting at different times, the main at t=10.0 and the rival at t=12.0, is
+ *   what lets the anchor subtraction be OBSERVED. With a shared lap start the
+ *   value at the anchor is already 0 and removing the subtraction changes
+ *   nothing.
+ * - differing in pace is what lets the VALUES be observed. The rival was a flat
+ *   +2.0 s behind at identical pace, and a re-based delta reports that, quite
+ *   correctly, as 0.0 everywhere - so every value assertion in this file went
+ *   invariant at once and could no longer tell one car from another.
+ *
+ * The rival loses 0.2 s per 100 m: main advances 1 s per 100 m, rival 1.2 s. So
+ * the delta reads 0.0, +0.2, +0.4 and the on-track gap the old fixture pinned,
+ * +2.0, is exactly what the subtraction removes.
  */
-const MAIN_SPAN = [100, 200, 300, 400, 500].map((dist, i) => ({
+const MAIN_SPAN = [0, 100, 200, 300, 400, 500].map((dist, i) => ({
   lap: 24,
   t: 10 + i,
   dist,
@@ -58,9 +76,9 @@ const MAIN_SPAN = [100, 200, 300, 400, 500].map((dist, i) => ({
   gear: 6,
   drs: 8,
 }));
-const RIVAL_SPAN = [100, 200, 300].map((dist, i) => ({
+const RIVAL_SPAN = [0, 100, 200].map((dist, i) => ({
   lap: 24,
-  t: 12 + i,
+  t: 12 + i * 1.2,
   dist,
   speed: 190 + i * 10,
   throttle: 40 + i,
@@ -68,6 +86,12 @@ const RIVAL_SPAN = [100, 200, 300].map((dist, i) => ({
   gear: 6,
   drs: 8,
 }));
+/** What the delta lane must read, worked out by hand from the two spans above. */
+const EXPECTED_DELTA = [
+  [0, 0],
+  [100, 0.2],
+  [200, 0.4],
+];
 /** The main driver's own position, which is where the cursor must land. */
 const CURSOR_DIST = 500;
 
@@ -380,8 +404,8 @@ for (const [index, [name, range]] of expected.entries()) {
   );
 }
 
-// The delta the interpolation produced. Three points, not five: the rival's
-// samples stop at 300 m and `lerpSorted` returns null past the end rather
+// The delta the interpolation produced. Three points, not six: the rival's
+// samples stop at 200 m and `lerpSorted` returns null past the end rather
 // than extrapolating a flat tail that would look like real data.
 // Looked up by NAME, not by index. These two used to read `series[1]` and
 // `series[0]`, and the declaration order is exactly what the z-order fix had to
@@ -409,15 +433,38 @@ const laneSeries = (lane, car) =>
 
 const delta = (await laneSeries("delta", "rival")).data;
 check(
-  delta.length === 3 && delta.every(([, value]) => Math.abs(value - 2) < 1e-9),
-  `the delta is +2.0 s over the rival's three samples only (${JSON.stringify(delta)})`,
+  delta.length === EXPECTED_DELTA.length &&
+    delta.every(
+      ([x, value], i) =>
+        x === EXPECTED_DELTA[i][0] && Math.abs(value - EXPECTED_DELTA[i][1]) < 1e-9,
+    ),
+  `the delta is lap-relative: 0.0, +0.2, +0.4 over the rival's three samples only (${JSON.stringify(delta)})`,
+);
+// The anchor, stated as its own assertion rather than left implicit in the list
+// above. The raw difference at x=0 is the rival's +2.0 s on-track gap; the series
+// starts at exactly 0 because that gap is subtracted out. Removing the
+// subtraction turns this list into 2.0, 2.2, 2.4, and it is this check that says
+// which of those two the lane is drawing.
+check(
+  delta.length > 0 && delta[0][1] === 0,
+  `and it is anchored: the first point is exactly 0 (${JSON.stringify(delta[0])})`,
+);
+// The gap is GONE from the lane, deliberately (#1066). Asserted as an absence
+// because "the values are lap-relative" and "the values are the gap" are two
+// claims and the first does not imply the second on a fixture where they could
+// coincide.
+check(
+  !delta.some(([, value]) => Math.abs(value - 2) < 1e-9),
+  `and the on-track gap of +2.0 s appears nowhere in it (${JSON.stringify(delta)})`,
 );
 
-// The speed trace carries the whole main span.
+// The speed trace carries the whole main span. Derived from the fixture rather
+// than typed, so adding a sample to the span cannot leave this asserting a stale
+// count that happens to still pass.
 const speedPoints = (await laneSeries("speed", "main")).data.length;
 check(
-  speedPoints === 5,
-  `the speed trace holds all five samples (${speedPoints})`,
+  speedPoints === MAIN_SPAN.length,
+  `the speed trace holds all ${MAIN_SPAN.length} samples (${speedPoints})`,
 );
 
 // **The own car paints ON TOP, on every chart.** ECharts paints in declaration
@@ -4044,10 +4091,27 @@ check(
   const FIRST = [100, 200, 300];
   const SECOND = [400, 500, 600];
   const mainT = (dist) => 10 + (dist - 100) / 100;
-  // PIA sits +2.0 s behind the main car for the whole lap, VER +5.0 s. The two
-  // offsets are what make a surviving PIA sample visible in the delta.
-  const piaT = (dist) => mainT(dist) + 2;
-  const verT = (dist) => mainT(dist) + 5;
+  /**
+   * PIA is QUICKER than the main car and VER is slower, and that is the point.
+   *
+   * These were `mainT + 2` and `mainT + 5`: pure offsets at identical pace. A
+   * re-based delta (#1066) subtracts the value at the anchor, so both collapsed
+   * to flat zero and the two checks below stopped being able to tell the cars
+   * apart - the positive one would have gone red and invited a repair to `- 0`,
+   * which leaves the negative one, the actual chimera guard, true no matter what
+   * the buffer holds.
+   *
+   * The starting offsets stay, because the anchor has to have something to remove.
+   * What is new is the PACE: PIA takes 0.9 s per 100 m against the main car's 1.0
+   * and VER takes 1.3. So PIA's anchored delta runs 0, -0.1 ... -0.5 and VER's
+   * runs 0, +0.3 ... +1.5 - disjoint apart from the anchor, and on opposite sides
+   * of zero, so a single surviving PIA sample shows up as a sign the series
+   * should not contain.
+   */
+  const piaT = (dist) => 12 + ((dist - 100) / 100) * 0.9;
+  const verT = (dist) => 15 + ((dist - 100) / 100) * 1.3;
+  /** VER's anchored delta against the main car, per 100 m: 0.3 s lost each time. */
+  const verDelta = (dist) => ((dist - 100) / 100) * 0.3;
 
   const field = { NOR: driver(), PIA: driver(), VER: driver() };
   const beforeSwitch = tick(1, {
@@ -4116,12 +4180,16 @@ check(
     `the newly pinned car is charted back to the start of the lap, not from the switch (${values.length} of 6)`,
   );
   check(
-    values.every((value) => Math.abs(value - 5) < 1e-9),
-    `every delta point is VER's +5.0 s (${JSON.stringify(values)})`,
+    switched.every(([x, value]) => Math.abs(value - verDelta(x)) < 1e-9),
+    `every delta point is VER's own lap-relative loss, 0.3 s per 100 m (${JSON.stringify(values)})`,
   );
+  // The chimera guard, and it is this one rather than the check above: a buffer
+  // holding PIA's early samples beside VER's late ones still produces SIX points
+  // and could still satisfy a count. PIA is quicker than the main car, so every
+  // delta point it contributes is negative, and VER contributes none below zero.
   check(
-    !values.some((value) => Math.abs(value - 2) < 1e-9),
-    `no sample of the PREVIOUS rival survives in the delta (${JSON.stringify(values)})`,
+    !values.some((value) => value < -1e-9),
+    `and no sample of the PREVIOUS rival survives: PIA runs NEGATIVE (${JSON.stringify(values)})`,
   );
 
   // The identity check the delta cannot make on its own: read the OWNER off the
@@ -4161,15 +4229,44 @@ check(
   const LAP = 30;
   const FIELD = ["NOR", "PIA", "VER", "LEC", "RUS"];
   const RETIRED = "SAI";
-  // A car that is RUNNING and sends nothing on this lap - the common case once
-  // the tower can pin anyone, measured at five of seven on real Melbourne ticks.
+  /**
+   * A car that is RUNNING, sending plenty, and sharing NO TRACK with the main car.
+   *
+   * This used to be a car with an empty span, on the premise that a pinned car
+   * "sends nothing on this lap", measured at five of seven. #1066 abolishes that
+   * premise: every car now keeps its own lap, so those five draw. What survives
+   * is the state per-driver laps CREATE, which is the opposite shape - hundreds of
+   * samples, none of them at a distance the main car has also covered, measured
+   * at 2,564 of 9,936 car-ticks on the Melbourne capture.
+   *
+   * The difference is the whole guard. An empty span trips a note keyed on the
+   * rival's sample COUNT and a note keyed on the DELTA alike, so it cannot tell
+   * the two apart; this fixture trips only the second.
+   */
   const FAR = "HAM";
+  const FAR_XS = [3000, 3100, 3200, 3300];
   const bandFor = (code) => (FIELD.indexOf(code) + 3) * 100;
-  const XS = [100, 200, 300, 400];
+  const XS = [0, 100, 200, 300];
+  /**
+   * Each car gets its own LAP START and its own PACE, and both are required.
+   *
+   * The times here used to be `10 + (dist - 100) / 100 + index`: one shared pace,
+   * a constant per-car offset. Under a re-based delta (#1066) that offset is
+   * exactly what gets subtracted, so every car produced an identical flat-zero
+   * series and any delta assertion built on this fixture would have been born
+   * unable to tell one car from another.
+   *
+   * Now car `i` starts its lap `i` seconds after the main car and takes
+   * `1 + i/10` seconds per 100 m, so its anchored delta against NOR climbs by
+   * `i/10` per 100 m: PIA draws 0, 0.1, 0.2, 0.3 and VER draws 0, 0.2, 0.4, 0.6.
+   * Distinct at every point except the anchor, which is 0 for everyone by
+   * construction.
+   */
+  const paceOf = (code) => 1 + FIELD.indexOf(code) / 10;
   const spanOf = (code) =>
     XS.map((dist, i) => ({
       lap: LAP,
-      t: 10 + (dist - 100) / 100 + FIELD.indexOf(code),
+      t: 10 + FIELD.indexOf(code) + (dist / 100) * paceOf(code),
       dist,
       speed: bandFor(code) + i,
       throttle: 50,
@@ -4177,6 +4274,8 @@ check(
       gear: 6,
       drs: 8,
     }));
+  /** What car `code`'s anchored delta against NOR must be, point by point. */
+  const deltaOf = (code) => XS.map((dist) => (dist / 100) * (paceOf(code) - paceOf("NOR")));
 
   const field = Object.fromEntries([
     ...FIELD.map((code) => [code, driver({ lap: LAP })]),
@@ -4189,7 +4288,19 @@ check(
   const spans = Object.fromEntries([
     ...FIELD.map((code) => [code, spanOf(code)]),
     [RETIRED, []],
-    [FAR, []],
+    [
+      FAR,
+      FAR_XS.map((dist, i) => ({
+        lap: LAP,
+        t: 40 + i,
+        dist,
+        speed: 800 + i,
+        throttle: 50,
+        brake: 0,
+        gear: 6,
+        drs: 8,
+      })),
+    ],
   ]);
   // The retired car sits BETWEEN two selectable rows, not at the end. At the end
   // nothing can be observed to skip over it: ArrowDown from the row before would
@@ -4333,29 +4444,42 @@ check(
     `a retired row carries no aria-selected at all, rather than "false" (${retiredAria})`,
   );
 
-  // --- A pinned car with nothing on this lap SAYS so ---------------------------
+  // --- A pinned car the DELTA cannot use SAYS so -------------------------------
   //
-  // Measured on real Melbourne ticks at lap 23 with NOR as the main car: of the
-  // seven cars that can be pinned, five contribute ZERO samples and one
-  // contributes eleven. Four silent axes under a control the reader has just
-  // used read as a broken window, so the header names the reason.
+  // Four silent axes under a control the reader has just used read as a broken
+  // window, so the header names the reason. The reason changed with #1066: it is
+  // no longer "that car sends nothing on this lap" but "the two have covered no
+  // common track yet", and the note has to be keyed on the DELTA rather than on
+  // the rival's sample count. FAR sends four samples at 3000-3300 m while the
+  // main car has covered 0-300, so a note keyed on the count would stay silent.
   await rowFor(FAR).click();
   await page.waitForTimeout(350);
   const lapLine = await page.locator(".traces-lap").innerText();
   check(
-    lapLine.includes(`${FAR} NOT ON THIS LAP YET`),
-    `a pinned car with no samples on this lap says so (${lapLine.trim()})`,
+    lapLine.includes(`NO TRACK IN COMMON WITH ${FAR} YET`),
+    `a pinned car the delta cannot use says so (${lapLine.trim()})`,
   );
-  const rusSeries = (await trio()).speeds;
+  const farSpeeds = (await trio()).speeds;
   check(
-    rusSeries.length === 0,
-    `and it really has nothing to draw (${JSON.stringify(rusSeries)})`,
+    farSpeeds.length === FAR_XS.length,
+    `and it is NOT a car with nothing to send: its speed trace draws ${FAR_XS.length} points (${JSON.stringify(farSpeeds)})`,
+  );
+  const farDelta = await page.evaluate(() => {
+    const found = document
+      .querySelector(".trace-stack-plot")
+      .__pitwallChart.getOption()
+      .series.find((s) => s.name === "delta-rival");
+    return found ? found.data : null;
+  });
+  check(
+    Array.isArray(farDelta) && farDelta.length === 0,
+    `while the delta lane has nothing at all (${JSON.stringify(farDelta)})`,
   );
   await page.keyboard.press("Escape");
   await page.waitForTimeout(300);
   const backToPia = await page.locator(".traces-lap").innerText();
   check(
-    !backToPia.includes("NOT ON THIS LAP YET"),
+    !backToPia.includes("NO TRACK IN COMMON"),
     `and the note clears with the pin (${backToPia.trim()})`,
   );
 
@@ -4410,6 +4534,215 @@ check(
   );
 
   await ctx.close();
+}
+
+// --- Per-driver laps: the four properties #1066 turns on ---------------------
+//
+// The buffer used to hold ONE lap number, the main car's, and wipe every driver
+// when it turned. Measured on real Melbourne ticks, that left nine of nineteen
+// cars with no trace at all: a car that has not yet crossed the main car's line
+// is on a different lap and every sample of it was thrown away. Each car now
+// keeps its own lap and the delta subtracts the two anchors.
+//
+// Four properties, four fixtures, because each fails in its own way and a single
+// scenario asserting all four could pass on three.
+{
+  const MAIN_LAP = 24;
+  const behind = (dist, i) => ({
+    lap: MAIN_LAP - 1,
+    // A whole lap's worth of elapsed time behind, which is the point: under the
+    // old rule these samples were discarded, and under session-time subtraction
+    // they would draw an 80-second delta on a lane locked to three.
+    t: 90 + i * 1.1,
+    dist,
+    speed: 700 + i,
+    throttle: 50,
+    brake: 0,
+    gear: 6,
+    drs: 8,
+  });
+  const ownLap = [0, 100, 200, 300, 400, 500].map(behind);
+
+  const deltaOf = (page) =>
+    page.evaluate(() => {
+      const found = document
+        .querySelector(".trace-stack-plot")
+        .__pitwallChart.getOption()
+        .series.find((s) => s.name === "delta-rival");
+      return found ? found.data : null;
+    });
+
+  const render = async (ticks) => {
+    const ctx = await browser.newContext({ viewport: CLIENT });
+    const page = await ctx.newPage();
+    watchPage(page, failures, "per-driver laps");
+    await page.addInitScript((payload) => {
+      window.__ticks = payload;
+      window.__cursor = -1;
+      window.pywebview = {
+        api: {
+          get_tick: async () => {
+            if (window.__cursor < window.__ticks.length - 1) window.__cursor += 1;
+            return window.__ticks[window.__cursor];
+          },
+          get_bulk: async () => null,
+          get_live_lap: async () => null,
+          get_connection: async () => ({ label: "Connected", colour: "#10b981" }),
+        },
+      };
+    }, ticks);
+    await page.goto(url, { waitUntil: "domcontentloaded" });
+    await page.waitForSelector(".trace-stack-plot canvas", { timeout: 5000 });
+    await page.waitForTimeout(ticks.length * 250 + 400);
+    return { ctx, page };
+  };
+
+  // (1) A car on ANOTHER lap is charted, over the whole stretch the two share.
+  {
+    const { ctx, page } = await render([
+      tick(1, {
+        rival: "PIA",
+        drivers: { NOR: driver(), PIA: driver({ lap: MAIN_LAP - 1 }) },
+        spans: { NOR: MAIN_SPAN, PIA: ownLap },
+      }),
+    ]);
+    const data = await deltaOf(page);
+    // Six points, not three: the rival covers 0-500 of ITS lap and the main
+    // covers 0-500 of its own, so every main sample interpolates. Asserted on the
+    // COUNT, because a mutant restoring the shared lap number drops it to zero
+    // while any assertion on the VALUES could still hold for the wrong reason.
+    check(
+      Array.isArray(data) && data.length === MAIN_SPAN.length,
+      `a car on another lap is charted across every shared metre (${JSON.stringify(data)})`,
+    );
+    check(
+      Array.isArray(data) && data.length > 0 && data[0][1] === 0,
+      `and its delta is anchored, not the 80 s of session time between the laps (${JSON.stringify(data?.[0])})`,
+    );
+    const lapLine = await page.locator(".traces-lap").innerText();
+    check(
+      lapLine.includes(`LAP ${MAIN_LAP}`) && !lapLine.includes("NO TRACK IN COMMON"),
+      `and no note claims it has nothing to draw (${lapLine.trim()})`,
+    );
+    const chip = await page.locator(".driver-chip-rival").innerText();
+    check(
+      chip.includes(`L${MAIN_LAP - 1}`),
+      `and the chip names the rival's OWN lap, so the reader knows which two laps (${chip.trim()})`,
+    );
+    await ctx.close();
+  }
+
+  // (2) A backwards lap number is a glitch, not a rewind, and must not clear.
+  //
+  // Measured on the Melbourne capture: 70 of these a race across 17 of the 20
+  // drivers. One frame carries a stale lap with a mid-lap `dist` - HAM reads lap
+  // 23 at 2586.2 m one frame after crossing into 24. The old `lap !== currentLap`
+  // fired in both directions and threw the fresh lap away.
+  {
+    const glitched = [
+      { ...MAIN_SPAN[0] },
+      { ...MAIN_SPAN[1] },
+      // The stale frame: previous lap, mid-lap distance, between two good ones.
+      { ...MAIN_SPAN[2], lap: MAIN_LAP - 1, dist: 2586 },
+      { ...MAIN_SPAN[3] },
+    ];
+    const { ctx, page } = await render([
+      tick(1, {
+        rival: "PIA",
+        drivers: { NOR: driver(), PIA: driver() },
+        spans: { NOR: glitched, PIA: RIVAL_SPAN },
+      }),
+    ]);
+    const speeds = await page.evaluate(() => {
+      const found = document
+        .querySelector(".trace-stack-plot")
+        .__pitwallChart.getOption()
+        .series.find((s) => s.name === "speed-main");
+      return found ? found.data.map(([x]) => x) : null;
+    });
+    // Three of the four survive: the two before the glitch and the one after. The
+    // glitch frame itself is dropped rather than stored, so 2586 m is absent. A
+    // mutant that CLEARS on it keeps only the last frame, and one that STORES it
+    // puts a foreign lap's distance in the trace.
+    check(
+      Array.isArray(speeds) && speeds.length === 3,
+      `a stale backwards lap frame does not clear the buffer: 3 of 4 survive (${JSON.stringify(speeds)})`,
+    );
+    check(
+      Array.isArray(speeds) && !speeds.includes(2586),
+      `and the glitch frame's own distance is not stored (${JSON.stringify(speeds)})`,
+    );
+    await ctx.close();
+  }
+
+  // (3) A car that has STOPPED stops being stored.
+  //
+  // The producer republishes a retired car's last frame every tick with an
+  // ADVANCING `t` - measured on the wire, SAI, DOO and HAD each carry one sample
+  // per tick exactly like a running car. `store` keys by distance, so the last key
+  // is rewritten with the current session clock forever: ALO's last point drifts
+  // +2,785 s between its lap-33 retirement and the flag. The shared lap number
+  // used to wipe it once a lap and hide it.
+  {
+    const frozen = (t) => [{ ...RIVAL_SPAN[RIVAL_SPAN.length - 1], t }];
+    const stopped = driver({ active: false, has_finished: false });
+    const { ctx, page } = await render([
+      tick(1, {
+        rival: "PIA",
+        drivers: { NOR: driver(), PIA: driver() },
+        spans: { NOR: MAIN_SPAN, PIA: RIVAL_SPAN },
+      }),
+      // Same car, now stopped, republishing its last frame 500 s later.
+      tick(2, {
+        rival: "PIA",
+        drivers: { NOR: driver(), PIA: stopped },
+        spans: { NOR: [], PIA: frozen(RIVAL_SPAN[RIVAL_SPAN.length - 1].t + 500) },
+      }),
+    ]);
+    const data = await deltaOf(page);
+    check(
+      Array.isArray(data) &&
+        data.length === EXPECTED_DELTA.length &&
+        data.every(([, v], i) => Math.abs(v - EXPECTED_DELTA[i][1]) < 1e-9),
+      `a stopped car's last point does not absorb the advancing clock (${JSON.stringify(data)})`,
+    );
+    await ctx.close();
+  }
+
+  // (4) One common metre is not a reading.
+  //
+  // A single shared point is `[[x, 0]]` by construction - the anchor subtracts
+  // itself - so it draws nothing and would still hand the lane's readout a `+0.00`
+  // that a reader cannot tell from a genuinely level pair. This repo has paid for
+  // a manufactured value colliding with a real one before.
+  {
+    // The rival's range starts exactly where the main's ends, so `lerpSorted`
+    // returns a value at that one metre and null everywhere else. A rival
+    // straddling the main's range would interpolate across all of it.
+    const oneCommon = [
+      { ...RIVAL_SPAN[0], dist: MAIN_SPAN[MAIN_SPAN.length - 1].dist },
+      { ...RIVAL_SPAN[1], dist: 9000 },
+    ];
+    const { ctx, page } = await render([
+      tick(1, {
+        rival: "PIA",
+        drivers: { NOR: driver(), PIA: driver() },
+        spans: { NOR: MAIN_SPAN, PIA: oneCommon },
+      }),
+    ]);
+    const data = await deltaOf(page);
+    check(
+      Array.isArray(data) && data.length === 0,
+      `a single common metre yields no series rather than a manufactured 0.00 (${JSON.stringify(data)})`,
+    );
+    // Lane 1 is the delta: speed owns 0.
+    const readout = await page.locator(".trace-lane-value").nth(1).innerText();
+    check(
+      readout.trim() === "—",
+      `and the lane's readout prints the no-value dash, not +0.00 (${readout.trim()})`,
+    );
+    await ctx.close();
+  }
 }
 
 await browser.close();

--- a/src/pitwall/ui/src/features/data/OwnCarTraces.tsx
+++ b/src/pitwall/ui/src/features/data/OwnCarTraces.tsx
@@ -32,6 +32,7 @@
  */
 
 import type { Tick } from "../../lib/bridge";
+import { driverStatus } from "../../lib/driverStatus";
 import { TraceStack } from "./TraceStack";
 import type { TraceFrame } from "./useTraceFrame";
 
@@ -107,7 +108,7 @@ export function OwnCarTraces({ tick, frame, rival, frozen = false }: OwnCarTrace
 
   return (
     <section className="traces card">
-      <TracesHeader tick={tick} rival={rival} rivalSamples={frame.rival.xs.length} />
+      <TracesHeader tick={tick} rival={rival} frame={frame} />
       <TraceStack
         main={frame.main}
         rival={frame.rival}
@@ -131,12 +132,12 @@ export function OwnCarTraces({ tick, frame, rival, frozen = false }: OwnCarTrace
 function TracesHeader({
   tick,
   rival: rivalCode,
-  rivalSamples,
+  frame,
 }: {
   tick: Tick;
   rival: string | null;
-  /** How many of the rival's samples landed on the main car's current lap. */
-  rivalSamples: number;
+  /** The buffers themselves: every note below is about what the DELTA lane has. */
+  frame: TraceFrame;
 }) {
   const { arcade } = tick;
   // BOTH charted drivers, not just the main one. Reading the main alone left
@@ -147,30 +148,55 @@ function TracesHeader({
   );
 
   /**
-   * The chosen rival has nothing on this lap, so its four overlays are empty.
+   * The delta lane has nothing to draw, and the note has to say WHICH nothing.
    *
-   * **The selector is what made this reachable, and it is not a defect in it.**
-   * A rival sample is kept only while that car is on the MAIN driver's current
-   * lap - the rule exists because mixing laps puts unrelated `t` next to each
-   * other in a distance-keyed store and spikes the delta interpolation by 4-6 s.
-   * Until the tower could pin a car, the only rival ever charted was the one the
-   * producer chose, and it sits seconds away. Measured on Melbourne lap 23 with
-   * NOR as the main car: PIA (+2.10 s) contributes 233 samples, VER (+10.88 s)
-   * eleven, and RUS, LEC, TSU, ALB and HAM none at all.
+   * **The predicate is the DELTA, not the rival's sample count**, and the
+   * difference is the whole of #1066. While every car was held to the main
+   * driver's lap the two were equivalent: no samples meant no series. Now a
+   * rival carries hundreds of samples of its OWN lap and can still share no
+   * track with the main car, because each buffer only holds from its own
+   * crossing forward and the two cars sit at different points of the circuit.
+   * Measured on the Melbourne capture that state is 2,564 of 9,936 car-ticks,
+   * and a note keyed on `rival.xs.length` fires on none of them: four silent
+   * axes under a chip saying the car is being compared.
    *
-   * So the note says WHY the lane is blank. Four silent axes under a control the
-   * reader has just used read as a broken window - the same argument this file
-   * already makes for the starved-trace placeholder, and for the blind-note
-   * above. Widening the horizon itself is a separate question (#1066).
+   * Three causes, three sentences, because a true state with a false cause is
+   * the defect this file already pays for twice above:
+   *
+   * - the rival has STOPPED, so its trace ended whenever it ended;
+   * - the MAIN car is blind, so there is no reference to compare against;
+   * - neither, so the two simply have no common track yet.
    */
-  const noOverlap = rivalCode !== null && rivalSamples < 2 && !blind.includes(rivalCode);
+  const rivalState = rivalCode === null ? undefined : arcade.drivers[rivalCode];
+  const rivalStopped = rivalState !== undefined && driverStatus(rivalState) !== "running";
+  const mainBlind = arcade.drivers[arcade.driver_main]?.has_position === false;
+  const noDelta = rivalCode !== null && frame.delta.length < 2 && !blind.includes(rivalCode);
+
+  /**
+   * Where the delta lane's zero sits, when it is not the start/finish line.
+   *
+   * The series is anchored at the first x the two cars share, which IS the line
+   * once both buffers have rooted at a crossing. Until then - a window just
+   * opened, or just seeked, measured at up to 84.9 s of session time - the
+   * anchor is wherever the main buffer happens to start, and the readout then
+   * means "lost since 409 m" while reading `Δ TIME s +0.42`. Nothing else on
+   * screen carries that 409 m: every other lane starts at the same x, so a
+   * partial lap looks identical either way.
+   */
+  const anchorX = frame.delta.length >= 2 ? frame.delta[0][0] : null;
+  const offLine = anchorX !== null && anchorX > 0;
 
   return (
     <header className="traces-header">
       <span className="traces-lap">
         {arcade.lap ? `LAP ${arcade.lap}` : "LAP —"}
         {blind.length ? `  ·  NO POSITION DATA (${blind.join(", ")})` : ""}
-        {noOverlap ? `  ·  ${rivalCode} NOT ON THIS LAP YET` : ""}
+        {offLine ? `  ·  Δ FROM ${Math.round(anchorX)} m` : ""}
+        {noDelta && rivalStopped ? `  ·  ${rivalCode} STOPPED, NO DELTA` : ""}
+        {noDelta && !rivalStopped && mainBlind ? "  ·  NO DELTA WITHOUT THE OWN CAR" : ""}
+        {noDelta && !rivalStopped && !mainBlind
+          ? `  ·  NO TRACK IN COMMON WITH ${rivalCode} YET`
+          : ""}
       </span>
       <span className="driver-chip driver-chip-main">{arcade.driver_main || "—"}</span>
       {rivalCode ? (
@@ -180,8 +206,18 @@ function TracesHeader({
            * legends are gone. Rival car data is real and public, but it is the
            * coarse low-rate channel every team sees rather than pit-wall-grade
            * telemetry, and the Qt window rendered it unlabelled. */}
+          {/* The rival's OWN lap, whenever it differs from the main car's. The
+           * overlay compares two laps rather than two instants (#1066), so which
+           * two has to be on screen: `NOR vs GAS L23` under `LAP 24` is the whole
+           * statement, and without it a reader has no way to know the two traces
+           * are not simultaneous. Both numbers come from the accumulator, never
+           * one from it and one from `arcade.drivers`. */}
           <span className="driver-chip driver-chip-rival" title="broadcast tier">
-            {rivalCode} <span className="trace-tier">BROADCAST</span>
+            {rivalCode}
+            {frame.rivalLap !== null && frame.rivalLap !== frame.mainLap ? (
+              <span className="trace-rival-lap"> L{frame.rivalLap}</span>
+            ) : null}{" "}
+            <span className="trace-tier">BROADCAST</span>
           </span>
         </>
       ) : null}

--- a/src/pitwall/ui/src/features/data/TraceStack.tsx
+++ b/src/pitwall/ui/src/features/data/TraceStack.tsx
@@ -117,9 +117,24 @@ const LANES: Lane[] = [
     key: "delta",
     label: "Δ TIME",
     unit: "s",
-    // Generous for one lap, and it clips when the series wanders - the Qt range,
-    // kept deliberately: no autorange churn at 10 Hz, and the tower's GAP column
-    // carries the number while the trace is off the top.
+    // The Qt range, kept deliberately: no autorange churn at 10 Hz.
+    //
+    // **Its old justification died with #1066 and this replaces it.** The comment
+    // used to add "and the tower's GAP column carries the number while the trace
+    // is off the top". GAP and INT report an ON-TRACK gap; this lane now reports a
+    // lap-time difference, and no other panel on the window carries that. The
+    // escape hatch is the lane's OWN readout, which prints the value whether or
+    // not the line is inside the axis.
+    //
+    // It is off the top more often than "wanders" suggests, and the number is
+    // measured rather than felt. Over Melbourne 2025, 6,451 same-lap driver pairs:
+    // the end-of-lap difference exceeds 3 s on 27.7 % of them, a lap with a pit
+    // stop costs a median 16.47 s, a neutralised lap puts 57.6 % outside, and the
+    // worst pairing in the race is 50.97 s, seventeen lane-heights. Widening to
+    // [-6, 6] would buy 83.9 % coverage for half the resolution near zero, which
+    // is where two cars actually racing live; autoranging per lap would fit
+    // everything and make a quiet lap's noise look like drama. Locked, clipped and
+    // read off the number is the deliberate choice.
     range: [-3, 3],
     colour: INFO,
     weight: 3,

--- a/src/pitwall/ui/src/features/data/traceBuffer.ts
+++ b/src/pitwall/ui/src/features/data/traceBuffer.ts
@@ -15,22 +15,28 @@
  * the same sample both times, and the second pass therefore reproduces the
  * first exactly.
  *
- * Ported 1:1, including the two rules that look like bugs and are not:
+ * Ported 1:1, including the rule that looks like a bug and is not:
  *
  * - **Eviction happens BEFORE the append**, not after. The tick that reports
  *   `dropped` also carries a valid post-jump span, and clearing afterwards
  *   threw those samples away - up to 250 of them, ten seconds of trace the
  *   payload had already delivered.
- * - **Rival samples are only kept while the rival is on the main driver's
- *   current lap.** Mixing laps puts samples with unrelated `t` next to each
- *   other in a distance-keyed store and the delta interpolation spikes 4-6 s.
- *   The visible cost is real and inherited: each lap opens with the rival
- *   trace empty for exactly the gap between the two cars (16.76 s on lap 30
- *   of the session measured), and a rival a full lap down never matches at
- *   all.
+ *
+ * **The second inherited rule is GONE, and this says so because it was load
+ *   bearing for two years.** Qt kept a rival sample only while that car was on
+ *   the main driver's current lap, on the argument that mixing laps puts
+ *   samples with unrelated `t` in one distance-keyed store. That argument is
+ *   the BROADCAST convention - the battle graphic drawn only for two cars
+ *   close together - and band 4 is the engineer's overlay, which is lap
+ *   against lap everywhere in motorsport. Keeping it cost the whole panel:
+ *   once the tower could pin any car (#1051), five of seven pinnable cars drew
+ *   nothing at all, because a car not yet across the main driver's line was
+ *   never stored. Each car now keeps its OWN lap and the delta subtracts the
+ *   two anchors, so the store never holds two laps at once (#1066).
  */
 
 import type { TelemetrySample } from "../../lib/bridge";
+import { driverStatus, type StatusInputs } from "../../lib/driverStatus";
 
 /** What a chart needs out of one sample; `dist` is the key, not a field. */
 export interface TraceRow {
@@ -52,6 +58,12 @@ export interface SortedTrace {
 
 const EMPTY: SortedTrace = { xs: [], rows: [] };
 
+/** One driver's current lap and the samples it has covered of it. */
+interface LapBuffer {
+  lap: number;
+  rows: Map<number, TraceRow>;
+}
+
 /**
  * One buffer per DRIVER, with the comparison chosen at render (#1050).
  *
@@ -64,70 +76,104 @@ const EMPTY: SortedTrace = { xs: [], rows: [] };
  * another.
  *
  * Accumulating every driver removes the question. The newly pinned car's trace is
- * already populated back to the start of the main driver's current lap, because
- * it was being kept all along, and the lap is the buffer's whole horizon anyway -
- * the wire carries only the span since the last tick and cannot backfill.
+ * already populated back to the start of ITS OWN lap, because it was being kept
+ * all along, and one lap is the buffer's whole horizon anyway - the wire carries
+ * only the span since the last tick and cannot backfill.
+ *
+ * Each buffer also owns its own LAP NUMBER (#1066), which is the half #1050 left
+ * on the main driver: accumulating every car while letting one car's crossing
+ * wipe every buffer meant a car not yet across that line was stored and then
+ * thrown away, so nine of nineteen drew nothing on the tick measured.
  *
  * Cost: twenty spans of `FPS x speed / 10 Hz` samples, so about 400 `Map.set`
  * calls a tick at 8x against 40 before, and 5,000 on a capped forward jump. On
  * integer keys that is sub-millisecond beside the ECharts render it feeds.
  */
 export class TraceAccumulator {
-  private buffers = new Map<string, Map<number, TraceRow>>();
-  private currentLap: number | null = null;
+  private entries = new Map<string, LapBuffer>();
 
-  /** Fold one tick's spans in. Safe to call twice with the same tick. */
-  ingest(spans: Record<string, TelemetrySample[]>, mainCode: string, evict: boolean): void {
+  /**
+   * Fold one tick's spans in. Safe to call twice with the same tick.
+   *
+   * `drivers` is the tick's own state block, and it is here for ONE reason: a
+   * car that has stopped must stop being stored. The producer republishes a
+   * retired car's last frame every tick with an advancing `t`, so a buffer that
+   * keeps accepting it rewrites its last distance key with the current session
+   * clock forever - measured on Melbourne 2025, ALO's last point drifts +2,785 s
+   * between its lap-33 retirement and the flag, and the readout that reads it
+   * counts up one second per second. The old shared lap number wiped every
+   * buffer at each of the main car's crossings and hid this; per-driver laps
+   * remove that wipe, so the predicate has to be explicit.
+   */
+  ingest(
+    spans: Record<string, TelemetrySample[]>,
+    evict: boolean,
+    drivers: Record<string, StatusInputs>,
+  ): void {
     if (evict) this.clear();
 
-    // The MAIN driver's span runs first and to completion, then everyone else is
-    // compared against the lap it left behind. That ordering is inherited rather
-    // than incidental: reading it as "store a sample while its driver is on the
-    // current lap" is a different algorithm, interleaved in time, and the two
-    // agree only because the lap-change clear wipes the old lap anyway.
-    for (const sample of spans[mainCode] ?? []) {
-      const lap = Math.trunc(sample.lap || 0);
-      if (lap !== this.currentLap) {
-        this.currentLap = lap;
-        this.buffers.clear();
-      }
-      store(this.bufferFor(mainCode), sample);
-    }
-
+    // The main driver's code was a parameter here until #1066 and is not one now,
+    // which is the change in one line: its lap used to decide what every other car
+    // was allowed to store, and that is what forced its span to run first and to
+    // completion. Each car now answers only for itself, so there is no ordering
+    // between drivers and nothing to privilege.
     for (const [code, span] of Object.entries(spans)) {
-      if (code === mainCode) continue;
-      for (const sample of span) {
-        // Same rule the single rival has always been held to: a car on another
-        // lap carries an unrelated `t`, and mixing those into one distance-keyed
-        // store spikes the delta interpolation by 4-6 s.
-        if (Math.trunc(sample.lap || 0) === this.currentLap) store(this.bufferFor(code), sample);
-      }
+      const state = drivers[code];
+      // Unknown rather than stopped: a code with a span and no state block is not
+      // a case the wire produces (`bridge.ts` pins the key sets equal), and
+      // dropping it silently would be the same mistake as trusting it silently.
+      if (state !== undefined && driverStatus(state) !== "running") continue;
+      for (const sample of span) this.absorb(code, sample);
     }
   }
 
   clear(): void {
-    this.buffers.clear();
-    this.currentLap = null;
+    this.entries.clear();
   }
 
   /** One driver's accumulated lap, or the empty trace for a car with nothing. */
   trace(code: string | null): SortedTrace {
     if (code === null) return EMPTY;
-    const buffer = this.buffers.get(code);
-    return buffer === undefined ? EMPTY : sorted(buffer);
+    const entry = this.entries.get(code);
+    return entry === undefined ? EMPTY : sorted(entry.rows);
   }
 
-  get lap(): number | null {
-    return this.currentLap;
+  /**
+   * The lap THIS buffer holds, which is the only honest source for the header.
+   *
+   * `tick.arcade.drivers[code].lap` is the other candidate and it is a different
+   * number: it reads the frame at the tick's own index while this reads the last
+   * sample actually stored, and the two disagree across a lap change inside one
+   * span and at all 70 of the lap-channel glitches a race carries. One number,
+   * one source.
+   */
+  lapOf(code: string | null): number | null {
+    if (code === null) return null;
+    return this.entries.get(code)?.lap ?? null;
   }
 
-  private bufferFor(code: string): Map<number, TraceRow> {
-    let buffer = this.buffers.get(code);
-    if (buffer === undefined) {
-      buffer = new Map<number, TraceRow>();
-      this.buffers.set(code, buffer);
+  /** Store one sample under its driver's own lap, opening a new lap when it turns. */
+  private absorb(code: string, sample: TelemetrySample): void {
+    const lap = Math.trunc(sample.lap || 0);
+    const entry = this.entries.get(code);
+    if (entry === undefined) {
+      this.entries.set(code, { lap, rows: new Map() });
+    } else if (lap > entry.lap) {
+      // A new lap replaces the buffer rather than adding to it: one lap is the
+      // whole horizon, and the wire cannot backfill what came before.
+      this.entries.set(code, { lap, rows: new Map() });
+    } else if (lap < entry.lap) {
+      // A lap number that goes BACKWARDS is a glitch, not a rewind - a rewind
+      // arrives as `rewound` and evicts everything. Measured on Melbourne 2025:
+      // 70 of these a race across 17 of the 20 drivers, one frame each, and the
+      // glitch frame carries a stale lap with a mid-lap `dist` (HAM reads lap 23
+      // at 2586.2 m one frame after crossing into 24). Storing it would put a
+      // foreign lap in the map; clearing on it, which `lap !== currentLap` used
+      // to do, would throw the lap away twice per crossing. It is a producer-side
+      // defect and it reaches every consumer of `rel_dist`, not just this buffer.
+      return;
     }
-    return buffer;
+    store(this.entries.get(code)!.rows, sample);
   }
 }
 
@@ -182,13 +228,35 @@ export function lerpSorted(xs: number[], ys: number[], x: number): number | null
 }
 
 /**
- * The delta series: `t_rival(x) - t_main(x)` along the main driver's x.
+ * The delta series along the main driver's x, RE-BASED to lap-relative time.
  *
- * F1-broadcast convention - main is the flat reference at y=0, so a POSITIVE
- * trace means the rival is slower at that point on the lap and a negative one
- * means faster. Verified against the producer's own `interval_at_line`: the
- * delta at each lap's first common x agreed to 0.000 s on laps 10, 30 and 50
- * of Melbourne 2025, which is what one shared clock looks like.
+ * Main is the flat reference at y=0, so a POSITIVE trace means the rival is
+ * slower to that point of the lap and a negative one means faster.
+ *
+ * **What the subtraction at the end buys, and why it is the whole of #1066.**
+ * The raw difference `t_rival(x) - t_main(x)` is session time, so it carries the
+ * gap between the two cars as a constant offset. That was harmless while the
+ * only rival ever charted was one the producer picked to sit two seconds away;
+ * the moment the tower could pin anyone, a car ten seconds ahead drew a trace
+ * ten seconds off a lane locked to three. Subtracting the value at the first
+ * common x removes the offset and leaves the SHAPE, which is the question an
+ * engineer's overlay asks: not how far apart the two cars are, but where one is
+ * quicker. The gap is answered elsewhere, by the tower's GAP and INT columns.
+ *
+ * With both buffers rooted at their own line crossings the anchor sits at x = 0
+ * and this IS the lap-relative delta. It is exact to within one frame rather
+ * than exactly: `store` keys by integer metre, so a second frame landing in the
+ * same metre displaces the first, and the anchor moves with it. Measured over
+ * the Melbourne capture the divergence is 0.080 s on the one car whose lap
+ * channel glitched and 0.000 s on the other fifteen, and it is reachable on any
+ * crossing taken below 90 km/h, where 40 ms covers less than a metre: the pit
+ * lane, a safety-car queue, a spin.
+ *
+ * Below two common points there is no series and no anchor. Returning the empty
+ * array rather than a one-point one is deliberate: a single point draws nothing
+ * but would still feed the lane's readout, and by construction its value is
+ * exactly 0.00 - a manufactured number indistinguishable from a genuinely level
+ * pair. `delta.length < 2` is what the header tests to explain the blank lane.
  */
 export function deltaSeries(main: SortedTrace, rival: SortedTrace): [number, number][] {
   if (main.xs.length < 2 || rival.xs.length < 2) return [];
@@ -199,5 +267,11 @@ export function deltaSeries(main: SortedTrace, rival: SortedTrace): [number, num
     if (interpolated === null) return;
     out.push([x, interpolated - main.rows[index].t]);
   });
-  return out;
+  // Two traces that are each long enough can still share NO track: two cars on
+  // their own laps sit at different points of the circuit, and a buffer only
+  // holds from its own root forward. Measured at 2,564 of 9,936 car-ticks on the
+  // Melbourne capture, every running car among them.
+  if (out.length < 2) return [];
+  const anchor = out[0][1];
+  return out.map(([x, value]) => [x, value - anchor]);
 }

--- a/src/pitwall/ui/src/features/data/useTraceFrame.ts
+++ b/src/pitwall/ui/src/features/data/useTraceFrame.ts
@@ -30,6 +30,17 @@ export interface TraceFrame {
   main: SortedTrace;
   rival: SortedTrace;
   delta: ReturnType<typeof deltaSeries>;
+  /**
+   * The lap each charted buffer holds, from the accumulator and nowhere else.
+   *
+   * The header needs the rival's lap now that the two cars are compared lap
+   * against lap rather than instant against instant, and `arcade.drivers[code].lap`
+   * is a DIFFERENT number: it reads the frame at the tick's index while these read
+   * the last sample stored. They disagree across a lap change inside one span and
+   * at every lap-channel glitch.
+   */
+  mainLap: number | null;
+  rivalLap: number | null;
 }
 
 export function useTraceFrame(
@@ -55,7 +66,7 @@ export function useTraceFrame(
   // which is the half that changes without a new tick.
   return useMemo(() => {
     if (!tick) return null;
-    const { telemetry, driver_main } = tick.arcade;
+    const { telemetry, driver_main, drivers } = tick.arcade;
     // The producer's own eviction signals, plus the clock's - `FrameClock` sees a
     // backwards jump smaller than one broadcast that the flags miss.
     const evict =
@@ -63,13 +74,22 @@ export function useTraceFrame(
     // Every driver on the wire is accumulated; the comparison is a LOOKUP at
     // render (#1050). Selecting at ingest was safe only while the producer could
     // not switch rivals, and the tower's pin is exactly that switch.
-    accumulator.current.ingest(telemetry.drivers, driver_main, evict);
+    // The state block rides along so a car that has STOPPED stops being stored:
+    // the producer republishes its last frame every tick with an advancing `t`,
+    // and nothing else here would ever clear it (#1066).
+    accumulator.current.ingest(telemetry.drivers, evict, drivers);
     const main = accumulator.current.trace(driver_main);
     // Null in single-driver mode, which is a real state and not padding: the
     // rival trace is meant to be empty there, and `TraceStack` renders its own
     // placeholder for it.
     const rival = accumulator.current.trace(rivalCode);
-    return { main, rival, delta: deltaSeries(main, rival) };
+    return {
+      main,
+      rival,
+      delta: deltaSeries(main, rival),
+      mainLap: accumulator.current.lapOf(driver_main),
+      rivalLap: accumulator.current.lapOf(rivalCode),
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tick?.seq, rivalCode]);
 }

--- a/src/pitwall/ui/src/styles/data.css
+++ b/src/pitwall/ui/src/styles/data.css
@@ -604,12 +604,26 @@ td.col-drv {
   padding: 0 2px;
 }
 
+/* The lap label plus every note the header can append.
+ *
+ * `nowrap` is not decoration: the header is a flex row sharing its line with the
+ * two driver chips, and a note long enough to push them wraps the row, which
+ * takes its height out of the CHART below. Measured at 1265x593 with one note
+ * showing, the six lanes lose about 2 px each and the delta lane falls from 72 px
+ * to 71, which drops its 10 px labels below the 12 px pitch they need to stay
+ * apart. The exposure is not new - `NO POSITION DATA (X, Y)` is longer than any
+ * note added since - it had simply never been measured with a note up. Clipping
+ * the tail of a note is the right trade against shrinking the payload. */
 .traces-lap {
   color: var(--qt-fg-1);
   font-size: 13px;
   font-weight: 800;
   letter-spacing: 1px;
   margin-right: 10px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .traces-vs {


### PR DESCRIPTION
## What

Band 4's delta lane compares two laps instead of two instants. Each car keeps
its own lap in the trace buffer, and the delta subtracts the value at the first
metre the two cars share, so the lane reads lap-relative time.

Closes #1066. Closes #1052.

## Why

The buffer held one lap number for every car and took it from the main driver,
so a car that had not yet crossed that line was stored and then wiped. Measured
on 621 real Melbourne ticks at lap 24 with NOR as the main car, nine of nineteen
drivers drew nothing at all, and VER, the one distant car that did draw, sat
10.88 s off a lane locked to three.

That rule is the broadcast battle-graphic convention, which requires two cars to
be close and simultaneous. Band 4 is the engineer's telemetry overlay, which is
lap against lap everywhere in motorsport. The gap question is already answered
twice on this window, by the tower's GAP and INT columns and by RACE TRACE.

## How

Measured through the built bundle, replaying the same 621 ticks and pinning each
car through the real tower row:

| car | rival points | delta points | min | max | chip |
|---|---|---|---|---|---|
| PIA | 975 | 975 | -0.11 | +0.16 | PIA |
| VER | 731 | 719 | -0.00 | +0.50 | VER |
| GAS | 2284 | **1024** | -0.00 | +1.48 | GAS L23 |
| BEA | 1520 | **1024** | -0.01 | +2.07 | BEA L23 |
| HAM | 59 | 61 | -0.12 | +0.00 | HAM |

GAS and BEA drew zero points before this. A car that has not reached the main
driver's line is deep into its own lap, so it now contributes the most complete
delta of anyone: 1024 points, the whole main trace.

Anchoring at the first common metre is the lap-relative delta whenever both
buffers start at a line crossing, and 24 of 25 crossings in the capture put a
sample at `dist == 0.0` exactly. It is exact to within one frame rather than
exactly: `store` keys by integer metre, so a second frame in the same metre
displaces the anchor. HAM is the one car where that happens here and the two
forms differ by 0.080 s, visible in the table above. It is reachable on any
crossing taken below 90 km/h, where 40 ms covers less than a metre.

Four defects found while building it, each fixed here:

- `deltaSeries` returns nothing below two common points. Two traces long enough
  can still share no track, at 2564 of 9936 car-ticks, and reading the anchor
  off an empty array threw during render. Without the guard the window does not
  render at all.
- A car that has stopped stops being stored. The producer republishes its last
  frame every tick with an advancing `t`, so its last distance key absorbed the
  session clock: ALO's last point drifts 2785 s between its lap-33 retirement and
  the flag, and the readout counted up in real time. The shared lap number was
  the only thing clearing it, so removing that is what created this.
- A lap number that goes backwards is skipped rather than treated as a lap
  change. 70 of these a race across 17 of the 20 drivers.
- `.traces-lap` no longer wraps. The header shares its row with the driver chips,
  so a note long enough to push them took its height out of the chart: at
  1265x593 the six lanes lose about 2 px each and the delta lane's 10 px labels
  fall below the 12 px pitch they need. Not a new exposure, just never measured
  with a note showing.

The header now names the rival's own lap when it differs, distinguishes the
three reasons the delta lane can be empty, and prints the anchor when it is not
the start line.

## Out of scope

**The `[-3, 3]` lane range is unchanged, deliberately.** All sixteen running cars
stay inside it over the stretch measured, but that is 45% of one green-flag lap.
Over Melbourne 2025, 6451 same-lap driver pairs, the end-of-lap difference
exceeds 3 s on 27.7% of them, a lap with a pit stop costs a median 16.47 s,
neutralised laps put 57.6% outside, and the worst pairing is 50.97 s. The lock
stays because autoranging churns and widening halves the resolution where two
cars actually racing live. What changed is the comment: it justified the lock by
saying the tower's GAP column carries the number when the trace leaves the lane,
and GAP reports an on-track gap, which this lane no longer does. The escape hatch
is now the lane's own readout, and the numbers above sit beside it.

**A stated cost.** Band 4 used to tell a reader the size and sign of the on-track
gap at a glance. It now says the rival is level on pace and nothing about where
it is. GAP is to the leader and INT to the car ahead, so for a pinned car several
places away the reader subtracts two columns by eye.

**The lap-channel glitch is not fixed here.** It publishes a `dist` wrong by up
to half a lap to every consumer of `rel_dist`, not only to this buffer, and the
mechanism is in `src/arcade/data.py`. Band 4 defends itself; the producer-side
fix is tracked separately.

## Checks

- `smoke-data` 272 to **284**, `smoke-agents` **65**, `tests/surfaces/` **285**,
  `ruff check` and `ruff format --check` clean.
- **Eight mutants, every new guard watched failing against the code it guards.**
  Six went red on the named guard. The stopped-car mutant put the last delta
  point at 500.4 s against an expected 0.4, reproducing the drift exactly. The
  empty-series mutant did not fail a check at all: the page never rendered, which
  is the crash it guards. One mutant did not compile on its first form and was
  reported as no evidence rather than as a pass, then rewritten so it did.
- Two fixtures rewritten rather than renumbered. Both separated cars by a
  constant gap, which a re-based delta correctly reports as flat zero, so every
  value assertion built on them had gone invariant. They now differ in pace and
  in lap start. The `NOT ON THIS LAP YET` scenario used an empty span, so it
  would have stayed green over a premise this PR abolishes; its car now sends
  four samples at 3000-3300 m while the main car has covered 0-300.
- The real window opened on real ticks with a car from another lap pinned, and
  read: `LAP 24 · NOR vs BEA L23`, the lane climbing to a readout of +2.07,
  inside the locked range.
