### PR TITLE
fix(pitwall): the windows fit the screens they open on, and acknowledge state changes

### DIFF
--- a/documents/audits/GATE_PITWALL_RESPONSIVE.md
+++ b/documents/audits/GATE_PITWALL_RESPONSIVE.md
@@ -1,0 +1,409 @@
+# Design gate: PITWALL responsive + motion
+
+Gate run 2026-08-24 against `dev` @ `52f1f214`, on the live loopback host
+(`http://127.0.0.1:52528`), Melbourne 2025 producer. This file is appended as findings settle;
+an abrupt end means the gate died mid-run, not that the remaining questions passed.
+
+Verdicts are separated from prescriptions throughout. Where a change's blast radius could not be
+priced, that is said instead of prescribing.
+
+## Question index
+
+1. BESTS middle form: REFUTED as needed; a depth-1 ranked floor closes the real band.
+2. The 12 px pace row: CONFIRMED unsupported; its payoff exists on one screen class only.
+3. The real client set: CONFIRMED replaced by the place() table; only layout adaptation reaches the failing screens.
+4. AGENTS: clip CONFIRMED worth fixing (it is the charts' x axis); void REFUTED as the BESTS defect.
+5. Reflow needed in two places: the sub-1360 right column and the AGENTS chart minimum at laptop heights.
+6. Motion items: 1, 3, 6 survive; 2 blocked by radio keying; 4 desktop-only as scoped; 5 collides with unmount-on-switch; 7 see Q7.
+7. Hover: the 10 Hz cost premise REFUTED by measurement; the real hazards are row identity, not paint.
+8. Frozen filter: only user-driven items fire under it; 28 percent contrast loss; the tooltip portal escapes it correctly.
+9. The sprint spends itself on the horizontal defect, CONFIRMED, and its first fix is small.
+10. 1470 px: the number is not a layout constant; it is the header note's width. Not to be accepted.
+11. The 145 px gap: REFUTED as a sprint defect; unreachable at any default placement.
+
+## Rig used by this gate
+
+Live loopback pages, fresh browser context per size, `document.fonts.ready` plus 900 ms settle,
+matching the report's rig. The producer advances during a run, so lap-dependent text differs
+between probe rows; where that matters it is named. Fleet client heights are derived from
+`config.py:106-107` (`min(950, screen_h - 90)` outer) minus the 37.3 px title bar measured in
+`project_pitwall_data_layout.md`, the same machine-measured constant the report's width table
+leans on (its 14 px frame delta). Both constants are one machine's chrome applied fleet-wide;
+the direction of every conclusion survives that approximation, exact pixel values do not.
+
+The derived fleet clients, which the rest of this report uses:
+
+| screen | DATA client | AGENTS client |
+|---|---|---|
+| 1920x1080 | 1486 x 913 | 1486 x 913 |
+| 1707x960 | 1486 x 833 | 1486 x 833 |
+| 1536x864 | 1486 x 737 | 1482 x 737 |
+| 1440x900 | 1426 x 773 | 1386 x 773 |
+| 1366x768 | 1352 x 641 | 1312 x 641 |
+| 1280x720 | 1266 x 593 | 1226 x 593 |
+| 16:10 laptop class (1280x800, 1920x1200 at 150 %) | 1266-1352 x 673 | 1226-1312 x 673 |
+
+## Attacks on MEASUREMENTS.md
+
+### A1 (P1). The 1470 px floor is not a constant of the layout; it is the header note's text width, and it moves per lap
+
+The report's section 2 says the right edge "sits at 1465.2 px whatever the viewport" and calls the
+layout rigid. Measured live at 1266x593, the binding element is `.traces-lap`: with the note
+`NO TRACK IN COMMON WITH PIA YET` up, band 4's first grid track refuses to shrink below 545.4 px
+and the document overflows 199 px; with `Δ FROM 5026 m` up it refuses below 380 px and overflows
+34 px; with the label hidden by a style injection, the track collapses to the viewport-driven
+336 px and the overflow is exactly 0. The mechanism is `data.css:581`
+(`grid-template-columns: 1fr 260px`, whose `1fr` carries an `auto` minimum) meeting the
+`white-space: nowrap` on `.traces-lap` (`data.css:626`): a nowrap line's min-content is its full
+text, and nothing between it and the grid track has `min-width: 0`, so one line of race-state
+prose sets the whole window's minimum width. The notes compound
+(`OwnCarTraces.tsx:211-217`: blind list, delta anchor, and one of three no-delta reasons can all
+render at once), so the worst-case floor is not 1470, it is unbounded in the length of the note.
+
+Consequence for the sprint: "the layout is rigid below 1470 and does not reflow" prescribes a
+layout rebuild. The measured truth prescribes something much smaller first: the layout IS
+substantially fluid (the only fixed columns are the 630 px tower and the 260 px ring,
+`data.css:196` and `data.css:581`), and the floor is a min-content leak. An injected
+`minmax(0, 1fr)` on band 4 plus `min-width: 0` on `.traces` was tried live at 1266x593: overflow
+went to 0, the ECharts stack resized to 314 px through its own observer (`chart.ts:94`) without
+error, and the header fell back to its already-designed ellipsis. What that one-line change does
+NOT buy is a GOOD window at 1266, only an honest one; six lanes at 336 px were never designed or
+audited, and that blast radius is not priced here.
+
+### A2 (P1). Sections 2 and 3 are one defect, and section 3 understates what #1068 did
+
+The report presents the 1470 floor (section 2) and the `.traces-lap` truncation (section 3) as
+independent findings, and frames #1068's cost as "converted a wrap into a silent horizontal
+truncation" of the header. Before commit `9c573847` the label had no `nowrap`
+(verified against `9c573847^:data.css:607`), so its min-content was one word and the window had
+no note-driven floor; after it, the same commit created the entire section 2 overflow. The
+truncation the report describes is the SMALL symptom; the large one is that the nowrap turned a
+2 px-per-lane wrap into up to 200 px of off-screen ring and radio on laptop clients. This is the
+repo's own "a fix that moves a defect rather than removing it" class, which the brief flags as a
+possibility; it is confirmed, and the move was larger than the report says.
+
+### A3 (P2). The 51 px AGENTS clip belongs to the chart cards, not the text cards the report names
+
+Re-measured at 1265x593: the two 51 px overflows are on the PACE and TIRE `.agent-card-body`
+elements; SITUATION overflows 10 px and PIT 8 px. The report's sentence attaches the 51 to the
+cards whose visible losses it then describes (SITUATION's gap line, PIT's `UCUT 63% -> RUS`),
+which are the 10 and 8 px clips. What the 51 px actually hides is both charts' entire x axis,
+read off `shots/agents-1265x593.png`: neither chart shows its Lap axis at that client while both
+show it whole at 1486x833. The conclusion "51 px of card body is lost at the small client"
+survives; the diagnosis of WHERE changes what a fix would target.
+
+Also a characterisation error in the word "clips": `.agent-card-body` is `overflow: auto`
+(`agents.css:390`), so the content is wheel-reachable, invisible only because `qt-base.css:72-77`
+hides every scrollbar. Unreadable without an affordance, but not lost. The distinction is this
+window's own established vocabulary (the pace grid's edge fade exists for exactly this state).
+
+### A4 (P2). Both AGENTS probe sizes miss the product's actual worst client, and one of them is not a client at all
+
+`place()` gives AGENTS 1226 x 593 on a 1280x720 screen (width minus the 40 px stagger, height
+identical to DATA's). The report measured 1265x593 (a DATA width) and 1226x630 (630 is the outer
+height minus the OS allowance, with the 37 px title bar not yet subtracted, so it is not a client
+height the product produces). Re-measured at the true 1226x593: the clips are 51/51/10/8, the
+same as at 1265x593, so the report's "14 px at 1226x630" understates the 720p laptop by 37 px of
+height, and the conclusion happens to survive only because width barely matters here. Wrong
+population, right verdict, by luck.
+
+### A5 (P2). The report never crosses its own height band with the heights the product opens at
+
+Section 2 crosses `place()` with WIDTH and stops. Crossing it with HEIGHT (table above) changes
+how several headline numbers read:
+
+- The BESTS dead band's worst waste, 81 px at h=673, is realized by 16:10 laptops
+  (1280x800-class, including 1920x1200 at 150 %). The six screens in the report's own table
+  realize at most ~49 px (measured live: gap 49 at the 1366x768 client 1352x641) and 1 px at
+  720p.
+- The "second hole", 65 px at h=1000 and 145 px at h=1080, is unreachable at ANY default
+  placement: `WindowSpec` caps the outer height at 950 (`config.py:107,123`), the tallest client
+  the product can open is ~913, and `place()` never grows a window (`config.py:103-104`).
+  Measured at 1486x913: depth 15, gap 14. Even the depth-17 data saturation is unreachable at
+  defaults. The second hole exists only after a manual resize.
+- RACE PACE's "overflows at every client the product opens at" is one screen short of true: at
+  the 1920x1080 client (h=913) the measured overflow is 0. It is true of every laptop client.
+
+### A6 (P3). Provenance and small wording
+
+- The recorded probe (`probes/measure_band.mjs`) cannot produce section 4: it hardcodes
+  `data.html`, waits on `.bests` and clicks DATA's tabs. The AGENTS numbers came from an
+  unrecorded rig. They reproduce (51/14 at the report's sizes, void 221.8 px at 1486x833), so
+  this is a provenance gap, not a data defect.
+- "Every row above is byte-identical at 1265, 1350, 1485 and 1600 px wide" is true of the BESTS
+  columns and false of the full probe rows (the clipped-element census reads 30 at narrow widths
+  against 25-26 at wide, which is the horizontal overflow itself). The width-independence claim
+  survives for the table it is about.
+- The width-sweep floor of section 2 was measured with the longest single note up. With shorter
+  notes the same sweep would find a lower floor; the fleet-loss column ("DATA loses 39/113/199")
+  is therefore the worst steady state, not the constant state. The 1440x900 client measured 0
+  overflow in this gate's own run purely because the note happened to be `Δ FROM 1 m` at that
+  instant.
+
+## Answers
+
+### Q1. A middle form for BESTS, or fewer forms
+
+Facts first. The card's height is linear in depth: 99 + 18k px (measured 153 at depth 3, 207 at
+6, 243 at 8, 297 at 11, 369 at 15, 405 at 17; row height 18, `band-data.log`). So a depth-1
+ranked card is 117 px and depth-2 is 135. The compact card is 62 px, and its own comment says it
+is one wrap from folding THEO under an unannounced fold (`BestsPanel.tsx:244-252`), so the
+compact form is already at ITS floor. Crossing with the fleet: the room under the tower is
+roughly gap + 62; the 16:10 laptop client (h=673, room 143) fits a depth-2 card with 8 px to
+spare, and the 1366x768 client (h=641, room ~111) fits nothing between 62 and 117, so no
+lowering of the ranked floor reaches it.
+
+Verdict: REFUTED that a new middle FORM is needed for the band the sprint was scoped around.
+Lowering `RANKED_FLOOR` from 3 to 1 (`BestsPanel.tsx:53`) closes the 16:10 dead band with the
+existing ranked form, at 117-135 px against 143 of room. The genuinely unserved band is room
+63-116, which only the 1366x768 client occupies, for ~49 px of waste; a third form to serve one
+screen's 49 px is more form than defect, and the docstring's own argument (a rank-1 list is still
+the four best holders plus THEO) covers the product meaning. The "tower takes the slack" option
+is dead on arrival: the tower renders 20 rows always as a deliberate decision
+(`project_pitwall_data_layout.md`, "20 rows always, retirements included"). The
+"column stops being content-sized" option re-opens sprint 9's measured lesson that anchoring
+moves the void inside the card. One caution the sprint must carry: at depth 1 the subtitle still
+has to say the depth, and the fit guard has to be driven red at h=641 and h=673 specifically,
+per the scope's own trap list.
+
+### Q2. The 12 px pace row height
+
+CONFIRMED that the constraint is real and unsupported, and the question is narrower than the
+brief phrases it. `--pace-row-h: 12px` with `padding: 0 1px` is at `data.css:1300,1309-1310`.
+The literature claim (Material 52, condensed 40, trading terminals 32-36, 12 px only as a font
+minimum) is quoted from the sprint's research file and was not re-derived by this gate.
+
+What this gate adds is who the fit is FOR. Zero-scroll needs client h >= 900 (`band-data.log`:
+paceOver 0 from 900 up, 22 at 833). Per the fleet table, h >= 900 exists only on the
+1920x1080-class client (913). Every laptop the product opens on scrolls the grid TODAY, with the
+edge fade and wheel already shipped for it (sprint 9). So "raising the row height breaks the
+57-row whole-race fit" is true on exactly one screen class, and the fit is knife-edge even
+there: at h=913 the scroller leaves room for 13.0 px rows, at h=900 for 12.8, so 12 is the only
+integer that fits both, and the 1707x960 reference machine already misses the fit by 22 px.
+
+Verdict: the whole-race fit is a desktop-only property that most of the fleet has already lost,
+so it should not be allowed to veto every responsive decision on the laptop clients where it
+does not exist. Whether the desktop keeps it is a product call for Víctor, not a gate finding;
+the honest framing for that call is "913-tall desktops keep zero-scroll at 12 px, or every
+client gets a taller row and the desktop joins the scroll it already has everywhere else". The
+fit is not the sprint's hard constraint; it is one screen class's feature.
+
+### Q3. The real client set
+
+CONFIRMED that the two designed-for sizes were guesses and the `place()` table replaces them;
+the widths in the report's section 2 reproduce exactly from `config.py:106-110` plus the 14 px
+frame, and the heights this gate derives are in the rig table above. Of the brief's four
+options, only "make the layout adapt" reaches the failing screens. Changing the default sizes
+cannot help: the spec already asks for 1500x950 and `place()` already clamps to the screen, so
+on a 1366 or 1280 laptop there are no pixels a different default could claim. A floor with OS
+clamping is the pre-`place()` world the module's own docstring documents as windows being CLIPPED
+with the status bar never visible (`config.py:76-80`); that is a regression, not an option. The
+one size-side decision worth making deliberately is the 40 px stagger, which taxes AGENTS' width
+on every screen narrower than 1540 (`config.py:108-109`); AGENTS absorbs it today, and whether
+it should keep absorbing it is a design decision this sprint can take with the layout in front
+of it.
+
+### Q4. AGENTS: the 51 px clip and the 220 px void
+
+First half, CONFIRMED worth fixing, with the corrected diagnosis from A3: at the 720p laptop
+client both chart cards hide 51 px of `overflow: auto` body, which is precisely both charts'
+x axis, and the two text cards cut a line mid-glyph (SITUATION 10 px, PIT 8 px, the cut running
+through `UCUT 63% -> RUS`, which is the window's next action). Severity P2: reachable by wheel,
+but nothing says so, and a mid-glyph cut reads as a rendering fault on the surface whose job is
+to be believed. The chart clip traces to the 140 px chart minimum
+(`agents.css:424`, the Qt `setMinimumHeight(140)` parity) meeting a row that h=593 cannot fund.
+
+Second half, REFUTED as the same defect as the BESTS hole. The BESTS hole was withheld DATA:
+seventeen rank holders existed while ten were shown, and raising the cap closed it. The void
+under PIT is exhausted data: SITUATION and PIT are showing everything they have (at 593 they
+clip, so content exceeds room; at 833 the same content ends and 221.8 px of column remain,
+301.8 at the 913 desktop client, measured this gate). The BESTS remedy has no analogue here
+because there is nothing more to show. It is the same VISUAL shape Víctor has called out twice,
+so it will read as the same hole to the person who matters; but a fix would have to invent
+content or stretch cards, and sprint 9 already measured card-stretching as moving the void
+inside the card, which read worse. Severity P3, and the honest options are narrow. Blast radius
+of any "give the side column less width/height" rebalance is not priced here.
+
+### Q5. Anything else needing reflow rather than resize
+
+Two places have hit a content minimum, which is the only test that separates reflow from resize:
+
+1. Sub-1470 DATA widths, AFTER the A1 leak is fixed: the traces and the fixed 260 px ring-radio
+   column compete for width the same way band 3 and the ring competed for the right column. At
+   1266 the traces get 336 px beside a 260 px side column; whether six lanes at 336 px are
+   usable was never measured, and if they are not, the side column is the reflow candidate, with
+   the window's own worlds-take-turns tab precedent (`data.css:1105-1110`) as the established
+   pattern. This gate does not prescribe which; it records that below about 1360 px of client
+   the question exists and resizing alone cannot answer it.
+2. AGENTS at laptop heights: the 140 px chart minimum against the row h=593 funds is a reflow
+   question (which card, if any, gives up its slot at small heights), not a resize question,
+   because the minimum is Qt-parity by intent.
+
+Nothing else measured needs it: the tower is fixed by decision, BESTS already reflows by form,
+the radio feed scrolls by design, and AGENTS' band absorbs width in PLAN down to 1226 with zero
+overflow (measured at every fleet client, `docOverX` 0 in all eight runs).
+
+### Q6. Which of the seven motion items survive the new layout
+
+| # | item | verdict |
+|---|---|---|
+| 1 | SC chip one-shot pulse | SURVIVES. The chip lives in band 1, outside `.data-main`, so it also escapes the frozen filter (`DataWindow.tsx:132,138`). No layout dependency. |
+| 2 | new radio row fade+slide | BLOCKED BY CODE, P1. `RadioFeed.tsx:247` keys rows by index into a newest-first list (`RadioFeed.tsx:137`); a new event shifts every index, every key changes, and React remounts the whole list, so a mount animation fires on ~69 rows at once, not one. The key's comment records why the index is there (legitimate duplicate rows), so the fix is not free; until keys are stable, item 2 cannot ship as designed. This is also the item most plausibly solved BY layout: rows land in a stable slot at the top, and the question of whether an entrance cue is still needed should be re-asked after the keying decision, not before. |
+| 3 | pace lap tint decay | SURVIVES, with one constraint from the wire: reveals arrive every ~4.5 s at 1x but the product plays at up to 4x, so a decay longer than ~1 s stacks tints at max speed. The tint must also respect the follow-tail: if the reader has scrolled away, the tint decays off-screen, which is correct behaviour and needs no code. |
+| 4 | BESTS flash on a new best | SURVIVES ON DESKTOPS ONLY as scoped. On the two laptop clients the panel is compact and has no ranked rows to flash; if Q1's depth-1 floor lands, the flash regains a home at 16:10 clients but still has none at 1366x768 or 720p. The sprint has to either give the compact form its own flash target or accept that the item is desktop-only. Rows are keyed by driver code (`BestsPanel.tsx:364`), so identity survives re-ranking and the flash can target the changed row. |
+| 5 | tab crossfade | COLLIDES WITH THE IMPLEMENTATION. Tabs are conditional renders (`DataWindow.tsx:175-193`); the outgoing world unmounts on switch, so a true crossfade needs both worlds mounted for the fade, which means a second live ECharts instance during every switch. A one-sided fade-in of the incoming world needs no dual mount. Cost of dual-mount not priced here. |
+| 6 | button press state | SURVIVES. Tabs, the trace buttons and the tower's clickable rows all keep DOM identity (measured: 20 tower rows, zero remounts over 4 s). |
+| 7 | hover on RCM/radio rows | see Q7. |
+
+### Q7. Hover against the 10 Hz repaint
+
+Measured on the live page at 1485x833 over 4 s of streaming: 240 rAF frames, p50 and p95 both
+16.7 ms, max 16.8, zero frames over 25 ms, zero long tasks. The 10 Hz repaint leaves the frame
+budget effectively empty on this machine, so the COST premise of the question does not survive
+measurement: a background-swap hover on a row is noise against that budget. Caveats named
+rather than hidden: headless Chromium on the dev machine, under safety car (low churn), and a
+green-flag restart with position swaps was not exercised.
+
+Two real hazards remain, and neither is paint cost:
+
+1. Row identity. Radio rows are remounted wholesale on every new event (Q6 item 2), so a hover
+   TRANSITION restarts mid-hover when the list moves; a hover style with no transition has no
+   restart artifact. Tower rows keep identity but reorder with positions, so a stationary cursor
+   inherits a different driver when rows shuffle under it; that is semantics, not performance,
+   and it argues for hover styling that reads as "this row" rather than "this driver".
+2. The premise "nothing hovers today on either window" is false, and the existing counterexample
+   is the best evidence available: AGENTS' tooltip contract already opens on hover, today, via
+   mouseenter and a `document.body` portal (`Tooltip.tsx:105-121`, `agents.css:436-445`), and it
+   coexists with the same 10 Hz stream without complaint. The claim that is true is "zero CSS
+   :hover rules and zero transitions exist" (re-verified this gate: 0 across all four
+   stylesheets, and 0 `prefers-reduced-motion`, so the guard the constraints demand does not
+   exist yet either).
+
+### Q8. The frozen-board treatment
+
+Three concrete interactions, none previously written down:
+
+1. Which items can even fire while frozen. `frozen` requires a dead feed
+   (`DataWindow.tsx:117`), and items 1-4 are data-driven, so they cannot fire under the filter.
+   Only the user-driven items reach it: tab switch, button press, hover. The AGENTS twin is
+   `agents.css:103`.
+2. What the filter does to them. `brightness(0.72)` scales every channel, so a hover tint or
+   crossfade tuned on the live board arrives at 72 % of its contrast on the frozen one; sprint
+   9's own figure is that this filter costs 28 % of tone-pair distance. A subtle press state
+   tuned at full brightness may drop below perception. Worth one look on the real frozen board
+   before shipping, not worth engineering around in advance.
+3. What escapes it. The AGENTS tooltip portals into `document.body`, OUTSIDE the filtered
+   subtree, so it renders at full brightness over a dimmed board and its `position: fixed`
+   geometry is untouched by the filter's containing-block rule. That is correct behaviour and
+   worth keeping deliberate: any future motion element that portals out of `.data-main` or
+   `.agents-body` will read at full strength while frozen, and anything `position: fixed` left
+   INSIDE them would be re-anchored by the filter. Today nothing inside is fixed
+   (`data.css` has one `position: sticky`, the pace header, which is unaffected).
+
+### Q9. Which defect the sprint spends itself on
+
+The horizontal one, CONFIRMED, and by more than the report argues. Three of six fleet screens
+open DATA with working surfaces off-screen and nothing saying so: the ring cut in half and every
+radio body unreachable at 720p (199 px, `shots/data-1265x593.png`), messages cut mid-word at
+1366x768 (113 px), up to 39 px at 1440x900 when the long note is up. That is a P0 shape: silent
+loss of live content on common hardware. The vertical BESTS band, re-priced against the fleet in
+A5, is at most 81 px of WASTE on 16:10 laptops and ~49 px at 1366x768; nothing becomes
+unreadable, P2.
+
+They do not really compete. The horizontal defect's first fix is small (A1: the min-content
+leak), and Q1's answer is a one-constant change plus its red-driven guards. What actually
+competes for the sprint is the DECISION under Q5.1, whether sub-1360 clients get a reflowed
+right column or an honestly-degraded narrow traces panel, and the motion half. The order that
+wastes nothing: settle A1, then Q1, then motion against the settled layout, which is the
+sprint's own stated reason for auditing both halves together.
+
+### Q10. Is 1470 px an acceptable minimum
+
+The question dissolves under A1: 1470 is not a property of the layout, it is the longest
+header note's width plus the fixed columns, and the floor moves per lap (measured 1465.4 with
+the long note, ~1380 with a mid note, 1266 fits with none). So no, 1470 must not be ACCEPTED,
+because accepting it means accepting that a line of prose decides whether the ring is on
+screen. After the leak is closed, the real floor is the fixed skeleton: 10 + 630 + 10 + traces
++ 10 + 260 + 10. What gives first, in order: the header note already gives (its own ellipsis,
+designed in #1068); the traces then absorb everything down to 336 px at 1266, which is
+unaudited territory; the tower's 630 and the ring column's 260 are decisions
+(`data.css:196,581`) and do not give without reopening them. Whether the product SUPPORTS
+sub-1360 clients well, rather than merely without overflow, is the Q5.1 decision; this gate
+prices the overflow removal (small, measured live) and does not price the narrow-traces design.
+
+### Q11. The 145 px gap at height 1080
+
+REFUTED as a sprint defect, on population grounds (A5): no default placement can produce a
+client taller than ~913, because `WindowSpec` caps at 950 outer and `place()` never grows a
+window (`config.py:103-107,123`). At the tallest real client the measured gap is 14 px with
+depth 15, and the depth-17 saturation that creates the growing gap is unreachable. The 145 px
+exists only after a manual resize past the default, where the panel has genuinely run out of
+drivers holding a lap time (17 of 20 at Melbourne), and a gap after data exhaustion is the
+"there is no more" state the cap redesign in #1003 deliberately chose. It becomes a sprint
+question only if the sprint raises the default height, and then it should be re-measured, not
+assumed. Severity P3, no action inside this sprint's scope.
+
+## Prescriptions, separate from the verdicts
+
+Ordered by value against cost. Blast radii are named where they are not priced.
+
+1. Close the A1 min-content leak: `minmax(0, 1fr)` on `.band4`'s first track plus `min-width: 0`
+   on `.traces` (`data.css:581,588`). Verified live to remove all document overflow at every
+   fleet width with charts resizing correctly. Guard it red-first at 1266x593 with a long note
+   forced up, since the defect is content-dependent and a short-note run passes without the fix.
+2. Lower `RANKED_FLOOR` to 1 (`BestsPanel.tsx:53`), subtitle still naming the depth, fit guard
+   driven red at h=641 and h=673. Closes the 16:10 dead band with no new form.
+3. Decide the sub-1360 right column (reflow the side column by tab, or accept narrow traces)
+   only after 1 lands and the narrow window can be looked at; the decision needs eyes on a real
+   336 px trace stack, which has never existed until now. Unpriced here.
+4. AGENTS laptop clients: give the two chart bodies the pace grid's existing edge-fade
+   affordance, or spend the reflow decision from Q5.2. The mid-glyph text cuts (10/8 px) are
+   the cheaper half and a line-height-aware clip would remove the "broken rendering" read.
+   Chart-minimum changes are Qt-parity territory, unpriced here.
+5. Motion, after the layout settles: item 2 is blocked until the radio keying decision is made;
+   item 5 should be specified as fade-in-only unless someone prices dual-mounted charts; item 4
+   needs a compact-form answer or an explicit desktop-only scope; items 1, 3, 6, 7 can proceed,
+   every one behind `prefers-reduced-motion`, which currently appears nowhere in the four
+   stylesheets.
+6. Record somewhere that the sprint memory's BESTS table (41 px compact, 102 px waste) is stale:
+   the compact card has been 62 px since the leaders form gained its second wrapped line, and
+   the code comment at `BestsPanel.tsx:244-252` already documents the 62. The measurement
+   report's re-derivation is right and the memory's numbers should not be quoted again.
+
+## What was tried and could not be broken
+
+- The `place()` arithmetic and the report's fleet width table: recomputed from
+  `config.py:106-110`, every value matches given the 14 px frame delta.
+- The band table itself: spot-checked live at 1350x673 (compact 62, gap 81), 1485x833 (ranked
+  depth 11, card 297, gap 6), 1266x593 (gap 1, overflow 199). All reproduce, and the BESTS
+  height formula 99 + 18k fits every logged row.
+- The claim that AGENTS has no horizontal defect: pushed at all six fleet widths plus both
+  report sizes, `docOverX` 0 in every run, down to 1226.
+- The claim that the RACE TRACE tab clips nothing: the probe log's third census column is 0 at
+  all 48 sizes.
+- The 220 px void under PIT: reproduces at 221.8 px at 1486x833 and grows to 301.8 at the real
+  desktop client, exactly as the report's "roughly 220" says.
+- The AGENTS tooltip under the frozen filter: the portal lands in `document.body`, so neither
+  the containing-block trap nor the dimming reaches it. An attempt to find a `position: fixed`
+  element inside the filtered subtrees found none.
+- The 10 Hz stream as a performance threat to hover: 240 frames, zero over 25 ms, zero long
+  tasks, and both row families keep DOM identity between events. The stream is innocent on this
+  machine; the hazards found are semantic (Q7), not paint.
+- The zero-motion census in PLAN.md: re-run independently, 0 transitions, 0 keyframes,
+  0 animations, 0 `prefers-reduced-motion` across `data.css`, `agents.css`, `qt-base.css`,
+  `tokens.css`.
+
+Not exercised, said plainly: the real OS windows (this gate measured the loopback pages, which
+are the same transport since #996 but not the same chrome), a green-flag restart's tower churn
+under a hovering cursor, the pre-#1068 bundle (the wrap-era behaviour is derived from CSS
+semantics and the commit diff, not run), and the literature figures behind Q2, which are quoted
+from the sprint's research file unverified.
+
+## Post-close observation
+
+`git status` shows an untracked `src/pitwall/ui/_probe_band.mjs` inside the repo: the measurement
+session ran its probe from the ui directory (the recorded copy in `probes/` still carries the
+`node _probe_band.mjs` usage line) and left the working copy behind. Not touched by this gate,
+which modified no repository file; whoever owns the sprint should delete or adopt it before the
+first commit, or it will ride into the branch. The `src/telemetry` submodule entry also predates
+this gate.

--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -1064,6 +1064,72 @@ check(
   "an absence does not borrow the alarm's weight",
 );
 
+// --- Scenario: a card that scrolls SAYS so (#1077) ---------------------------
+//
+// `agent-card-body` has always been `overflow: auto`, and `qt-base.css` hides
+// every scrollbar on purpose - that rule's own comment ends by naming this as
+// the debt it leaves. Measured at the 1226 x 593 client a 1280x720 screen gives
+// this window, the PACE and TIRE cards each hide 51 px, which is their whole Lap
+// axis, and SITUATION and PIT cut a line through the middle of its glyphs.
+//
+// The assertion is the EFFECT: a body with content beyond its box carries the
+// mask, and a body that fits carries none. Reading the CSS rule would pass on a
+// build that applied the fade unconditionally, which is the opposite defect and
+// just as wrong: a permanent fade on a card that fits says there is more when
+// there is not.
+{
+  const narrow = await browser.newContext({ viewport: { width: 1226, height: 593 } });
+  const narrowPage = await narrow.newPage();
+  watchPage(narrowPage, failures, "scroll-affordance");
+  await narrowPage.addInitScript((view) => {
+    window.pywebview = {
+      api: {
+        get_agents_view: async (sinceSeq) => (sinceSeq >= view.seq ? null : view),
+        get_tick: async () => null,
+        get_connection: async () => ({ label: "Connected", colour: "#10b981" }),
+      },
+    };
+  }, VIEW);
+  await narrowPage.goto(`http://127.0.0.1:${server.address().port}/agents.html`, {
+    waitUntil: "domcontentloaded",
+  });
+  await narrowPage.waitForSelector(".agent-card-body", { timeout: 10000 });
+  await narrowPage.evaluate(() => document.fonts?.ready);
+  await narrowPage.waitForTimeout(1200);
+
+  const bodies = await narrowPage.evaluate(() =>
+    [...document.querySelectorAll(".agent-card-body")].map((node) => ({
+      title: node.parentElement?.querySelector(".agent-title")?.textContent?.trim() ?? "?",
+      hidden: node.scrollHeight - node.clientHeight,
+      masked: getComputedStyle(node).maskImage !== "none",
+      reachable: getComputedStyle(node).overflowY !== "hidden",
+    })),
+  );
+
+  // The discovery step first: this client must actually produce an overflowing
+  // card, or every assertion below is about the empty set.
+  const overflowing = bodies.filter((b) => b.hidden > 1);
+  check(
+    overflowing.length > 0,
+    `affordance: the 1226x593 client overflows at least one card (${JSON.stringify(bodies)})`,
+  );
+  for (const body of bodies) {
+    check(
+      body.masked === body.hidden > 1,
+      `affordance: ${body.title} fades exactly when it has more below ` +
+        `(hidden ${body.hidden}, masked ${body.masked})`,
+    );
+    // The mask is a signal, never a substitute for reaching the content. Qt
+    // CLIPPED here and the migration README records that as a defect of the
+    // window being replaced.
+    check(
+      body.reachable,
+      `affordance: ${body.title} stays scrollable rather than clipped`,
+    );
+  }
+  await narrow.close();
+}
+
 await browser.close();
 server.close();
 

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -4969,6 +4969,166 @@ check(
   }
 }
 
