### PR TITLE
fix(pitwall): the rival is drawn in its own team colour

### DIFF
--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -550,13 +550,20 @@ check(
   laneColours["throttle-main"] !== laneColours["brake-main"],
   `throttle and brake are told apart by colour (${laneColours["throttle-main"]} vs ${laneColours["brake-main"]})`,
 );
-// And every rival trace is the broadcast tier's amber, on all six lanes.
+// And every rival trace is the RIVAL'S OWN team colour, on all six lanes.
+//
+// This used to read `declared.RIVAL`, a fixed palette.WARNING amber parsed out of
+// `TraceStack`'s constants. #1070 deleted that constant: the rival takes the
+// pinned driver's colour off the wire now. The expected value therefore comes
+// from the FIXTURE's `driver_colors`, keyed by the car being charted, so the
+// assertion cannot drift back to a literal.
+const RIVAL_RGB = "rgb(255, 128, 0)";
 const rivalWrong = Object.entries(laneColours).filter(
-  ([series, colour]) => series.endsWith("-rival") && colour !== declared.RIVAL,
+  ([series, colour]) => series.endsWith("-rival") && colour !== RIVAL_RGB,
 );
 check(
-  rivalWrong.length === 6 - 6 && rivalWrong.length === 0,
-  `and every rival trace is the broadcast amber (${rivalWrong.map(([s, c]) => `${s}=${c}`).join("; ") || "all six"})`,
+  rivalWrong.length === 0,
+  `and every rival trace is the rival's own colour (${rivalWrong.map(([s, c]) => `${s}=${c}`).join("; ") || "all six"})`,
 );
 
 // And the lane ORDER itself, asserted once rather than assumed by every lookup.
@@ -4743,6 +4750,115 @@ check(
     );
     await ctx.close();
   }
+}
+
+// --- The rival is drawn in ITS OWN team colour (#1070) -----------------------
+//
+// Band 4 drew every rival series, on all six lanes, in a fixed palette.WARNING
+// amber, and the header chip matched it. That came 1:1 from the Qt panel, which
+// fixes the rival to WARNING whoever it is. It stopped being right when the tower
+// could pin any car: the amber sits an RGB distance of 33.5 from McLaren papaya,
+// the closest pair in the whole team palette, so a McLaren rival looked correct
+// and every other car looked like the colour had gone stale.
+//
+// **A palette-membership check cannot fail on this**, which is why there is no
+// Python token guard for it: the amber IS in the palette, and so is any wrong
+// driver's colour. This reads the SERVED value and compares it to the pinned
+// car's own entry in the same fed tick, never to a hex literal.
+{
+  const LAP = 30;
+  const PAIR = ["NOR", "PIA", "VER"];
+  // Papaya for both McLarens, Red Bull blue for VER. **The pinned car must not be
+  // a teammate of the producer's rival**: with PIA pinned over a NOR/PIA pairing,
+  // a version that looked the colour up under the wrong key would find the same
+  // papaya and pass.
+  const COLOURS = { NOR: [255, 128, 0], PIA: [255, 128, 0], VER: [6, 0, 239] };
+  const rgbOf = (code) => `rgb(${COLOURS[code].join(", ")})`;
+  const span = (code) =>
+    [0, 100, 200, 300].map((dist, i) => ({
+      lap: LAP,
+      t: 10 + PAIR.indexOf(code) + dist / 100,
+      dist,
+      speed: (PAIR.indexOf(code) + 3) * 100 + i,
+      throttle: 50,
+      brake: 0,
+      gear: 6,
+      drs: 8,
+    }));
+
+  const ctx = await browser.newContext({ viewport: CLIENT });
+  const page = await ctx.newPage();
+  watchPage(page, failures, "rival colour");
+  const payload = tick(1, {
+    rival: "PIA",
+    drivers: Object.fromEntries(PAIR.map((code) => [code, driver({ lap: LAP })])),
+    spans: Object.fromEntries(PAIR.map((code) => [code, span(code)])),
+    order: PAIR,
+    colors: COLOURS,
+  });
+  await page.addInitScript((one) => {
+    window.pywebview = {
+      api: {
+        get_tick: async () => one,
+        get_bulk: async () => null,
+        get_live_lap: async () => null,
+        get_connection: async () => ({ label: "Connected", colour: "#10b981" }),
+      },
+    };
+  }, payload);
+  await page.goto(url, { waitUntil: "domcontentloaded" });
+  await page.waitForSelector(".trace-stack-plot canvas", { timeout: 5000 });
+  await page.waitForTimeout(400);
+
+  const readColours = () =>
+    page.evaluate(() => {
+      const chart = document.querySelector(".trace-stack-plot").__pitwallChart;
+      const chip = document.querySelector(".driver-chip-rival");
+      return {
+        series: chart
+          .getOption()
+          .series.filter((s) => s.name.endsWith("-rival"))
+          .map((s) => s.lineStyle?.color),
+        chip: chip ? getComputedStyle(chip).color : null,
+      };
+    });
+
+  const before = await readColours();
+  check(
+    before.series.length === 6 && before.series.every((c) => c === rgbOf("PIA")),
+    `every rival lane is the producer rival's own colour (${JSON.stringify(before.series)})`,
+  );
+  check(
+    before.chip === rgbOf("PIA"),
+    `and so is the chip, so the two cannot be fixed apart (${before.chip})`,
+  );
+
+  await page.evaluate(() => {
+    const row = [...document.querySelectorAll(".tower-row")].find(
+      (r) => r.querySelector(".col-drv")?.textContent.trim() === "VER",
+    );
+    row?.click();
+  });
+  await page.waitForTimeout(400);
+
+  const after = await readColours();
+  check(
+    after.series.length === 6 && after.series.every((c) => c === rgbOf("VER")),
+    `pinning VER repaints all six lanes in Red Bull blue (${JSON.stringify(after.series)})`,
+  );
+  check(
+    after.chip === rgbOf("VER"),
+    `and the chip follows it (${after.chip})`,
+  );
+  // The assertion that fails against the fixed amber, and against any future
+  // memo staleness: the value has to have MOVED across the click. Both readings
+  // above could be satisfied by a constant if that constant happened to equal
+  // one of the two cars' colours.
+  check(
+    before.series[0] !== after.series[0] && before.chip !== after.chip,
+    `and the colour actually changed across the pin (${before.series[0]} -> ${after.series[0]})`,
+  );
+  await ctx.close();
 }
 
 await browser.close();

