### PR TITLE
fix(arcade): sort the shared lap-boundary sample stably

### DIFF
--- a/documents/research/PITWALL_DELIVERY_PLAN.md
+++ b/documents/research/PITWALL_DELIVERY_PLAN.md
@@ -604,20 +604,29 @@ over a threshold that could never fire.
   the reveal withholds that driver's later parquet laps. Data-honest - the replay has no telemetry
   to place them - and unreachable on Melbourne, where all twenty run to the line. Written down so
   it is not filed as a reveal bug.
-- **The latent P2 for trace readers FIRES on real data, and the mechanism named here was wrong.**
-  This entry used to say the arcade's `lap` channel "is interpolated, so it can label ~2,000 frames
-  as a lap that has no telemetry behind it", and that Gate A could reproduce the mechanism by
-  executing the code path but not show it firing. Measured on 621 real Melbourne ticks during R3:
-  **70 events a race across 17 of the 20 drivers.** One frame carries the PREVIOUS lap number with
-  a mid-lap distance, between two correct frames 40 ms apart. HAM at the lap-24 crossing reads lap
-  23 at 2586.2 m, half a lap from where the car is.
-  The channel is not interpolated: `data.py:402` writes a per-lap CONSTANT into each lap's array,
-  `410-411` concatenates every lap and sorts the whole thing by `t`, and FastF1's padded lap
-  windows overlap, so a stale row sorts in between two live ones and carries its own lap's
-  `dist` with it.
-  It reaches every consumer of `rel_dist`, not only the trace buffer. Band 4 defends itself by
-  skipping a sample whose lap goes backwards (`traceBuffer.ts`, #1066); the producer-side fix is
-  tracked separately.
+- **The latent P2 for trace readers FIRED on real data. Fixed in #1069, and the mechanism this
+  entry named was wrong twice before it was measured.**
+  It first said the arcade's `lap` channel "is interpolated, so it can label ~2,000 frames as a lap
+  that has no telemetry behind it". The correction that replaced it said FastF1's padded lap
+  windows overlap so a stale row sorts in between two live ones carrying its own `dist`. Both are
+  refuted by the census in #1069: across 2,820 lap boundaries on three races, every boundary shares
+  **exactly one** sample with the previous lap at **exactly the same `t`**, every gap zero to the
+  bit, no multi-row overlap and no near-tie. There is nothing to interleave.
+  The real mechanism: FastF1's per-lap windows SHARE their boundary sample, so the concatenation
+  carries every crossing twice at one instant, and `np.argsort` defaulted to quicksort, which is
+  not stable. The tie broke arbitrarily and flipped 158 of Melbourne's 907 boundaries, 190 of Las
+  Vegas's 866 and 256 of Qatar's 1,047. What it corrupted is the three per-lap CONSTANTS: `lap`,
+  `tyre` and `tyre_life`. Per-sample channels are bitwise identical in both copies and cannot move.
+  **The measurement was also mislabelled.** The "70 events a race across 17 of the 20 drivers" is
+  the FULL-RACE served count, not something a 124-second capture over laps 22 to 24 could hold;
+  that window contains about three. Served, Melbourne 2025: `lap` backwards on 70 frames,
+  `tyre_life` on 105, `tyre` flicker on 2, out of 3,083,460.
+  **And the worst effect was never noticed.** A glitched FINAL crossing makes
+  `_lap_fraction_from_distance` normalise the whole last lap by the two-to-four-frame phantom
+  segment, so `rel_dist` saturates: HAM and LEC shipped their entire lap 57 pinned at the
+  start/finish line, 92.3 s and 90.7 s of active frames, while speed and gear kept moving. About
+  two drivers a race. `kind="stable"` takes all of it to zero.
+  Band 4's own defence stays (`traceBuffer.ts`, #1066): it guards against an older producer.
 - **#199 Phase D.3 gains weight.** `snapshot_dict` re-runs a recursive `asdict` over the 30-entry
   tail ten times a second with a blocking `sendall`, so one stalled subscriber can hitch the pyglet
   frame loop. Inherited, not introduced, but the wire is now load-bearing.

--- a/src/arcade/config.py
+++ b/src/arcade/config.py
@@ -173,7 +173,7 @@ ARCADE_CACHE_DIR: Final[Path] = get_data_root() / "cache" / "arcade"
 # not written because rebuilding a session costs 254 s. Until it is, the obligation lives
 # here: if the bytes a rebuild would produce differ from the bytes on disk, this string moves
 # in the SAME commit, or the fix reaches nobody who already has a pickle.
-CACHE_VERSION: Final[str] = "v13"  # + the discrete channels stop being interpolated (#1002)
+CACHE_VERSION: Final[str] = "v14"  # + the shared lap-boundary sample sorts stably (#1069)
 
 # --- Multiprocessing pool -------------------------------------------------
 # Serial by default — Windows spawn + pickling a loaded session across 8

--- a/src/arcade/data.py
+++ b/src/arcade/data.py
@@ -259,7 +259,11 @@ def _nearest_sample(t: np.ndarray, timeline: np.ndarray) -> np.ndarray:
 
     Ties go to the EARLIER sample, which matters because the raw stream carries
     907 duplicate-`t` pairs on this race: `<=` makes the pick deterministic
-    instead of dependent on floating-point noise.
+    instead of dependent on floating-point noise. Those 907 all have one cause,
+    found in #1069: FastF1's per-lap windows share their boundary sample, so
+    every crossing is concatenated twice at the same instant. `<=` settles which
+    of the pair a timeline instant reads; `_concat_sorted_by_time` settles which
+    of them comes first, and until #1069 that half was left to quicksort.
 
     Leans on `len(t) >= 2`, which `_process_driver_data` guarantees - it skips
     any lap with fewer than two samples and returns None when a driver has no
@@ -273,6 +277,51 @@ def _nearest_sample(t: np.ndarray, timeline: np.ndarray) -> np.ndarray:
 # The eight forward gears plus neutral. 0 is a REAL reading - 1,400 raw samples
 # on Melbourne 2025, and the PITWALL GEAR lane's [0, 9] range renders it - so the
 # validity test is one-sided.
+def _concat_sorted_by_time(arrays: dict[str, list[np.ndarray]]) -> dict[str, np.ndarray]:
+    """Flatten the per-lap arrays into one time-ordered block per channel.
+
+    **The sort has to be STABLE, and that is why this is a function** (#1069).
+    FastF1's per-lap telemetry windows SHARE their boundary sample rather than
+    abutting, so the concatenation carries every lap crossing twice at the same
+    `SessionTime`: 907 duplicate pairs on Melbourne 2025, 866 on Las Vegas, 1047
+    on Qatar, all 2820 of them a lap boundary and none anywhere else, every gap
+    zero to the bit. `np.argsort` defaults to quicksort, which is not stable, so
+    the tie broke arbitrarily and put the OLD lap's copy second on 158 rows of
+    Melbourne, 190 of Las Vegas and 256 of Qatar.
+
+    What that corrupted is the three channels written as per-lap CONSTANTS in
+    `_process_driver_data`: `lap`, `tyre` and `tyre_life`. A per-SAMPLE reading
+    cannot be hurt by the swap, because both copies are the same instant and hold
+    bitwise-identical values - `gear`, `drs`, `brake`, `throttle` and `speed`
+    moved by zero on all 2820 pairs. A per-lap constant is discontinuous at
+    exactly that boundary, so it moved on every flipped one. `tyre_life` was the
+    worst, reading a 34-lap-old INTERMEDIATE one frame after a fresh MEDIUM went
+    on.
+
+    **The consequence was not one frame.** `_lap_fraction_from_distance` finds
+    lap starts with `np.diff(lap) > 0`, which fires twice on `23, 24, 23, 24`,
+    leaving a segment two to four frames long. Mid-race that publishes a stale
+    frame at half a lap. On a driver's FINAL crossing the last segment borrows
+    that length as `previous_length`, so the whole last lap is normalised by
+    about 10 m instead of 5220 and `rel_dist` saturates at 1.0: on the shipped
+    Melbourne replay HAM and LEC sat on the start/finish line for 92.3 s and
+    90.7 s of active frames while their speed and gear kept moving. Roughly two
+    drivers a race.
+
+    Stability keeps the concatenation order for equal times, and the
+    concatenation follows `iterlaps()`, which is ascending for every driver on
+    all three of those races. `np.lexsort((concat["lap"], concat["t"]))` would
+    decide the tie explicitly rather than inherit it; it is not used because the
+    ordering already holds and one keyword is smaller. Dropping the duplicate row
+    instead was measured and rejected: it advances the lap counter early on about
+    1100 frames a race, where keeping both copies reads the old lap right up to
+    the crossing, which is the correct reading.
+    """
+    concat = {k: np.concatenate(v) for k, v in arrays.items()}
+    order = np.argsort(concat["t"], kind="stable")
+    return {k: v[order] for k, v in concat.items()}
+
+
 _MAX_GEAR = 8
 
 
@@ -407,10 +456,7 @@ def _process_driver_data(args: tuple) -> dict | None:
     if not arrays["t"]:
         return None
 
-    concat = {k: np.concatenate(v) for k, v in arrays.items()}
-    order = np.argsort(concat["t"])
-    for k in concat:
-        concat[k] = concat[k][order]
+    concat = _concat_sorted_by_time(arrays)
     # After the sort, because the fill carries a gear FORWARD in time and the
     # per-lap arrays are concatenated in lap order but the samples inside them
     # are only sorted here.

--- a/src/pitwall/ui/src/features/data/traceBuffer.ts
+++ b/src/pitwall/ui/src/features/data/traceBuffer.ts
@@ -164,13 +164,22 @@ export class TraceAccumulator {
       this.entries.set(code, { lap, rows: new Map() });
     } else if (lap < entry.lap) {
       // A lap number that goes BACKWARDS is a glitch, not a rewind - a rewind
-      // arrives as `rewound` and evicts everything. Measured on Melbourne 2025:
-      // 70 of these a race across 17 of the 20 drivers, one frame each, and the
-      // glitch frame carries a stale lap with a mid-lap `dist` (HAM reads lap 23
-      // at 2586.2 m one frame after crossing into 24). Storing it would put a
+      // arrives as `rewound` and evicts everything. Storing it would put a
       // foreign lap in the map; clearing on it, which `lap !== currentLap` used
-      // to do, would throw the lap away twice per crossing. It is a producer-side
-      // defect and it reaches every consumer of `rel_dist`, not just this buffer.
+      // to do, would throw the lap away twice per crossing.
+      //
+      // The producer emitted 70 of these a race across 17 of the 20 drivers on
+      // Melbourne 2025, fixed in #1069. **The mechanism this comment used to name
+      // was wrong** and is worth correcting rather than deleting, because it is
+      // what would stop the next reader checking: the stale frame does NOT carry
+      // a mid-lap `dist` of its own. Its distance sits a median 0.1 m from its
+      // neighbour. The half-lap reading came from the producer's lap-fraction
+      // helper dividing one frame of travel by a two-frame segment, which is 0.5
+      // by construction for every car at every crossing.
+      //
+      // Kept after the producer fix, not dead code: it guards against an older
+      // producer on the other end of the socket and against the next member of
+      // this family. Against a current producer it simply never fires.
       return;
     }
     store(this.entries.get(code)!.rows, sample);

--- a/tests/surfaces/test_arcade_telemetry_span.py
+++ b/tests/surfaces/test_arcade_telemetry_span.py
@@ -748,6 +748,64 @@ def test_a_tyre_age_is_a_whole_number_of_laps():
     assert not fractional, f"{len(fractional)} frames carry a fractional tyre age"
 
 
+# --- #1069: the shared lap-boundary sample is ordered stably --------------------
+
+
+def test_no_served_frame_takes_the_lap_number_backwards():
+    """FastF1's per-lap windows share their boundary sample, so every crossing is
+    concatenated twice at the same instant and an unstable sort put the OLD copy
+    second. Melbourne 2025 shipped **70 such frames across 17 of the 20 drivers**.
+
+    `tyre` and `tyre_life` are asserted in the same breath because they are the same
+    defect: all three are per-lap CONSTANTS, and a constant is discontinuous exactly
+    at the boundary the tie sits on. `tyre_life` was the worst of them at 105 frames,
+    reading a 34-lap-old INTERMEDIATE one frame after a fresh MEDIUM went on. A
+    per-sample channel cannot be hurt by the swap, which is why gear and DRS are not
+    here.
+    """
+    session = _melbourne_or_skip()
+    offenders = []
+    for code, frames in session.frames_by_driver.items():
+        for previous, current in zip(frames, frames[1:]):
+            if not current.active:
+                continue
+            if current.lap < previous.lap:
+                offenders.append(f"{code} lap {previous.lap}->{current.lap}")
+            # A tyre age may only fall onto a FRESH tyre, which is a pit stop and
+            # correct. Melbourne has 35 of those and they must survive.
+            if current.tyre_life < previous.tyre_life and current.tyre_life > 2:
+                offenders.append(f"{code} life {previous.tyre_life}->{current.tyre_life}")
+    assert not offenders, f"{len(offenders)} backwards frames, first few: {offenders[:5]}"
+
+
+def test_no_driver_is_parked_on_the_line_for_a_whole_lap():
+    """The glitch's largest effect, and the one nobody had noticed (#1069).
+
+    `_lap_fraction_from_distance` lengths each lap by the distance to the next lap
+    start. A doubled crossing leaves a segment two to four frames long, and on a
+    driver's FINAL crossing the last lap borrows that as `previous_length`, so the
+    whole lap is normalised by about 10 m instead of 5220 and `rel_dist` saturates.
+    On the v13 pickle **HAM and LEC sat at `rel_dist >= 0.999` for 2308 and 2267
+    consecutive active frames, 92.3 s and 90.7 s**, the entirety of lap 57, while
+    their speed and gear kept moving. The TrackRing and the pyglet renderer both
+    place a car from `rel_dist`, so both drew them stopped on the line.
+
+    A car really is at the line for a few frames per crossing, so the threshold is a
+    run LENGTH rather than the value. The worst legitimate run measured across the
+    field is 10 frames; 100 is four seconds and cannot be a real approach.
+    """
+    session = _melbourne_or_skip()
+    parked = {}
+    for code, frames in session.frames_by_driver.items():
+        longest = run = 0
+        for frame in frames:
+            run = run + 1 if (frame.active and frame.rel_dist >= 0.999) else 0
+            longest = max(longest, run)
+        if longest > 100:
+            parked[code] = f"{longest} frames ({longest * DT:.1f} s)"
+    assert not parked, f"drivers pinned at the start line: {parked}"
+
+
 # --- the same rules on a hand-built driver, so CI can see them ------------------
 #
 # Every guard above reads the cached 382 MB pickle, which no CI runner has, so all of
@@ -862,3 +920,63 @@ def test_a_channel_that_is_entirely_impossible_is_left_as_published():
 
     published = np.array([128.0, 128.0])
     assert list(_drop_impossible_gears(published)) == [128.0, 128.0]
+
+
+def _windows_sharing_their_boundary(laps: int = 56, per_lap: int = 20) -> dict:
+    """Per-lap arrays shaped the way FastF1 hands them over: each lap's window ENDS
+    on the instant the next one begins, so the concatenation carries every crossing
+    twice at the same `t`.
+
+    **The size is load-bearing and must not be shrunk.** numpy's default sort is an
+    introsort whose leaf is insertion sort, which IS stable, so below about 17
+    elements the duplicate keeps its order under the broken code too and the guard
+    would assert about a condition it cannot create. WHICH ties flip is also
+    position-dependent: only 158 of Melbourne's 907 do. At 56 laps of 20 samples,
+    the shape of a real driver, the default sort misorders 15 of the 55 boundaries.
+    """
+    import numpy as np
+
+    arrays: dict[str, list] = {"t": [], "lap": [], "tyre": [], "tyre_life": []}
+    clock = 0.0
+    for lap_number in range(1, laps + 1):
+        window = np.arange(per_lap, dtype=float) * DT + clock
+        clock = float(window[-1])
+        arrays["t"].append(window)
+        arrays["lap"].append(np.full(per_lap, float(lap_number)))
+        # One stop on lap 31, so the tyre age resets the way a real one does and a
+        # backwards step can be told apart from a pit stop.
+        fresh = lap_number > 30
+        arrays["tyre"].append(np.full(per_lap, 2.0 if fresh else 1.0))
+        arrays["tyre_life"].append(
+            np.full(per_lap, float(lap_number - 30 if fresh else lap_number))
+        )
+    return arrays
+
+
+def test_a_shared_lap_boundary_sample_comes_out_lap_ascending():
+    """The mechanism of #1069, on hand-built arrays, so CI sees it without the pickle.
+
+    The two guards above read the cached 382 MB session and skip everywhere else.
+    This one runs the ordering itself, and it is what goes red if `kind="stable"`
+    is dropped from `_concat_sorted_by_time`: on this fixture the default sort puts
+    the old lap's copy second at 15 of the 55 boundaries.
+    """
+    import numpy as np
+
+    from src.arcade.data import _concat_sorted_by_time
+
+    arrays = _windows_sharing_their_boundary()
+    concat = _concat_sorted_by_time(arrays)
+
+    # The fixture must actually contain the tie, or everything below is vacuous.
+    duplicated = int(np.count_nonzero(np.diff(concat["t"]) == 0.0))
+    assert duplicated == 55, f"the fixture carries {duplicated} shared boundaries, not 55"
+
+    assert np.all(np.diff(concat["lap"]) >= 0), "the lap number goes backwards"
+    # Nothing may be dropped: this orders rows, it does not filter them.
+    assert len(concat["lap"]) == 56 * 20
+    # A tyre age falls only onto the fresh tyre fitted on lap 31.
+    falls = np.flatnonzero(np.diff(concat["tyre_life"]) < 0)
+    assert list(concat["tyre_life"][falls + 1]) == [1.0], "a tyre aged backwards mid-stint"
+    # And the compound changes once, rather than flickering back and forth.
+    assert int(np.count_nonzero(np.diff(concat["tyre"]) != 0)) == 1

--- a/tests/surfaces/test_arcade_wire_contract.py
+++ b/tests/surfaces/test_arcade_wire_contract.py
@@ -876,7 +876,9 @@ def test_the_reveal_carrier_is_per_driver_and_not_the_main_driver_lap():
     field spans two or three different laps at 96 % of instants - so masking
     everyone at one lap lags the leaders and leaks look-ahead for the cars
     behind, at the same time. `laps_completed` reads the crossing map, so it
-    is per driver and monotone forward, unlike the interpolated `lap`.
+    is per driver and monotone forward. `lap` is not interpolated (it has been
+    nearest-sample since #1002) and it is monotone since #1069, but it is still
+    one driver's number on a tick that has to mask twenty.
     """
     snapshot = _order_snapshot(FAST=_drift_frames(12000, 52.0), SLOW=_drift_frames(12000, 30.0))
     fast = snapshot["drivers"]["FAST"]

--- a/tests/surfaces/test_pitwall_session_data.py
+++ b/tests/surfaces/test_pitwall_session_data.py
@@ -86,10 +86,13 @@ def test_the_reveal_is_per_driver_not_one_shared_cut():
 def test_the_reveal_is_strict_so_the_lap_in_progress_stays_hidden():
     """`L <= laps_completed`, never `<`, and never the lap being driven.
 
-    The carrier used to be the tick's `lap`, a rounded interpolation of a
-    step function measured non-monotone on 101 frames of 2.49 M: it flickers
-    a lap open a tick early at the line and never opens a finisher's last
-    lap. `laps_completed` comes off the crossing map.
+    The carrier used to be the tick's `lap`, which was measured non-monotone
+    and flickered a lap open a tick early at the line while never opening a
+    finisher's last lap. The non-monotonicity is gone as of #1069 (an unstable
+    sort over the boundary sample FastF1 delivers twice, 70 frames of 3.08 M on
+    Melbourne 2025, not the interpolation an earlier version of this docstring
+    blamed). `laps_completed` still comes off the crossing map, because a per
+    driver carrier is what a twenty car mask needs.
     """
     session = _session_or_skip()
     code = sorted(session.masked_view({}, 0.0)["drivers"])[0]


### PR DESCRIPTION
## What

`np.argsort` in the arcade loader's per-lap concatenation now sorts stably, and `CACHE_VERSION` moves to v14.

Closes #1069.

## Why

FastF1's per-lap telemetry windows **share their boundary sample** rather than abutting, so the concatenation carries every lap crossing twice at the same `SessionTime`. `np.argsort` defaults to quicksort, which is not stable, so the tie broke arbitrarily and sometimes put the old lap's copy second.

Measured over 2,820 lap boundaries on three cached races: every boundary shares exactly one sample with the previous lap, every gap zero to the bit, no multi-row overlap and no near-tie. Ties that actually flip: 158 of Melbourne's 907, 190 of Las Vegas's 866, 256 of Qatar's 1,047.

The swap corrupts the three channels written as per-lap **constants** (`lap`, `tyre`, `tyre_life`). A per-sample reading cannot move: both copies are the same instant and bitwise equal, so `gear`, `drs`, `brake`, `throttle` and `speed` differ on zero of the 2,820 pairs.

Served, Melbourne 2025, 3,083,460 frames:

| channel | before | after |
|---|---|---|
| `lap` backwards | 70 | **0** |
| `tyre_life` backwards | 105 | **35** |
| `tyre` flicker | 2 | **0** |
| drivers affected | 17 of 20 | **0** |

The 35 survivors are real pit stops: all at lap boundaries, landing on `tyre_life <= 2`, 30 of them changing compound.

### The effect was bigger than one frame, and nobody had noticed

`_lap_fraction_from_distance` finds lap starts with `np.diff(lap) > 0`, which fires twice on `23, 24, 23, 24` and leaves a segment two to four frames long.

Mid-race that publishes the stale frame at half a lap, and the half is arithmetic rather than a position: one frame of travel over a two-frame segment is 0.5 for every car at every crossing. Executed on the shipped helper at 3.2 m/frame it returns 2610.0 m of a 5220 m lap while the row's own distance advanced 3.2 m.

On a driver's **final** crossing the last lap borrows that segment as `previous_length`, so the whole lap is normalised by about 10 m instead of 5220 and `rel_dist` saturates at 1.0. On the shipped v13 pickle **HAM and LEC sat at `rel_dist >= 0.999` for 2,308 and 2,267 consecutive active frames, 92.3 s and 90.7 s, the entirety of lap 57**, while their speed and gear kept moving. The TrackRing and the pyglet renderer both place a car from `rel_dist`, so both drew them parked on the start/finish line. Roughly two drivers a race (ANT on Las Vegas; COL, OCO and ALO on Qatar).

## How

- `src/arcade/data.py` — the concat-and-sort moves into `_concat_sorted_by_time`, with `kind="stable"`. Extracted rather than patched in place so the ordering rule is reachable from a test without a FastF1 session or the 382 MB pickle. `_nearest_sample`'s docstring already cited "907 duplicate-`t` pairs" with no cause; it now names it.
- `src/arcade/config.py` — `v13` to `v14`, required by the obligation at `:169-175`.
- Three guards, two of them watched failing against the pre-fix data.
- Four documents corrected, because the wrong mechanism was written into four places and fixing only the code would leave the rest teaching it: `PITWALL_DELIVERY_PLAN.md` (the note that claims to *be* the correction and replaced one wrong mechanism with another), two test docstrings still calling the lap channel interpolated, and the `traceBuffer.ts` comment.

### Alternatives measured and rejected

- **Drop the duplicate row.** Advances the lap counter early on about 1,100 frames a race. Keeping both copies reads the old lap right up to the crossing, which is the correct reading.
- **Trim the padding.** There is no padding. The windows share exactly one instant; trimming removes a real edge sample and shifts the interpolation of `x`, `y` and `dist`.

## Out of scope

- `traceBuffer.ts`'s backwards-lap skip (#1066) **stays**. It guards against an older producer on the other end of the socket, and against the next member of this family. Against a current producer it never fires.
- The 35 legitimate `tyre_life` resets are correct and untouched.
- Four pandas `sort_values` calls on a wall-clock `Time` can tie the same way and also take the quicksort default (`data.py:764`/`:774`, `race_state_manager.py:580-585`, `weather_restore.py:75-76`, all weather samples). Unmeasured, not touched here.

## Checks

- `tests/surfaces/` **288 passed**, 0 skipped (285 on `dev` + 3 new).
- `ruff check .` clean, `ruff format --check .` 185 files formatted, repo-wide.
- `tsc --noEmit` clean, `npm run build` 0 TS errors, `smoke-data` 289, `smoke-agents` 65 (unchanged; the client change is a comment).
- **The Melbourne pickle was rebuilt on v14** (147 s) and the six pickle-backed guards were confirmed **executed, not skipped** — a version bump silently skips them otherwise.
- **Mutation, red first.** Removing `kind="stable"` leaves a mutant that still compiles (checked with `ast.parse`, since a mutant that does not build reads exactly like one that went red) and the CI guard fails on its named assertion. Restored with `cp` and verified byte-identical with `cmp`.
- **The two effect guards were run against the pre-fix payload** and both went red: `134 backwards frames, first few: ['NOR lap 7->6', 'NOR life 7.0->6.0', ...]` and `drivers pinned at the start line: {'LEC': '2267 frames (90.7 s)', 'HAM': '2308 frames (92.3 s)'}`.
- The pyglet replay was opened on the v14 rebuild and looked at: lap 1/57, the field distributed around the circuit, nobody on the line. **It was not driven to lap 57 by hand**, so the HAM/LEC park is verified by the served `rel_dist` measurement on both pickles and by the guard going red, not by eye.
- The guard's fixture size is load-bearing and the docstring says so: numpy's default sort is stable below about 17 elements, so a 3-lap fixture is green under the broken code too.