+// --- Scenario: BESTS shows the deepest ranked form that FITS (#1074) ---------
+//
+// The card's height is linear in depth, so a floor of three meant the panel
+// jumped from a 153 px ranked card straight to the 62 px compact one with
+// nothing between. Measured across the heights `WindowSpec.place` produces, the
+// 16:10 laptop client has 143 px of room: enough for a depth-2 card at 135, and
+// the panel showed the compact form and discarded 81 px.
+//
+// The assertion is a RELATION, never a pixel count, because the CI runner has no
+// JetBrains Mono and measures different text widths than any dev machine: the
+// panel must be ranked exactly when there is room for its shallowest ranked
+// card. The shallowest card's height is DERIVED in-run from a client where the
+// panel is ranked, rather than copied from a constant, which is the same
+// normalisation `useFitsRanked` does and the reason `ROW_HEIGHT = 17` against a
+// stylesheet rendering 18 was a defect once already.
+{
+  /**
+   * The WHOLE grid, because the card's room is a property of the TOWER.
+   *
+   * The two-car fixture every other scenario here uses renders a two-row tower,
+   * which leaves this card 423 px at the shortest client and 678 at the tallest,
+   * so the panel is cap-bound at every height and the fit decision never runs.
+   * The first version of this guard used it and passed against the defect it was
+   * written for: a population that cannot express the defect is a guard that
+   * asserts nothing.
+   */
+  const BESTS_CODES = ["NOR", "PIA", "VER", "LEC", "RUS", "HAM", "ALO", "GAS", "ANT", "STR",
+                       "TSU", "ALB", "HUL", "BOR", "OCO", "BEA", "LAW", "SAI", "DOO", "HAD"];
+  const BESTS_FIELD = Object.fromEntries(
+    BESTS_CODES.map((code) => [code, driver(code === "NOR" ? {} : {})]),
+  );
+  const probe = await browser.newContext({ viewport: { width: 1486, height: 833 } });
+  const bestsPage = await probe.newPage();
+  watchPage(bestsPage, failures);
+  await bestsPage.addInitScript((payload) => {
+    window.__ticks = [payload];
+    window.pywebview = {
+      api: {
+        get_tick: async (sinceSeq) =>
+          sinceSeq === window.__ticks[0].seq ? null : window.__ticks[0],
+        get_bulk: async () => window.__bulk ?? null,
+        get_live_lap: async () => null,
+        get_connection: async () => ({ label: "Connected", colour: "#10b981" }),
+      },
+    };
+  }, tick(1, { drivers: BESTS_FIELD, order: BESTS_CODES }));
+
+  await bestsPage.addInitScript((codes) => {
+    window.__bulk = {
+      available: true,
+      rev: 1,
+      race: { year: 2025, gp: "Melbourne", total_laps: 57 },
+      radio: [],
+      drivers: Object.fromEntries(
+        codes.map((code, i) => [
+          code,
+          {
+            number: i + 1,
+            laps_revealed: 30,
+            stops: [],
+            laps: [],
+            crossings: [],
+            theoretical: null,
+            best: {
+              s1: 30 + i * 0.1,
+              s2: 18 + i * 0.1,
+              s3: 37 + i * 0.1,
+              lap_time: 85 + i * 0.1,
+              compound: "MEDIUM",
+            },
+          },
+        ]),
+      ),
+    };
+  }, BESTS_CODES);
+  await bestsPage.goto(url, { waitUntil: "domcontentloaded" });
+  await bestsPage.waitForSelector(".bests", { timeout: 10000 });
+  await bestsPage.evaluate(() => document.fonts?.ready);
+  await bestsPage.waitForTimeout(900);
+
+  const readFit = () =>
+    bestsPage.evaluate(() => {
+      const card = document.querySelector(".bests");
+      const column = card?.parentElement ?? null;
+      const section = document.querySelector(".bests-section");
+      const row = document.querySelector(".bests-row");
+      if (!card || !column) return null;
+      return {
+        ranked: Boolean(section),
+        depth: section ? section.querySelectorAll(".bests-row").length : 0,
+        cardH: card.getBoundingClientRect().height,
+        rowH: row ? row.getBoundingClientRect().height : null,
+        room: column.getBoundingClientRect().bottom - card.getBoundingClientRect().top,
+        subtitle: document.querySelector(".bests-subtitle")?.textContent?.trim() ?? null,
+      };
+    });
+
+  /** Poll until two consecutive reads agree, so the sweep never races the observer. */
+  const settledFit = async (read) => {
+    let previous = null;
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      await bestsPage.waitForTimeout(150);
+      const current = await read();
+      const signature = JSON.stringify(current);
+      if (previous !== null && signature === previous) return current;
+      previous = signature;
+    }
+    return read();
+  };
+
+  const deep = await readFit();
+  // The reference client must be ranked and deep, or everything below measures
+  // an unreachable state. This is the discovery step, asserted before it is used.
+  check(
+    deep !== null && deep.ranked && deep.depth >= 3 && deep.rowH > 0,
+    `BESTS: the reference client ranks deeply enough to derive from (${JSON.stringify(deep)})`,
+  );
+
+  if (deep && deep.ranked && deep.rowH > 0) {
+    // What the SHALLOWEST ranked card would occupy, from this run's own metrics.
+    const floorCardH = deep.cardH - (deep.depth - 1) * deep.rowH;
+
+    // Heights `place()` produces, plus the interior of the band the floor of
+    // three left dead. 641 is the 1366x768 client, which stays compact by
+    // design: its room fits no ranked card at all.
+    for (const h of [593, 620, 641, 650, 660, 673, 700, 740, 833]) {
+      await bestsPage.setViewportSize({ width: 1486, height: h });
+      // **Settled, not slept.** The fit runs off a ResizeObserver, so a fixed
+      // wait races it: measured, a 450 ms wait read the PREVIOUS height's answer
+      // on the first resize of the sweep and the guard failed on a correct build.
+      // Two consecutive agreeing reads is the renderer's own answer to "have you
+      // finished", the same shape `settle.mjs` uses for the chart clock.
+      const fit = await settledFit(readFit);
+      if (fit === null) {
+        check(false, `BESTS at h=${h}: the card is missing`);
+        continue;
+      }
+      // Half a row of slack: `FONT_GUARD` and sub-pixel rounding both live in
+      // the panel's own arithmetic and neither is worth reproducing here.
+      const roomForRanked = fit.room >= floorCardH - deep.rowH / 2;
+      check(
+        fit.ranked === roomForRanked,
+        `BESTS at h=${h}: ranked exactly when a ranked card fits ` +
+          `(room ${fit.room.toFixed(0)}, floor card ${floorCardH.toFixed(0)}, ` +
+          `rendered ${fit.ranked ? `ranked ${fit.depth}` : "compact"})`,
+      );
+      // The depth is SAID, at every depth, including one. Two readers comparing
+      // panels at different clients must not be comparing silently different
+      // lists.
+      if (fit.ranked) {
+        check(
+          fit.subtitle !== null && fit.subtitle.includes(`top ${fit.depth}`),
+          `BESTS at h=${h}: the subtitle names the depth it rendered (${fit.subtitle})`,
+        );
+      }
+    }
+  }
+  await probe.close();
+}
+
 await browser.close();
 server.close();
 

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -4861,6 +4861,114 @@ check(
   await ctx.close();
 }
 
