### PR TITLE
docs(arcade): close out the v2.6.0 ledger items

### DIFF
--- a/src/arcade/__init__.py
+++ b/src/arcade/__init__.py
@@ -8,5 +8,12 @@ windows read.
 The strategy pipeline runs IN THIS PROCESS (`strategy_pipeline.py`, delegating
 to `src/strategy/inference/engine.py::run_lap`), so the arcade has no runtime
 dependency on FastAPI at all - which is the whole reason `f1-arcade` needs no
-backend. The leftover SSE constants in `config.py` are dead; see the note there.
+backend.
+
+The backend's own `/api/v1/strategy/simulate` still exists and still streams;
+what is gone is any path from it to here. `src/arcade/strategy.py` says the
+same thing from the other side, that the two share an engine rather than a
+transport. This paragraph used to end by pointing at dead SSE constants in
+`config.py` and a note explaining them: both were deleted, so the sentence was
+citing something that is not there.
 """


### PR DESCRIPTION
## What

Closes out v2.6.0's remaining ledger items. One of the three was a real defect, the other two had already been fixed and the ledger had carried them forward unchecked.

## The one real change

`src/arcade/__init__.py`'s docstring ended with "the leftover SSE constants in `config.py` are dead; see the note there". Both the constants and the note are gone: `config.py` has no SSE token in it at all, so the sentence cited something that does not exist.

Rewritten to say what is true and checkable. The backend's `/api/v1/strategy/simulate` still exists and still streams (`src/telemetry/backend/api/v1/endpoints/strategy.py:1664`), so the claim worth making is not that SSE is gone but that no path runs from it to the arcade. `src/arcade/strategy.py` already says the same thing from the other side and is named so the pair can be diffed.

The "Arcade renders the SSE stream" claim this item was filed against had already been corrected; what survived was the dangling half of the correction.

## The two that were already done, verified rather than assumed

**#199 D.3.** `broadcast` (`stream.py:217`) takes a payload factory rather than a dict and returns without touching a socket or calling it, so the recursive `asdict` runs on the sender daemon and the pyglet loop pays one queue put. Its docstring carries the measurement that motivated the move: 2.48 ms of a 3.19 ms tick. On the "a stalled subscriber hitches the loop" half, `_send_loop` is one thread and every client socket carries `settimeout(0.05)` (`stream.py:70,375`), so a subscriber that stopped reading raises `socket.timeout`, an `OSError` subclass, and is pruned and closed. Worst case is 50 ms on the sender thread, once, and nothing on the pyglet loop. Recorded on the issue.

**#283's gap-provider bullet.** Not a closing item, and scoped on the issue instead. The tower's gap seconds already come from the bulk's official clock by a documented decision with 7,018 measured pairs behind it; `intervals.parquet` would add sub-lap evolution, and it is keyed on a wall clock, so it needs a time mapping, a loader, a wire field and a rule for which clock wins mid-lap. That last part reopens the decision `gapCell.ts` records. Comparable to the R1 wire sprint.

## Checks

`tests/surfaces/` 288 passed. Ruff clean, repo-wide format check clean. Docs-only change to a module docstring, so no new guard: there is nothing here whose effect a test could observe.