--- a/src/pitwall/ui/src/features/data/DataWindow.tsx
+++ b/src/pitwall/ui/src/features/data/DataWindow.tsx
@@ -39,6 +39,8 @@ import { useLiveLap } from "../../lib/useLiveLap";
 import { useStatusText } from "../../lib/useStatusText";
 import { useTick } from "../../lib/useTick";
 import { waitingBody, waitingStatus } from "../../lib/waitingCopy";
+import { AXIS_TEXT } from "../../lib/chart";
+import { driverColour } from "../../lib/driverColour";
 
 /**
  * The right column's tabs, in the order a strategist reaches for them.
@@ -77,6 +79,12 @@ export function DataWindow() {
   const [pinned, setPinned] = useState<string | null>(null);
   const rival = pinned ?? tick?.arcade.driver_rival ?? null;
   const traceFrame = useTraceFrame(tick, discontinuity, rival);
+  // The rival's COLOUR is resolved here for the same reason its code is: band 4
+  // draws it on six series and on the header chip, and those were free to
+  // disagree. The fallback is a literal rather than a `var(--qt-*)` because one
+  // of the consumers is an ECharts canvas, which cannot resolve a custom
+  // property and would silently fall back to its own palette (#1070).
+  const rivalColour = driverColour(tick?.arcade.driver_colors ?? {}, rival, AXIS_TEXT);
 
   // The pin releases when its car retires, or when the code stops being on the
   // wire at all - a relaunched arcade pointed at another race is the second
@@ -167,7 +175,13 @@ export function DataWindow() {
               {tab === "traces" && (
                 <div className="band4">
                   {traceFrame && (
-                    <OwnCarTraces tick={tick} frame={traceFrame} rival={rival} frozen={frozen} />
+                    <OwnCarTraces
+              tick={tick}
+              frame={traceFrame}
+              rival={rival}
+              rivalColour={rivalColour}
+              frozen={frozen}
+            />
                   )}
                   <div className="side-column">
                     <TrackRing arcade={tick.arcade} rival={rival} />

--- a/src/pitwall/ui/src/features/data/OwnCarTraces.tsx
+++ b/src/pitwall/ui/src/features/data/OwnCarTraces.tsx
@@ -69,11 +69,25 @@ interface OwnCarTracesProps {
    * pinned car.
    */
   rival: string | null;