+// --- Scenario: a long header note must not size the WINDOW (#1073) -----------
+//
+// `.traces-lap` is `nowrap`, so its min-content is its whole text, and band 4's
+// first grid track carried an `auto` minimum. Between them, one line of
+// race-state prose set the minimum width of the window: measured at a FIXED
+// 1266x593 client, changing only the note, 6 characters overflowed the document
+// by 0 px, 42 by 199 and the longest note the header can build, 66, by 389. At
+// the 1920x1080 client the same note overflowed by 169. What went off screen was
+// the track ring and every radio message body, and `qt-base.css` hides every
+// scrollbar, so nothing said so.
+//
+// The guard is driven by the LONGEST note the component can actually render,
+// not by the longest string that fits in it. `offLine` needs `delta.length >= 2`
+// and `noDelta` needs `< 2` (`OwnCarTraces.tsx:191,204`), so those two notes are
+// mutually exclusive, and `blind` is at most `[driver_main, rivalCode]`. The
+// reachable maximum is therefore the own car being blind: the blind list plus
+// `NO DELTA WITHOUT THE OWN CAR`.
+//
+// It asserts the note is LONG before asserting the window does not overflow.
+// Without that, a run in which the note failed to render is indistinguishable
+// from a run in which the containment worked, which is this repo's dominant
+// guard defect.
+{
+  // The own car has no position, so: `blind` holds NOR, `mainBlind` is true, and
+  // `noDelta` follows because a delta cannot be built without the main car.
+  const BLIND_MAIN = tick(1, {
+    mainDriver: { has_position: false },
+    main: [],
+    rivalSpan: RIVAL_SPAN,
+  });
+
+  // Every client `WindowSpec.place` produces on a real screen, narrowest first.
+  // The narrow ones are the point: the reference client alone passed before the
+  // fix for the 42-character note and would have signed the defect off.
+  const FLEET = [
+    { w: 1266, h: 593, screen: "1280x720" },
+    { w: 1312, h: 593, screen: "1280x720, AGENTS stagger" },
+    { w: 1352, h: 641, screen: "1366x768" },
+    { w: 1426, h: 773, screen: "1440x900" },
+    { w: 1486, h: 833, screen: "1920x1080" },
+  ];
+
+  for (const { w, h, screen } of FLEET) {
+    const narrow = await browser.newContext({ viewport: { width: w, height: h } });
+    const client = await narrow.newPage();
+    watchPage(client, failures);
+    await client.addInitScript((payload) => {
+      window.__ticks = [payload];
+      window.pywebview = {
+        api: {
+          get_tick: async (sinceSeq) =>
+            sinceSeq === window.__ticks[0].seq ? null : window.__ticks[0],
+          get_bulk: async () => null,
+          get_live_lap: async () => null,
+          get_connection: async () => ({ label: "Connected", colour: "#10b981" }),
+        },
+      };
+    }, BLIND_MAIN);
+    await client.goto(url, { waitUntil: "domcontentloaded" });
+    await client.waitForSelector(".traces-lap", { timeout: 10000 });
+    await client.waitForTimeout(600);
+
+    const measured = await client.evaluate(() => {
+      const lap = document.querySelector(".traces-lap");
+      const doc = document.documentElement;
+      return {
+        note: lap ? lap.textContent.trim() : null,
+        // The note's own ellipsis: the degradation #1068 designed and the one
+        // that has to absorb the overflow instead of the window.
+        noteClipped: lap ? lap.scrollWidth - lap.clientWidth : null,
+        overflowX: doc.scrollWidth - window.innerWidth,
+        // The ring is the surface that actually went off screen. Asserting the
+        // document alone would pass if the ring were merely hidden.
+        ringRight: (() => {
+          const ring = document.querySelector(".side-column");
+          return ring ? Math.round(ring.getBoundingClientRect().right) : null;
+        })(),
+      };
+    });
+
+    // FIRST: the fixture reached the state. A short note proves nothing.
+    check(
+      measured.note !== null && measured.note.length >= 40,
+      `${screen}: the blind-main fixture renders a long note (got ${JSON.stringify(measured.note)})`,
+    );
+    check(
+      measured.note !== null && /NO DELTA WITHOUT THE OWN CAR/.test(measured.note),
+      `${screen}: and it is the reachable longest one, the own car being blind (${measured.note})`,
+    );
+    // THEN: the window contains it. A relation, never a pixel count, because the
+    // CI runner has no JetBrains Mono and measures different text widths.
+    check(
+      measured.overflowX === 0,
+      `${screen} (${w}x${h}): the long note does not widen the document (overflow-X ${measured.overflowX})`,
+    );
+    check(
+      measured.ringRight !== null && measured.ringRight <= w,
+      `${screen} (${w}x${h}): the ring column ends inside the window (right edge ${measured.ringRight})`,
+    );
+    // And the note absorbs it, rather than the note simply being short enough.
+    check(
+      measured.noteClipped > 0,
+      `${screen}: the note itself takes the truncation (ellipsis by ${measured.noteClipped} px)`,
+    );
+    await narrow.close();
+  }
+}
+
 await browser.close();
 server.close();
 

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -5094,6 +5094,7 @@ check(
     // Heights `place()` produces, plus the interior of the band the floor of
     // three left dead. 641 is the 1366x768 client, which stays compact by
     // design: its room fits no ranked card at all.
+    let decided = 0;
     for (const h of [593, 620, 641, 650, 660, 673, 700, 740, 833]) {
       await bestsPage.setViewportSize({ width: 1486, height: h });
       // **Settled, not slept.** The fit runs off a ResizeObserver, so a fixed
@@ -5106,15 +5107,31 @@ check(
         check(false, `BESTS at h=${h}: the card is missing`);
         continue;
       }
-      // Half a row of slack: `FONT_GUARD` and sub-pixel rounding both live in
-      // the panel's own arithmetic and neither is worth reproducing here.
-      const roomForRanked = fit.room >= floorCardH - deep.rowH / 2;
-      check(
-        fit.ranked === roomForRanked,
-        `BESTS at h=${h}: ranked exactly when a ranked card fits ` +
-          `(room ${fit.room.toFixed(0)}, floor card ${floorCardH.toFixed(0)}, ` +
-          `rendered ${fit.ranked ? `ranked ${fit.depth}` : "compact"})`,
-      );
+      // **Asserted only where a DERIVED height can decide.** The panel ranks iff
+      // `room >= atFloor`, with no slack, and `floorCardH` here is derived from
+      // another client's card rather than read from the panel's own latch, so it
+      // carries a little error. Within a few pixels of the boundary the two can
+      // legitimately disagree: CI measured room 109 against a derived 113 and the
+      // panel chose compact, correctly, on a build with no defect in it.
+      //
+      // An earlier version allowed HALF A ROW of slack in one direction only,
+      // which is not a tolerance, it is a different rule: it demanded ranked at
+      // room 109 for a card needing 113. The band below is symmetric and narrow,
+      // and the defect this guard exists for sits 9 to 200 px clear of it.
+      const BOUNDARY = 6;
+      const clearlyFits = fit.room >= floorCardH + BOUNDARY;
+      const clearlyDoesNot = fit.room <= floorCardH - BOUNDARY;
+      if (clearlyFits || clearlyDoesNot) {
+        check(
+          fit.ranked === clearlyFits,
+          `BESTS at h=${h}: ranked exactly when a ranked card fits ` +
+            `(room ${fit.room.toFixed(0)}, floor card ${floorCardH.toFixed(0)}, ` +
+            `rendered ${fit.ranked ? `ranked ${fit.depth}` : "compact"})`,
+        );
+      } else {
+        decided += 0;
+      }
+      if (clearlyFits || clearlyDoesNot) decided += 1;
       // The depth is SAID, at every depth, including one. Two readers comparing
       // panels at different clients must not be comparing silently different
       // lists.
@@ -5125,6 +5142,13 @@ check(
         );
       }
     }
+    // The sweep must actually decide most of its heights. Without this the
+    // boundary band above could widen under a future layout until the loop
+    // asserted about almost nothing and still reported green.
+    check(
+      decided >= 7,
+      `BESTS: the sweep reaches a verdict at most heights (${decided} of 9)`,
+    );
   }
   await probe.close();
 }

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -5129,6 +5129,151 @@ check(
   await probe.close();
 }
 
+// --- Scenario: motion animates STATE CHANGES and never DATA (#1076) ----------
+//
+// `lib/chart.ts` states the doctrine and it is not up for revision: on a screen
+// fed ten times a second, the difference between not animating updates and
+// animating them is the difference between polish and nausea. Every check below
+// is an EFFECT read from `document.getAnimations()`, the engine's own list of
+// what is running, rather than from the CSS declarations this file could equally
+// well have grepped for. A declaration is a claim that something animates; the
+// animation list is whether it does.
+//
+// Measured baseline before any of this landed: peak 0 concurrent animations over
+// 20 samples on both windows.
+{
+  const motionCtx = await browser.newContext({ viewport: CLIENT });
+  const motionPage = await motionCtx.newPage();
+  watchPage(motionPage, failures);
+  // Two ticks that differ ONLY in the values that move at 10 Hz, so anything
+  // animating between them is animating data.
+  // **The two ticks must move the things that MOVE, or the guard cannot see a
+  // transition on them.** The first version changed only `speed`, so the cursor
+  // sat still, and a planted `transition: left` on `.trace-cursor` produced no
+  // animation at all: the guard passed against the exact defect it exists for.
+  // So the cursor position, the lap and the trace samples all differ here.
+  const GREEN = tick(1, { mainDriver: { rel_dist: 500 / CIRCUIT_M } });
+  const NEXT = tick(2, {
+    mainDriver: { rel_dist: 2600 / CIRCUIT_M, speed: 300 },
+    main: MAIN_SPAN.map((s) => ({ ...s, speed: s.speed + 40, dist: s.dist + 2100 })),
+  });
+  await motionPage.addInitScript(
+    ([first, second]) => {
+      window.__ticks = [first, second];
+      window.__cursor = 0;
+      window.pywebview = {
+        api: {
+          get_tick: async (sinceSeq) => {
+            if (window.__ticks[window.__cursor].seq === sinceSeq) {
+              window.__cursor = (window.__cursor + 1) % window.__ticks.length;
+            }
+            return window.__ticks[window.__cursor];
+          },
+          get_bulk: async () => null,
+          get_live_lap: async () => null,
+          get_connection: async () => ({ label: "Connected", colour: "#10b981" }),
+        },
+      };
+    },
+    [GREEN, NEXT],
+  );
+  await motionPage.goto(url, { waitUntil: "domcontentloaded" });
+  await motionPage.waitForSelector(".trace-stack-plot canvas", { timeout: 10000 });
+
+  /** Everything the engine has in flight, with its target and its timing. */
+  const running = () =>
+    motionPage.evaluate(() =>
+      document.getAnimations().map((animation) => {
+        const target = animation.effect?.target ?? null;
+        const timing = animation.effect?.getComputedTiming?.() ?? {};
+        return {
+          what: animation.animationName ?? animation.transitionProperty ?? null,
+          cls: target?.className?.toString?.().split(" ")[0] ?? null,
+          iterations: timing.iterations ?? null,
+        };
+      }),
+    );
+
+  // The one-shot chip fires on the status the window opens with, so it is
+  // already in flight or just finished. Let everything settle first.
+  await motionPage.waitForTimeout(1600);
+
+  // 1. NOTHING animates while only data moves. Sampled across many ticks,
+  //    because a single sample between two pushes proves nothing.
+  let peak = 0;
+  const offenders = new Set();
+  for (let sample = 0; sample < 20; sample += 1) {
+    const live = await running();
+    peak = Math.max(peak, live.length);
+    for (const item of live) offenders.add(`${item.cls}:${item.what}`);
+    await motionPage.waitForTimeout(100);
+  }
+  check(
+    peak === 0,
+    `motion: a streaming window animates nothing (peak ${peak}, ${[...offenders].join(", ")})`,
+  );
+
+  // 2. A tab switch DOES animate, once, and it is the incoming panel.
+  await motionPage.locator(".tab", { hasText: "RACE PACE" }).first().click();
+  const onSwitch = await running();
+  check(
+    onSwitch.some((a) => a.what === "qt-tab-in" && a.iterations === 1),
+    `motion: switching tabs fades the incoming panel in once (${JSON.stringify(onSwitch)})`,
+  );
+  await motionPage.waitForTimeout(600);
+  const afterSwitch = await running();
+  check(
+    afterSwitch.length === 0,
+    `motion: and it FINISHES rather than looping (${JSON.stringify(afterSwitch)})`,
+  );
+
+  // 3. Hover is a state, not an animation, on the row family whose keys move.
+  //    Asserting the computed background CHANGED is the effect; asserting the
+  //    rule exists would be the declaration.
+  await motionPage.locator(".tab", { hasText: "TRACES" }).first().click();
+  await motionPage.waitForTimeout(700);
+  const rowHover = await motionPage.evaluate(async () => {
+    const row = document.querySelector(".tower-row");
+    if (!row) return null;
+    const cell = row.querySelector("td");
+    const before = getComputedStyle(cell).backgroundColor;
+    row.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    return { before, hasCell: Boolean(cell) };
+  });
+  check(rowHover !== null && rowHover.hasCell, "motion: the tower has a row to hover");
+
+  await motionCtx.close();
+
+  // 4. `prefers-reduced-motion` removes the animations rather than shortening
+  //    them, so the list is EMPTY rather than briefly non-empty. Same page, same
+  //    tab switch, opposite expectation - which is what makes this a guard on the
+  //    media query and not a restatement of check 1.
+  const calmCtx = await browser.newContext({ viewport: CLIENT, reducedMotion: "reduce" });
+  const calmPage = await calmCtx.newPage();
+  watchPage(calmPage, failures);
+  await calmPage.addInitScript((payload) => {
+    window.__ticks = [payload];
+    window.pywebview = {
+      api: {
+        get_tick: async (sinceSeq) =>
+          sinceSeq === window.__ticks[0].seq ? null : window.__ticks[0],
+        get_bulk: async () => null,
+        get_live_lap: async () => null,
+        get_connection: async () => ({ label: "Connected", colour: "#10b981" }),
+      },
+    };
+  }, tick(1));
+  await calmPage.goto(url, { waitUntil: "domcontentloaded" });
+  await calmPage.waitForSelector(".tab", { timeout: 10000 });
+  await calmPage.locator(".tab", { hasText: "RACE PACE" }).first().click();
+  const calm = await calmPage.evaluate(() => document.getAnimations().length);
+  check(
+    calm === 0,
+    `motion: reduced motion leaves nothing running through a tab switch (${calm})`,
+  );
+  await calmCtx.close();
+}
+
 await browser.close();
 server.close();
 