+  /**
+   * The rival's own team colour, resolved by `DataWindow` alongside its code.
+   *
+   * Both halves travel together on purpose (#1070): this file holds the chip and
+   * the stack, and handing it a code without a colour is how they came to
+   * disagree in the first place.
+   */
+  rivalColour: string;
   /** The producer is gone; these buffers will not fill. */
   frozen?: boolean;
 }
 
-export function OwnCarTraces({ tick, frame, rival, frozen = false }: OwnCarTracesProps) {
+export function OwnCarTraces({
+  tick,
+  frame,
+  rival,
+  rivalColour,
+  frozen = false,
+}: OwnCarTracesProps) {
   const { arcade } = tick;
 
   // The X lock is derived here because `circuit_length_m` rides on every tick, so
@@ -108,13 +122,14 @@ export function OwnCarTraces({ tick, frame, rival, frozen = false }: OwnCarTrace
 
   return (
     <section className="traces card">
-      <TracesHeader tick={tick} rival={rival} frame={frame} />
+      <TracesHeader tick={tick} rival={rival} rivalColour={rivalColour} frame={frame} />
       <TraceStack
         main={frame.main}
         rival={frame.rival}
         delta={frame.delta}
         xMax={xMax}
         rivalCode={rival}
+        rivalColour={rivalColour}
         cursorX={cursorX}
         // ONE caption over the whole stack, where the 2x2 printed the same sentence
         // four times. It claims starvation only when the MAIN trace is starved: a
@@ -132,10 +147,13 @@ export function OwnCarTraces({ tick, frame, rival, frozen = false }: OwnCarTrace
 function TracesHeader({
   tick,
   rival: rivalCode,
+  rivalColour,
   frame,
 }: {
   tick: Tick;
   rival: string | null;
+  /** The chip paints in the rival's own team colour; the border follows it. */
+  rivalColour: string;
   /** The buffers themselves: every note below is about what the DELTA lane has. */
   frame: TraceFrame;
 }) {
@@ -212,7 +230,14 @@ function TracesHeader({
            * statement, and without it a reader has no way to know the two traces
            * are not simultaneous. Both numbers come from the accumulator, never
            * one from it and one from `arcade.drivers`. */}
-          <span className="driver-chip driver-chip-rival" title="broadcast tier">
+          {/* `color` inline, because the value is per-driver and a stylesheet
+           * cannot know it. `data.css` gives this chip a `currentColor` border,
+           * so the border follows the team colour for free. */}
+          <span
+            className="driver-chip driver-chip-rival"
+            style={{ color: rivalColour }}
+            title="broadcast tier"
+          >
             {rivalCode}
             {frame.rivalLap !== null && frame.rivalLap !== frame.mainLap ? (
               <span className="trace-rival-lap"> L{frame.rivalLap}</span>

--- a/src/pitwall/ui/src/features/data/RaceTraceChart.tsx
+++ b/src/pitwall/ui/src/features/data/RaceTraceChart.tsx
@@ -45,19 +45,19 @@ import { neutralisedLaps, neutralisedRanges } from "../../lib/neutralised";
 import { raceTrace } from "../../lib/raceTrace";
 import type { TraceReference } from "../../lib/raceTrace";
 import type { ArcadeState, Bulk } from "../../lib/bridge";
+import { driverColour } from "../../lib/driverColour";
 
 /** The own car is drawn heavier than the nineteen it has to be picked out of. */
 const OWN_WIDTH = 2;
 const FIELD_WIDTH = 1;
 
-function colourOf(arcade: ArcadeState, code: string): string {
-  const rgb = arcade.driver_colors[code];
-  // Never a CSS custom property here, unlike the tower's version of this: an
-  // ECharts canvas cannot resolve `var(--qt-fg-1)` and would draw the series
-  // in its own default palette, which is the one colour set on this window
-  // that answers to nothing.
-  return rgb ? `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})` : AXIS_TEXT;
-}
+/**
+ * Never a CSS custom property here, unlike the tower's fallback: an ECharts
+ * canvas cannot resolve `var(--qt-fg-1)` and would draw the series in its own
+ * default palette, which is the one colour set on this window that answers to
+ * nothing.
+ */
+const NO_COLOUR = AXIS_TEXT;
 
 /** `+12.3` / `-4.5` - the sign is the whole reading, so it is always printed. */
 function signedSeconds(value: number): string {
@@ -121,7 +121,7 @@ export function RaceTraceChart({ bulk, arcade }: { bulk: Bulk | null; arcade: Ar
         },
       },
       series: trace.lines.map((line) => {
-        const colour = colourOf(arcade, line.code);
+        const colour = driverColour(arcade.driver_colors, line.code, NO_COLOUR);
         const isOwn = line.code === own;
         return {
           type: "line" as const,

--- a/src/pitwall/ui/src/features/data/TimingTower.tsx
+++ b/src/pitwall/ui/src/features/data/TimingTower.tsx
@@ -31,6 +31,7 @@ import { driverStatus, type DriverStatus } from "../../lib/driverStatus";
 import { formatSeconds } from "../../lib/format";
 import { formatGapCell, gapCell } from "../../lib/gapCell";
 import { sessionBests, type BestField, type SessionBests } from "../../lib/sessionBests";
+import { driverColour } from "../../lib/driverColour";
 
 interface TimingTowerProps {
   arcade: ArcadeState;
@@ -272,7 +273,7 @@ function TowerRow({
        * colour the arcade never sent, on a window whose whole colour discipline is
        * that `driver_colors` crosses the wire so no consumer invents one. */}
       <td className="col-drv">
-        <span className="drv-swatch" style={{ background: driverColour(arcade, code) }} />
+        <span className="drv-swatch" style={{ background: driverColour(arcade.driver_colors, code, NO_COLOUR) }} />
         {code}
       </td>
       <td className="col-gap">{formatGapCell(gap)}</td>
@@ -402,16 +403,8 @@ function tyreCell(last: LapRow | null): string {
 
 
 /**
- * The driver's own colour, from the arcade's palette on the wire.
- *
- * Never a table here: `driver_colors` rides on every tick precisely so no
- * consumer keeps a second copy of a palette this repo has already found five
- * copies of.
+ * `--qt-border` for a car the wire has no colour for, not `--qt-fg-1`: as a
+ * swatch the old fallback painted a bright white bar, which reads as a team
+ * colour rather than as the absence of one.
  */
-function driverColour(arcade: ArcadeState, code: string): string {
-  const rgb = arcade.driver_colors[code];
-  // `--qt-border` for a car the wire has no colour for, not `--qt-fg-1`: as a
-  // swatch the old fallback painted a bright white bar, which reads as a team
-  // colour rather than as the absence of one.
-  return rgb ? `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})` : "var(--qt-border)";
-}
+const NO_COLOUR = "var(--qt-border)";

--- a/src/pitwall/ui/src/features/data/TraceStack.tsx
+++ b/src/pitwall/ui/src/features/data/TraceStack.tsx
@@ -93,8 +93,6 @@ const INFO = "#3b82f6";
 const SUCCESS = "#10b981";
 /** palette.DANGER */
 const DANGER = "#ef4444";
-/** palette.WARNING - the rival, on every lane */
-const RIVAL = "#f59e0b";
 /** palette.ACCENT - gear, the one new colour site */
 const ACCENT = "#a78bfa";
 
@@ -253,6 +251,22 @@ export interface TraceStackProps {
   /** Locked X maximum: the circuit length, or the fallback until one arrives. */
   xMax: number;
   rivalCode: string | null;
+  /**
+   * The rival's own team colour, resolved by `DataWindow` (#1070).
+   *
+   * A prop rather than a constant here, and that IS the fix. Every rival series
+   * on all six lanes used to draw in a fixed `palette.WARNING` amber, inherited
+   * 1:1 from the Qt panel this is a port of, which fixes the rival to WARNING at
+   * `telemetry_panel.py:101,131,167,181,195`. That was deliberate and it stopped
+   * being right the moment the tower could pin any car: the amber sits an RGB
+   * distance of 33.5 from McLaren papaya, the closest pair in the whole team
+   * palette, so pinning a McLaren looked correct and pinning anyone else looked
+   * like the colour had gone stale.
+   *
+   * Resolved once above and passed down for the same reason the CODE is (#1051):
+   * the chip and the six series must not be able to disagree about one car.
+   */
+  rivalColour: string;
   /** Where the car is on the lap right now, in metres. Null before the first tick. */
   cursorX: number | null;
   /** Replaces the whole stack when set - a dead feed with nothing accumulated. */
@@ -291,6 +305,7 @@ export function TraceStack(props: TraceStackProps) {
     delta,
     xMax,
     rivalCode,
+    rivalColour,
     cursorX,
     placeholder = null,
   } = props;
@@ -419,8 +434,8 @@ export function TraceStack(props: TraceStackProps) {
               ? delta
               : channel(rival, lane)
             : [],
-          lineStyle: { color: RIVAL, width: 2, type: "dashed" as const },
-          itemStyle: { color: RIVAL },
+          lineStyle: { color: rivalColour, width: 2, type: "dashed" as const },
+          itemStyle: { color: rivalColour },
         };
         // **The rival is declared FIRST so the own car paints on top of it.** The
         // race trace states the rule ("our own car moved LAST so it draws on top")
@@ -429,7 +444,7 @@ export function TraceStack(props: TraceStackProps) {
         return [rivalSeries, own];
       }),
     };
-  }, [box, main, rival, delta, xMax, rivalCode]);
+  }, [box, main, rival, delta, xMax, rivalCode, rivalColour]);
 
   const chart = useEChart(box > 0 && !placeholder ? option : null);
   const boxes = laneLayout(box);

--- a/src/pitwall/ui/src/features/data/TrackRing.tsx
+++ b/src/pitwall/ui/src/features/data/TrackRing.tsx
@@ -25,6 +25,7 @@
  */
 
 import type { ArcadeState } from "../../lib/bridge";
+import { driverColour } from "../../lib/driverColour";
 import { driverStatus, type DriverStatus } from "../../lib/driverStatus";
 
 /** SVG user units. The viewBox is square and the ring is centred in it. */
@@ -59,9 +60,8 @@ function place(fraction: number): { x: number; y: number } {
   };
 }
 
-function rgb(colour: [number, number, number] | undefined): string {
-  return colour ? `rgb(${colour[0]}, ${colour[1]}, ${colour[2]})` : "var(--qt-fg-2)";
-}
+/** This ring's dim dot for a car the wire has no colour for. */
+const NO_COLOUR = "var(--qt-fg-2)";
 
 export function TrackRing({ arcade, rival }: { arcade: ArcadeState; rival: string | null }) {
   // The two labelled cars go on OPPOSITE sides of their dots. They are the
@@ -106,7 +106,7 @@ export function TrackRing({ arcade, rival }: { arcade: ArcadeState; rival: strin
     dots.push({
       code,
       ...place(car.rel_dist),
-      colour: rgb(arcade.driver_colors[code]),
+      colour: driverColour(arcade.driver_colors, code, NO_COLOUR),
       status: driverStatus(car),
       label: labelSide(code),
     });

--- a/src/pitwall/ui/src/lib/driverColour.ts
+++ b/src/pitwall/ui/src/lib/driverColour.ts
@@ -1,0 +1,45 @@
+/**
+ * A driver's own colour, off the wire, in the one place that conversion lives.
+ *
+ * `driver_colors` rides on every tick as an RGB triple precisely so no consumer
+ * keeps a second copy of a palette this repo has already found five copies of
+ * (#857). That solved the PALETTE and left the CONVERSION duplicated: the tower,
+ * the ring and the race trace each had their own three-line `rgb(...)` builder,
+ * and band 4 was about to get a fourth when its rival trace stopped being a
+ * fixed token (#1070). Three near-identical helpers is how the fourth one gets a
+ * different fallback nobody notices.
+ *
+ * **The fallback is a parameter, not a default, because the three callers
+ * genuinely need different ones and each reason is worth keeping:**
+ *
+ * - the tower wants `--qt-border`, because as a swatch a bright `--qt-fg-1`
+ *   reads as a team colour rather than as the absence of one;
+ * - the ring wants `--qt-fg-2`, its own dim dot;
+ * - anything drawn on an ECharts CANVAS cannot use a CSS custom property at
+ *   all - `var(--qt-fg-1)` does not resolve there and the series silently falls
+ *   back to ECharts' own palette, the one colour set on this window that answers
+ *   to nothing.
+ *
+ * So a caller that passes a `var(--...)` fallback is promising the value lands
+ * in CSS, and a canvas caller must pass a literal.
+ */
+
+/** The wire's per-driver palette: `arcade.driver_colors`. */
+export type DriverColours = Record<string, [number, number, number]>;
+
+/**
+ * `rgb(r, g, b)` for `code`, or `fallback` when the wire has no colour for it.
+ *
+ * A missing entry is a real state, not a bug to paper over: a car the producer
+ * has never placed has no colour, and painting it in some default would claim a
+ * team it does not have.
+ */
+export function driverColour(
+  colours: DriverColours,
+  code: string | null,
+  fallback: string,
+): string {
+  if (code === null) return fallback;
+  const rgb = colours[code];
+  return rgb ? `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})` : fallback;
+}

--- a/src/pitwall/ui/src/styles/data.css
+++ b/src/pitwall/ui/src/styles/data.css
@@ -642,14 +642,22 @@ td.col-drv {
   padding: 2px 8px;
 }
 
-/* palette.INFO / palette.WARNING, the two chip colours `TelemetryPanel`
- * constructs with. Guarded by `test_pitwall_tokens.py`. */
+/* palette.INFO, the own car's chip colour `TelemetryPanel` constructs with.
+ * Guarded by `test_pitwall_tokens.py`. */
 .driver-chip-main {
   color: #3b82f6;
 }
-.driver-chip-rival {
-  color: #f59e0b;
-}
+
+/* **The rival chip has no colour here, and that is the fix for #1070.** It used
+ * to carry palette.WARNING beside the rule above, matching the fixed amber the
+ * six trace lanes drew in. Both came from the Qt port, which fixes the rival to
+ * WARNING whoever it is. Once the tower could pin any car that stopped being
+ * right: the amber sits an RGB distance of 33.5 from McLaren papaya, the closest
+ * pair in the team palette, so a McLaren rival looked correct and everyone else
+ * looked like a stale colour. The value is now per-driver, off `driver_colors`
+ * on the wire, and arrives as an inline `color` from `DataWindow`; the
+ * `currentColor` border above follows it. A stylesheet cannot know which car is
+ * pinned, so there is nothing to put here. */
 
 /* --- The 2x2 grid ------------------------------------------------------- */
 

--- a/tests/surfaces/test_pitwall_tokens.py
+++ b/tests/surfaces/test_pitwall_tokens.py
@@ -263,11 +263,17 @@ ECHART_SITES = (("TEXT_SECONDARY", 1), ("BORDER_COLOR", 1), ("TEXT_TERTIARY", 1)
 # lane table in `TraceStack`, whose colours are the four palette names it uses plus
 # the two the new lanes add - ACCENT for gear (its own channel, a staircase) and INFO
 # reused for DRS (a bit, in the thinnest lane).
+# No RIVAL slot any more (#1070). Band 4's rival used to draw in a fixed
+# palette.WARNING on all six lanes, inherited from the Qt panel, and it now takes
+# the pinned driver's own colour off `driver_colors`. There is no constant left
+# to pin, and the property that replaced it - the served colour equals the pinned
+# car's - is not a palette question at all: it is asserted through the built
+# bundle in `smoke-data.mjs`, because a palette-membership check can never fail
+# on it.
 TRACE_SLOTS = {
     "INFO": "INFO",
     "SUCCESS": "SUCCESS",
     "DANGER": "DANGER",
-    "RIVAL": "WARNING",
     "ACCENT": "ACCENT",
 }
 
@@ -340,9 +346,12 @@ def test_the_trace_colours_are_in_the_right_slots():
     """Copy number six: band 4's six lanes, one palette name each.
 
     A DIFFERENT colour per channel - INFO for speed and the delta baseline, SUCCESS
-    for throttle, DANGER for brake, ACCENT for gear, WARNING for the rival on every
-    lane. A membership test cannot see brake and throttle swapping places; both
-    hexes stay in the palette and the window is simply wrong.
+    for throttle, DANGER for brake, ACCENT for gear. A membership test cannot see
+    brake and throttle swapping places; both hexes stay in the palette and the
+    window is simply wrong.
+
+    The rival is NOT in this map. It used to be, as WARNING on every lane, and
+    #1070 replaced that constant with the pinned driver's own colour.
 
     Read from `TraceStack`, which is where the lane table lives now. The file this
     used to read (`OwnCarTraces`) kept four `<metric>_main` constants for the 2x2;
@@ -396,8 +405,8 @@ def test_the_data_stylesheets_raw_hexes_are_guarded_too():
     )
     assert raw[3] == _rgb_to_hex(palette.DANGER), "band 1's Disconnected chip copies DANGER"
     assert raw[4] == _rgb_to_hex(palette.WARNING), (
-        "the rival chip, band 1's PROVISIONAL chip, a slower-than-own-best sector, the "
-        "neutralised-lap rail and the radio's SC / flag category chips copy WARNING"
+        "band 1's PROVISIONAL chip, a slower-than-own-best sector, the neutralised-lap "
+        "rail and the radio's SC / flag category chips copy WARNING"
     )
 
 


### PR DESCRIPTION
## What

Band 4's six rival traces and its header chip take the pinned driver's own team
colour from `driver_colors`, instead of a fixed amber.

Closes #1070.

## Why, and it was not what it looked like

Reported from the running product: changing the pinned rival from PIA to VER
left VER drawn in McLaren orange. That reads as a stale colour, and it is not.

The rival was **never** drawn from `driver_colors`. `TraceStack.tsx` held
`const RIVAL = "#f59e0b"`, applied to all six rival series, with a matching
literal on `.driver-chip-rival` in `data.css`. Both came 1:1 from the Qt panel
this is a port of, which fixes the rival to `WARNING` whoever it is
(`telemetry_panel.py:101,131,167,181,195`), and both shipped in `bf17cd95`,
before the selector existed. Neither #1067 nor #1068 touched a colour line.

Diagnosed off the built bundle fed real captured ticks. Clicking the VER tower
row moves the chip, the ring label and the plotted data to VER while every
rival series stays `#f59e0b`. That rules out memoisation staleness, an ECharts
`setOption` merge, and a wrong-key lookup: a lookup under the wrong key would
have drawn papaya, and amber exists nowhere in `driver_colors`.

**What made it look stale is arithmetic.** PIA's real colour is
`rgb(255,128,0)` papaya; the token is `#f59e0b` amber. RGB distance **33.5**,
the closest pair in the whole ten-colour team palette. So a McLaren rival looked
right and everyone else looked broken. VER's `#0600ef` is the farthest, at 366.

The fidelity is being broken deliberately: the rival now carries its team
colour.

## How

Resolved once in `DataWindow` beside the rival's code and passed down, for the
same reason the code is (#1051): the chip and the six series must not be able to
disagree about one car. The chip takes an inline `color`, and its
`currentColor` border follows for free.

**Also folded in, because band 4 was about to become the fourth copy.** The
RGB-triple to `rgb(...)` conversion existed three times, in the tower, the ring
and the race trace, each with its own fallback. It is now one helper in
`lib/driverColour.ts`, with the fallback as a parameter because the three
genuinely differ and each reason is worth keeping: the tower wants a border grey
so a missing colour does not read as a team colour, the ring wants its dim dot,
and an ECharts canvas must be handed a literal because `var(--qt-*)` does not
resolve there and the series would fall back to ECharts' own palette.

The inventory says these were the only two defect sites. The tower swatches, the
ring dots and the race trace already read `driver_colors` per car and were
pin-correct.

## Out of scope

**A readability note, from looking at the result rather than from the tests.**
Red Bull's `#0600ef` is dark, and the SPEED lane's own car already draws in INFO
`#3b82f6`. VER's dashed line is legible but has less punch than the amber had;
on THROTTLE, BRAKE and GEAR it stands out cleanly because those lanes are a
different hue. Separation now rests on dashed-rival against solid-main at equal
width. Left alone: it follows from the change being asked for, and it is one
line to adjust if it turns out to matter in use.

## Checks

- `smoke-data` 284 to **289**, `smoke-agents` **65**, `tests/surfaces/` **285**,
  ruff clean.
- **The new guard watched failing.** Restoring the fixed amber turns six checks
  red, including `and the colour actually changed across the pin (#f59e0b ->
  #f59e0b)`. The guard reads the rendered `lineStyle.color` off all six series
  and the chip's computed style, and compares both to `driver_colors[pinned]`
  from the same fed tick, never to a hex literal. It pins VER over a NOR/PIA
  pairing on purpose: a teammate pin would pass under a wrong-key bug, because
  both McLarens are the same papaya.
- **The first form of that mutant did not compile**, so the build stopped,
  `dist/` kept the previous bundle and the suite reported `289 OK`. Recorded as
  no evidence rather than as a pass, and rewritten until it built.
- Two Python token assertions that pinned the amber are gone rather than
  retargeted: there is no constant left to pin, and "the served colour equals the
  pinned car's" is not a palette question. A palette-membership check can never
  fail on it.
- Seen, not only tested: VER pinned against 200 real captured ticks renders the
  chip and all six dashed traces in Red Bull blue.