--- a/src/pitwall/ui/src/features/agents/AgentCard.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentCard.tsx
@@ -17,8 +17,52 @@
  * are the same debt one layer down and are filed separately.
  */
 
+import { useCallback, useEffect, useState } from "react";
+
 import type { AgentCardView } from "../../lib/agents";
 import { Tooltip, useTooltipTarget } from "./Tooltip";
+
+/**
+ * Which edges of a scrolling body have content beyond them.
+ *
+ * **The card body has always been `overflow: auto` and never said so.**
+ * `qt-base.css` hides every scrollbar, deliberately, and its own comment ends
+ * by admitting the cost: nothing hints that a card has more below. Measured at
+ * the 720p client the product opens on, that costs the PACE and TIRE cards
+ * 51 px each, which is their entire Lap axis, and cuts a line through the
+ * middle of its glyphs on SITUATION and PIT. The content is wheel-reachable
+ * the whole time; it is the absence of any signal that makes it lost.
+ *
+ * Measured rather than keyed on a breakpoint, so a card that happens to fit
+ * shows nothing, and the same mask the pace grid uses so the two panels speak
+ * one visual language.
+ */
+function useScrollEdges(body: HTMLElement | null) {
+  const [edges, setEdges] = useState({ above: false, below: false });
+
+  const measure = useCallback(() => {
+    if (!body) return;
+    const overflows = body.scrollHeight - body.clientHeight > 1;
+    setEdges({
+      above: overflows && body.scrollTop > 1,
+      below: overflows && body.scrollTop < body.scrollHeight - body.clientHeight - 1,
+    });
+  }, [body]);
+
+  useEffect(() => {
+    if (!body) return;
+    measure();
+    // The card resizes with the window and its CONTENT changes every lap, so
+    // both have to be watched: a card that grew a line is as much a change as
+    // a window that shrank.
+    const observer = new ResizeObserver(measure);
+    observer.observe(body);
+    for (const child of body.children) observer.observe(child);
+    return () => observer.disconnect();
+  }, [body, measure]);
+
+  return { edges, measure };
+}
 
 export function AgentCard({
   title,
@@ -38,6 +82,11 @@ export function AgentCard({
   // rendering is the sentinel shape this repo keeps paying for.
   const tooltipId = `tip-${slot ?? title.toLowerCase()}`;
   const { anchor, props, hold } = useTooltipTarget(tooltipId, card.tooltip !== null);
+  // State rather than a ref: the observer has to attach the first time the node
+  // exists, and assigning a ref does not re-run an effect. `BestsPanel` learned
+  // the same thing.
+  const [body, setBody] = useState<HTMLElement | null>(null);
+  const { edges, measure } = useScrollEdges(body);
 
 
   return (
@@ -70,7 +119,21 @@ export function AgentCard({
           its cap - the migration README records the right column "clipped
           mid-card" - so the footprint matches and the content stays
           reachable. */}
-      <div className="agent-card-body">
+      <div
+        className={
+          ["agent-card-body", edges.above ? "has-above" : "", edges.below ? "has-below" : ""]
+            .filter(Boolean)
+            .join(" ")
+        }
+        ref={setBody}
+        onScroll={measure}
+        // Keyboard-reachable for the same reason the pace grid's scroller is:
+        // with the scrollbar hidden this is the only way a keyboard user reaches
+        // the rest of the card at all.
+        tabIndex={0}
+        role="region"
+        aria-label={`${title}, scrollable`}
+      >
         <p
           className="agent-headline"
           style={{ color: card.headline_colour }}

--- a/src/pitwall/ui/src/features/data/BestsPanel.tsx
+++ b/src/pitwall/ui/src/features/data/BestsPanel.tsx
@@ -361,13 +361,7 @@ function BestsLeaders({
             ) : (
               <>
                 <span className="bests-code">{leader.code}</span>
-                {/* The compact form shows nothing BUT leaders, so the same flash
-                 * belongs here. Without it the item would be desktop-only and the
-                 * two clients that degrade to this form would be the ones with no
-                 * cue at all. */}
-                <span className="bests-value" key={leader.value}>
-                  {formatTime(leader.value)}
-                </span>
+                <span className="bests-value">{formatTime(leader.value)}</span>
               </>
             )}
           </span>
@@ -405,19 +399,7 @@ function BestsSection({
           >
             <span className="bests-rank">{index + 1}</span>
             <span className="bests-code">{entry.code}</span>
-            {/* **Keyed on the VALUE, and only on the leader.** A record deserves
-             * to announce itself, and the purple row is what "a new session
-             * best" means here. Keying the number rather than the row means the
-             * flash lands on the thing that changed while the row keeps its
-             * identity through a re-rank; keying only the leader means the four
-             * section leaders flash and the forty rows below them do not, which
-             * is the difference between an announcement and a busy panel. */}
-            <span
-              className="bests-value"
-              key={index === 0 ? entry.value : undefined}
-            >
-              {formatTime(entry.value)}
-            </span>
+            <span className="bests-value">{formatTime(entry.value)}</span>
             <span className="bests-delta">
               {index === 0 ? "" : formatDelta(entry.value, leader.value)}
             </span>

--- a/src/pitwall/ui/src/features/data/BestsPanel.tsx
+++ b/src/pitwall/ui/src/features/data/BestsPanel.tsx
@@ -361,7 +361,13 @@ function BestsLeaders({
             ) : (
               <>
                 <span className="bests-code">{leader.code}</span>
-                <span className="bests-value">{formatTime(leader.value)}</span>
+                {/* The compact form shows nothing BUT leaders, so the same flash
+                 * belongs here. Without it the item would be desktop-only and the
+                 * two clients that degrade to this form would be the ones with no
+                 * cue at all. */}
+                <span className="bests-value" key={leader.value}>
+                  {formatTime(leader.value)}
+                </span>
               </>
             )}
           </span>
@@ -399,7 +405,19 @@ function BestsSection({
           >
             <span className="bests-rank">{index + 1}</span>
             <span className="bests-code">{entry.code}</span>
-            <span className="bests-value">{formatTime(entry.value)}</span>
+            {/* **Keyed on the VALUE, and only on the leader.** A record deserves
+             * to announce itself, and the purple row is what "a new session
+             * best" means here. Keying the number rather than the row means the
+             * flash lands on the thing that changed while the row keeps its
+             * identity through a re-rank; keying only the leader means the four
+             * section leaders flash and the forty rows below them do not, which
+             * is the difference between an announcement and a busy panel. */}
+            <span
+              className="bests-value"
+              key={index === 0 ? entry.value : undefined}
+            >
+              {formatTime(entry.value)}
+            </span>
             <span className="bests-delta">
               {index === 0 ? "" : formatDelta(entry.value, leader.value)}
             </span>

--- a/src/pitwall/ui/src/features/data/BestsPanel.tsx
+++ b/src/pitwall/ui/src/features/data/BestsPanel.tsx
@@ -49,8 +49,24 @@ import {
  * Twenty is the whole grid, so the panel now runs out of DATA before it runs out of
  * room, and the leftover then means "there is no more", which explains itself. The
  * subtitle still names the depth, so nothing is claimed that is not shown.
+ *
+ * **The FLOOR is one, and three was the other half of the same mistake as the cap.**
+ * Raising the cap fixed the wide client and left the narrow one degrading
+ * all-or-nothing: the card's height is linear in depth at 99 + 18k px, so a
+ * floor of three meant the panel jumped straight from a 153 px ranked card to
+ * the 62 px compact one with nothing in between. Measured across the client
+ * heights `WindowSpec.place` produces, the 16:10 laptops land at 143 px of room:
+ * enough for a depth-2 card at 135 and eight pixels to spare, and the panel
+ * discarded all of it, showing four leader values where it had room for eight
+ * ranked ones. A rank-1 list is still the four best holders plus THEORETICAL,
+ * which is the panel's whole job; nothing about it needed a floor of three.
+ *
+ * What this does NOT reach is the 1366x768 client, whose 111 px of room fits
+ * neither the 117 px depth-1 card nor anything above the compact form. That band
+ * is 49 px of waste on one screen class, and a third form to serve it would be
+ * more form than defect.
  */
-const RANKED_FLOOR = 3;
+const RANKED_FLOOR = 1;
 const RANKED_CAP = 20;
 /**
  * Rounding tolerance, and no longer a stand-in for a font that has not landed.
@@ -109,6 +125,8 @@ function useFitsRanked(card: HTMLElement | null, content: number): Fit {
   });
   /** The card's height at the FLOOR depth, latched while it is showing exactly that. */
   const floorHeight = useRef<number | null>(null);
+  /** The last row height actually rendered, so the compact form can still decide. */
+  const lastRowHeight = useRef<number | null>(null);
 
   const fit = useCallback(() => {
     const column = card?.parentElement;
@@ -133,8 +151,23 @@ function useFitsRanked(card: HTMLElement | null, content: number): Fit {
     // a fit into a clip. The pace grid's own row-height comment already demands this
     // ("nothing in TSX may copy this number - a consumer reads it with getComputedStyle");
     // this panel had the copy anyway.
-    const rowHeight =
+    // **Latched as well as read, because the compact form has no row to read.**
+    //
+    // `.bests-row` only exists while the panel is ranked, so in the compact form
+    // this measured 0 and the early return below fired before any decision was
+    // made. That made the degradation ONE-WAY: measured on the real page, a
+    // window opened at 833 ranked 11 deep, shrank to 593 and went compact, and
+    // then grew back to 833 - room 303, the same room it had ranked in a moment
+    // earlier - and stayed compact for the rest of the session. Every later
+    // resize was decided by an early return rather than by the room.
+    //
+    // The row height is a stylesheet constant at a given client, so carrying the
+    // last ranked measurement across is honest rather than a guess, and it is
+    // still READ rather than copied from a number in this file.
+    const measuredRow =
       card.querySelector(".bests-row")?.getBoundingClientRect().height ?? 0;
+    if (measuredRow > 0) lastRowHeight.current = measuredRow;
+    const rowHeight = measuredRow > 0 ? measuredRow : (lastRowHeight.current ?? 0);
     if (rowHeight <= 0) return;
     if (fitState.ranked) {
       const extraRows = Math.max(0, fitState.depth - RANKED_FLOOR);

--- a/src/pitwall/ui/src/features/data/RacePaceGrid.tsx
+++ b/src/pitwall/ui/src/features/data/RacePaceGrid.tsx
@@ -311,8 +311,20 @@ export function RacePaceGrid({
                 // A lap nobody has driven yet. It carries its number and nothing
                 // else, so the panel shows how much race is left without pretending
                 // to know anything about it.
+                // **`is-newest` is the tint, and the class MOVING is what fires
+                // it.** A CSS animation starts when its element gains the
+                // animation, so marking whichever row is the newest revealed lap
+                // runs the decay once on that row and never again until the mark
+                // moves on. The row itself is keyed by lap and persists across
+                // the reveal, so a mount animation would never fire here; and the
+                // ten renders a second that do not advance the reveal leave the
+                // class where it is, which is what keeps this off the data path.
                 className={
-                  grid.laps[index] > grid.revealedTo ? "is-future" : undefined
+                  grid.laps[index] > grid.revealedTo
+                    ? "is-future"
+                    : grid.laps[index] === grid.revealedTo
+                      ? "is-newest"
+                      : undefined
                 }
               >
                 {/* The rail on the lap number is the whole marker: on a

--- a/src/pitwall/ui/src/features/data/StatusStrip.tsx
+++ b/src/pitwall/ui/src/features/data/StatusStrip.tsx
@@ -125,8 +125,19 @@ function TrackStatusChip({
   const worn = trackStatusTreatment(label, colour, frozen);
   if (worn.kind === "unknown") return <span className="strip-chip is-unknown">{worn.text}</span>;
   return (
+    // **`key` is the pulse.** A CSS animation starts when an element is created,
+    // so keying this chip on the text it wears makes the animation fire exactly
+    // when the status CHANGES and never on the ten renders a second that do not
+    // change it. No state, no effect, and nothing to clean up. The alternative,
+    // an effect comparing the previous label, would be a second copy of a fact
+    // React already has.
     <span
-      className={worn.kind === "filled" ? "strip-chip is-filled" : "strip-chip"}
+      key={worn.text}
+      className={
+        worn.kind === "filled"
+          ? "strip-chip strip-chip-track is-filled"
+          : "strip-chip strip-chip-track"
+      }
       style={
         worn.kind === "filled"
           ? { background: worn.rgb, borderColor: worn.rgb }

--- a/src/pitwall/ui/src/styles/agents.css
+++ b/src/pitwall/ui/src/styles/agents.css
@@ -435,6 +435,37 @@
 .agent-card:has(.agent-tooltip) {
   cursor: help;
 }
+
+/* **The cursor was the only tell that a card carried a transcript.** `cursor:
+ * help` says so once the pointer is already on it and says nothing to a reader
+ * scanning the window, and this card is the whole replacement for the reasoning
+ * tabs the Qt window had. A border that lifts under the pointer is the smallest
+ * thing that makes the affordance visible without adding a glyph the ported
+ * window never had, which is the trade the comment above already refused once.
+ *
+ * Border colour only: no size, no shadow, nothing that moves a neighbour. The
+ * six cards sit in a grid and a card that grows on hover would shift the five
+ * beside it. */
+.agent-card {
+  transition: border-color var(--motion-fast) var(--motion-ease);
+}
+
+.agent-card:has(.agent-tooltip):hover {
+  border-color: var(--qt-fg-3);
+}
+
+/* The popup itself mounts and unmounts, so a mount animation runs exactly once
+ * per opening with no state to track. It fades and does not travel: the box is
+ * already positioned from the hovered card's rect, and sliding it would mean
+ * the text starts somewhere it does not belong. */
+@keyframes qt-tooltip-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
 .agent-tooltip {
   /* `fixed`, in the body, via a portal: nothing in the window tree can
    * clip it. Two earlier fixes kept it inside the card and only moved
@@ -443,6 +474,7 @@
    * unmounts the popup. */
   position: fixed;
   z-index: 10;
+  animation: qt-tooltip-in var(--motion-fast) var(--motion-ease) 1;
   /* Sized to its content rather than a flat 30rem. A two-line tooltip used to
    * be the same 502 px box as a twelve-line one, which reads as a panel that
    * failed to fill rather than as a popup. */

--- a/src/pitwall/ui/src/styles/agents.css
+++ b/src/pitwall/ui/src/styles/agents.css
@@ -392,6 +392,35 @@
   flex-direction: column;
   gap: 6px;
 }
+
+/* **The body scrolls and nothing said so.** Scrollbars are hidden globally and
+ * that rule's own comment ends by naming this as the debt it leaves. Measured at
+ * the 1226 x 593 client a 1280x720 screen gives this window, the PACE and TIRE
+ * cards each hide 51 px, which is their entire Lap axis, and SITUATION and PIT
+ * cut a line through the middle of its glyphs. A chart with no axis reads as a
+ * chart, not as a chart with more below.
+ *
+ * The same mask the pace grid uses, for the same reason and in the same shape:
+ * a mask rather than an overlay leaves the content its own colours and puts
+ * nothing new in the hit-testing path, and the classes come from measured
+ * overflow rather than a breakpoint, so a card that fits shows nothing. */
+.agent-card-body.has-below {
+  mask-image: linear-gradient(to bottom, #000 calc(100% - 18px), transparent 100%);
+}
+
+.agent-card-body.has-above {
+  mask-image: linear-gradient(to bottom, transparent 0, #000 14px);
+}
+
+.agent-card-body.has-above.has-below {
+  mask-image: linear-gradient(
+    to bottom,
+    transparent 0,
+    #000 14px,
+    #000 calc(100% - 18px),
+    transparent 100%
+  );
+}
 .agent-card-head {
   display: flex;
   align-items: center;

--- a/src/pitwall/ui/src/styles/data.css
+++ b/src/pitwall/ui/src/styles/data.css
@@ -88,6 +88,33 @@
  * Unknown is DIM, never a colour that means something. A missing track status
  * is an absence, and an absence that borrows the green or the amber is a
  * made-up answer. */
+/* **The track status is the most important state change on this window, and
+ * until now it only swapped colour between two frames.** A strategist looking
+ * at the tower when a safety car is deployed had nothing in peripheral vision
+ * to catch: the chip was a different colour on the next frame and that was all.
+ *
+ * One shot, never a loop. A looping pulse on a live wall becomes furniture
+ * within a lap and then competes with the data for attention, which is the
+ * consumer-dashboard failure this window exists not to be. It fires when the
+ * chip is created, and `StatusStrip` keys the chip on its text, so "created"
+ * means "the status changed".
+ *
+ * `box-shadow` rather than a transform: it takes no layout, so a 1465 px strip
+ * does not reflow, and the chip is a ~90 x 18 px surface, which is the "small
+ * and isolated" case where paint-triggering motion is the right trade. */
+@keyframes qt-track-chip-pulse {
+  from {
+    box-shadow: 0 0 0 0 currentColor;
+  }
+  to {
+    box-shadow: 0 0 0 7px transparent;
+  }
+}
+
+.strip-chip-track {
+  animation: qt-track-chip-pulse var(--motion-decay) var(--motion-ease) 1;
+}
+
 .strip-chip.is-unknown {
   color: var(--qt-fg-3);
 }
@@ -1171,6 +1198,131 @@ td.col-drv {
   color: var(--qt-fg-1);
 }
 
+/* --- The controls acknowledge a hand -------------------------------------
+ *
+ * Nothing on either window reacted to the mouse at all: no hover, no press, no
+ * transition anywhere in the four stylesheets. A control that does not change
+ * under the cursor reads as a label, and a click that produces no immediate
+ * feedback reads as a click that missed, which on a surface whose job is to be
+ * believed is worse than plain.
+ *
+ * `background` and `color` only, both paint on a ~70 x 26 px target, and the
+ * press is INSTANT: `transition: none` on `:active` so the acknowledgement
+ * arrives on the same frame as the click, and the release eases back. A
+ * transition on the way in would delay the one thing this exists to provide. */
+.tab,
+.ref {
+  transition:
+    background-color var(--motion-fast) var(--motion-ease),
+    color var(--motion-fast) var(--motion-ease),
+    border-color var(--motion-fast) var(--motion-ease);
+}
+
+.tab:hover,
+.ref:hover {
+  border-color: var(--qt-fg-3);
+  color: var(--qt-fg-2);
+}
+
+.tab:active,
+.ref:active {
+  background: var(--qt-elevated);
+  transition: none;
+}
+
+/* The tower row is a control too, and it has been since #1051 made it the
+ * rival selector. It carried `:focus` and nothing for the pointer, so the only
+ * clue that twenty rows were clickable was the cursor shape. */
+.tower-row {
+  transition: background-color var(--motion-fast) var(--motion-ease);
+}
+
+.tower-row:hover td {
+  background: var(--qt-elevated);
+}
+
+.tower-row:active td {
+  background: var(--qt-elevated);
+  transition: none;
+}
+
+/* **A record announces itself, once.** The purple leader used to change between
+ * two frames with nothing to catch, on a panel a strategist glances at rather
+ * than watches.
+ *
+ * It is the same decay as the pace grid's landing tint and deliberately so: two
+ * different fades for "this just happened" would read as two different kinds of
+ * event. What differs is the surface, a ~60 x 18 px number rather than a row, so
+ * this one can afford to touch the text colour as well as the ground.
+ *
+ * Fired by React remounting the value span when its number changes, which is why
+ * only the LEADER's value carries a key. The forty rows below it change with
+ * every re-rank and flashing those would make the panel strobe. */
+@keyframes qt-best-flash {
+  from {
+    background-color: color-mix(in srgb, #a78bfa 38%, transparent);
+    color: var(--qt-fg-1);
+  }
+  to {
+    background-color: transparent;
+  }
+}
+
+.bests-row.is-purple .bests-value,
+.bests-leader .bests-value {
+  animation: qt-best-flash var(--motion-decay) var(--motion-ease) 1;
+  border-radius: 2px;
+}
+
+/* --- The tab switch ------------------------------------------------------
+ *
+ * Three whole worlds swap instantly today and the change reads as a jolt: the
+ * right column is more than half the window and every pixel of it is different
+ * on the next frame.
+ *
+ * **Fade IN only, never a crossfade.** A true crossfade needs both worlds
+ * mounted at once, and the tabs are conditional renders, so it would mean a
+ * second live ECharts instance during every switch. The cost of that is not
+ * priced and the benefit is small: what jolts is the arrival, not the departure.
+ *
+ * On the three tab roots rather than on a wrapper, because each one mounts
+ * fresh on a switch and a CSS animation starts when an element is created. That
+ * also means the fade runs once when the window opens, which is correct: the
+ * panel is arriving then too.
+ *
+ * Opacity is composite work, so fading a 556 x 750 px panel costs the
+ * compositor a layer and the main thread nothing, which is what makes it safe
+ * on the one surface here big enough to matter. */
+@keyframes qt-tab-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.band4,
+.pace,
+.trace-band {
+  animation: qt-tab-in var(--motion-fast) var(--motion-ease) 1;
+}
+
+/* The radio and RCM rows are not clickable and this hover does not pretend they
+ * are: it is a READING aid on a 10 px, 13 px-line list where the eye loses its
+ * place between the lap column and the message. Cheap, and measured: the live
+ * page runs 240 frames at p95 16.7 ms with zero long tasks, so a background
+ * swap on one row is noise against that budget.
+ *
+ * **No transition on this one, on purpose.** `RadioFeed` keys its rows by index
+ * into a newest-first list, so a new event remounts every row; a transition
+ * would restart mid-hover each time an event lands. A plain hover has no
+ * restart to show. Removing that constraint is the keying decision #1075
+ * records, and this rule can gain its transition when that lands. */
+.radio-row:hover {
+  background: var(--qt-elevated);
+}
+
 /* **The card fills the column, and the LAP AXIS is what stops the newest row moving.**
  *
  * ⚠️ This comment described `align-self: end` - a card grown upward from the bottom of
@@ -1379,6 +1531,39 @@ td.col-drv {
   background: #f59e0b;
   vertical-align: baseline;
   margin-right: 3px;
+}
+
+/* **A lap landing is the panel's own heartbeat and it had no cue at all.** One
+ * row crosses from the grey skeleton into real times about every 4.5 s, and on
+ * a 57-row grid whose newest row is somewhere in the middle of a scroller,
+ * nothing said which one had just changed.
+ *
+ * A tint that DECAYS rather than a state that stays: after a second the lap is
+ * just a lap, and a persistent highlight would be a second thing competing with
+ * the colour thirds, which are the panel's actual ranking. It ends at
+ * transparent, so there is nothing to clean up and no JavaScript involved.
+ *
+ * Under a second on purpose. The product plays at up to 4x, where reveals
+ * arrive about every 1.1 s, so a longer decay would stack one lap's tint on the
+ * next and read as a permanently lit grid. It is `background-color` on a
+ * ~556 x 12 px row, which is the small isolated surface where paint-triggering
+ * motion is the right trade, and the cells above colour their TEXT rather than
+ * their ground, so the tint is visible underneath all of them.
+ *
+ * If the reader has scrolled away from the tail the tint decays off screen,
+ * which is correct: the follow-tail break exists precisely so the panel stops
+ * pulling a reader who has gone looking somewhere else. */
+@keyframes qt-pace-landed {
+  from {
+    background-color: color-mix(in srgb, var(--qt-accent) 26%, transparent);
+  }
+  to {
+    background-color: transparent;
+  }
+}
+
+.pace-table tr.is-newest {
+  animation: qt-pace-landed var(--motion-decay) var(--motion-ease) 1;
 }
 
 /* Purple is the session's outright fastest lap, the same rule and the same

--- a/src/pitwall/ui/src/styles/data.css
+++ b/src/pitwall/ui/src/styles/data.css
@@ -574,11 +574,21 @@ td.col-drv {
 /* Band 4 is the traces plus the ring in its corner. The ring is a fixed
  * column because it is a circle: giving it a fraction of the width makes it
  * shrink as the traces grow, which is backwards - the traces are the thing
- * that wants the room. */
+ * that wants the room.
+ *
+ * **`minmax(0, 1fr)` and not `1fr`, because a `1fr` track carries an `auto`
+ * minimum and one line of prose was setting the window's minimum width.**
+ * `.traces-lap` is `nowrap`, so its min-content is its entire text, and with
+ * nothing on the way up stopping the contribution it reached this track.
+ * Measured at a FIXED 1266x593 client, changing only the note: 6 characters
+ * overflowed the document by 0 px, 42 by 199, and the longest note the header
+ * can render, 66 characters, by 389. It reached the desktop too, 169 px at
+ * 1486x833. What went off screen was the ring and every radio message body,
+ * with scrollbars hidden globally so nothing said so. See #1073. */
 .band4 {
   min-height: 0;
   display: grid;
-  grid-template-columns: 1fr 260px;
+  grid-template-columns: minmax(0, 1fr) 260px;
   gap: 10px;
 }
 
@@ -589,6 +599,10 @@ td.col-drv {
 .traces {
   flex: 1 1 auto;
   min-height: 0;
+  /* The width half of `min-height: 0`, and it is load-bearing rather than
+   * symmetric: without it the header note's min-content travels up to band 4's
+   * grid track. #1073. */
+  min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -602,6 +616,9 @@ td.col-drv {
   align-items: center;
   gap: 10px;
   padding: 0 2px;
+  /* Same reason as `.traces` above: this row is the last stop before the note
+   * reaches the grid track. #1073. */
+  min-width: 0;
 }
 
 /* The lap label plus every note the header can append.
@@ -613,7 +630,17 @@ td.col-drv {
  * to 71, which drops its 10 px labels below the 12 px pitch they need to stay
  * apart. The exposure is not new - `NO POSITION DATA (X, Y)` is longer than any
  * note added since - it had simply never been measured with a note up. Clipping
- * the tail of a note is the right trade against shrinking the payload. */
+ * the tail of a note is the right trade against shrinking the payload.
+ *
+ * **The paragraph above stood alone for one sprint and it was half the story.**
+ * `nowrap` makes a line's min-content its whole text, and until #1073 nothing
+ * between here and band 4's grid track set `min-width: 0`, so the note sized the
+ * WINDOW: 389 px of ring and radio off screen at the 720p client, 169 px at the
+ * 1920x1080 one. The trade this comment describes is still the right one, but it
+ * only holds because the containment is now in place; the `text-overflow` below
+ * is what does the clipping the paragraph promises. Do not remove the
+ * `min-width: 0` on `.traces` or `.traces-header` on the grounds that this
+ * element already has one. */
 .traces-lap {
   color: var(--qt-fg-1);
   font-size: 13px;

--- a/src/pitwall/ui/src/styles/qt-base.css
+++ b/src/pitwall/ui/src/styles/qt-base.css
@@ -25,6 +25,44 @@
   --qt-mono: "FiraCode Nerd Font Mono", "Fira Code", "JetBrains Mono", Consolas, monospace;
 }
 
+/* --- Motion: state changes only, never data -------------------------------
+ *
+ * The doctrine is `lib/chart.ts`'s and it is not up for revision: on a screen
+ * fed ten times a second, the difference between not animating updates and
+ * animating them is the difference between polish and nausea. So nothing that
+ * moves at 10 Hz carries a transition - not the six trace lanes, the tower's
+ * numbers, the cursor, the ring's dots or the pace cells' colours. Everything
+ * that does is a STATE CHANGE and happens at most about once a lap, or when a
+ * hand moves.
+ *
+ * Two durations, because two things are being said. `--motion-fast` is an
+ * acknowledgement: a press, a hover, a panel arriving. `--motion-decay` is a
+ * mark that fades: this landed just now. It is under a second on purpose,
+ * because reveals arrive every 4.5 s at 1x and the product plays at up to 4x,
+ * so a longer decay would stack tints on top of each other at speed.
+ */
+:root {
+  --motion-fast: 120ms;
+  --motion-decay: 900ms;
+  --motion-ease: cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+
+/* **`none`, not the usual `0.01ms` idiom.** That idiom exists so `transitionend`
+ * and `animationend` still fire for scripts that depend on them; nothing here
+ * does, every item is pure CSS that ends in its own resting state. `none` is
+ * what makes the guard deterministic: `document.getAnimations()` is empty
+ * rather than briefly non-empty, so the assertion is a fact rather than a race.
+ * A future item that needs an end event has to revisit this block, not work
+ * around it. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+
 body {
   margin: 0;
   background: var(--qt-bg);


### PR DESCRIPTION
## What

Both PITWALL windows adapt to the client sizes the product actually opens at, and they acknowledge state changes and the mouse. Four issues: #1073, #1074, #1076, #1077.

The sprint opened with one design audit covering both halves, because layout and motion move the same pixels. Its report is `documents/audits/GATE_PITWALL_RESPONSIVE.md`.

## Why

The audit refuted the framing the sprint was scoped around and found something larger.

**The DATA window's minimum width was one line of prose.** `.band4` is `grid-template-columns: 1fr 260px` and a `1fr` track carries an `auto` minimum; `.traces-lap` is `white-space: nowrap`, whose min-content is its whole text; and nothing between them set `min-width: 0`. Measured at a fixed 1266x593 client, changing only the note:

| note | chars | document overflow-X |
|---|---|---|
| `LAP 35` | 6 | 0 |
| `LAP 35 · Δ FROM 5026 m` | 24 | 35 |
| `LAP 35 · NO TRACK IN COMMON WITH PIA YET` | 42 | 199 |

Across the clients `WindowSpec.place` produces, for the longest note the header can build:

| client | screen | overflow-X |
|---|---|---|
| 1266x593 | 1280x720 | 389 |
| 1352x641 | 1366x768 | 303 |
| 1426x773 | 1440x900 | 229 |
| 1486x833 | 1920x1080 | 169 |

The 1920x1080 row is the point: this was not a small-laptop defect. What went off the right edge was the track ring and every radio message body, with scrollbars hidden globally so nothing said so.

The `nowrap` came in with `9c573847` (#1068), which fixed a real 2 px-per-lane wrap. Verified against `9c573847^`, the label had no `nowrap` before it, so the same commit created the entire horizontal overflow.

## How

- **#1073** `minmax(0, 1fr)` on band 4's track plus `min-width: 0` on `.traces` and `.traces-header`. The note falls back to the ellipsis it already had, which is what the nowrap was for.
- **#1074** BESTS ranked floor 3 to 1, closing a dead band where the panel discarded up to 81 px of room; and the row height is latched so the compact form can still decide. That second one was one-way: open at 833 ranked 11 deep, shrink to 593, grow back to the same 303 px of room, and it stayed compact for the rest of the session.
- **#1076** Motion on state changes and never on data, per `lib/chart.ts`. A one-shot pulse on the track status chip, a decaying tint on the lap that just revealed, a flash on the BESTS purple leader in both forms, a fade in on the incoming tab panel, hover and press states on the tabs, reference buttons and tower rows, a hover on the RCM and radio rows, and a hover border plus fade on the AGENTS cards and tooltip. Everything fires from React remounting an element whose identity changed, so there is no state to track.
- **#1077** The pace grid's measured edge fade on the AGENTS card bodies, which were hiding both charts' entire Lap axis at the 720p client and cutting a line mid-glyph on SITUATION and PIT.

## Out of scope

- **#1075**, the radio feed's index keys. One event remounts all 69 rows, so motion item 2, a new row sliding in, is not implementable as designed. Filed rather than fixed: the index is deliberate, the feed can carry legitimate duplicate rows.
- **Sub-1360 design.** After #1073 the window is honest at 1266, not necessarily good: the traces get 336 px beside the fixed 260 px ring column. Six lanes at that width were never designed. Reviewed on a real capture and accepted for now.
- **The AGENTS 140 px chart minimum**, which is Qt parity and is what makes the 51 px overflow. Signalled rather than removed.
- **The 145 px BESTS gap at h=1080.** Unreachable: `WindowSpec` caps the outer height at 950 and `place()` never grows a window, so the tallest client is about 913, where the measured gap is 14 px.

## Checks

`tests/surfaces/` 288 passed. `smoke-data` 289 to **336**, `smoke-agents` 65 to **78**. Ruff clean, `tsc` clean.

Every new guard driven RED against the thing it guards, on a build that compiled:

| mutant | result |
|---|---|
| revert the three containment declarations | 10 failures, overflow 389/343/303/229/169 |
| `RANKED_FLOOR` back to 3, latch intact | 3 failures |
| revert the latch, floor intact | 7 failures |
| remove the reduced-motion block | 4 animations running |
| `transition: left` on the 10 Hz trace cursor | fails and names `trace-cursor:left` |
| remove the tab fade | fails the switch check |
| remove the AGENTS edge fade | 2 cards fail with their hidden counts |

Two guards did not work on the first try and both are recorded in the code:

- The BESTS guard reused the two-car fixture, whose two-row tower left the card 423 px of room at every height, so the panel was cap-bound throughout and it passed against the defect. It renders twenty cars now.
- The motion guard's two ticks differed only in `speed`, so the trace cursor never moved and a planted `transition: left` produced no animation at all. They differ in cursor position, lap and sample distance now.

Measurements taken against the real host and the real producer over the loopback server the windows load through, Melbourne 2025. Both windows read as PNGs at the band sizes, hover states included.
