### PR TITLE
feat(pitwall): add a hover readout to every chart on both windows

### DIFF
--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -1130,6 +1130,171 @@ check(
   await narrow.close();
 }
 
+
+// ---------------------------------------------------------------------------
+// The hover readout on the two AGENTS cards (#999).
+//
+// The pointer PARKS, for the reason the DATA guards state at length: an ECharts
+// tooltip on these charts is visible 0 times out of 25 with the pointer still
+// and 14 out of 14 while it moves, because `notMerge: true` destroys it between
+// mousemoves. A sweeping probe passes over a readout that shows a reader
+// nothing.
+//
+// These are also the SECOND surface for the pixel mapping. The stack's grid
+// inset is not this one (44/10 here), so a mapping that hardwired one chart's
+// constants would answer this chart's laps wrong, and a stack-only guard could
+// never see it.
+// ---------------------------------------------------------------------------
+{
+  const hoverCtx = await browser.newContext({ viewport: CLIENT });
+  const hoverPage = await hoverCtx.newPage();
+  watchPage(hoverPage, failures, "agents-hover");
+  await hoverPage.addInitScript((view) => {
+    window.pywebview = {
+      api: {
+        get_agents_view: async (since) => (since >= view.seq ? null : view),
+        get_connection: async () => ({ label: "Connected", colour: "#10b981" }),
+      },
+    };
+  }, VIEW);
+  await hoverPage.goto(`http://127.0.0.1:${server.address().port}/agents.html`, {
+    waitUntil: "domcontentloaded",
+  });
+  await hoverPage.waitForSelector(".chart canvas", { timeout: 10000 });
+  await hoverPage.waitForTimeout(600);
+
+  check(
+    (await hoverPage.locator(".chart-hover").count()) === 2,
+    "agents hover: both cards carry a hover surface",
+  );
+  check(
+    (await hoverPage.locator(".chart-readout").count()) === 0,
+    "agents hover: nothing is shown before the pointer arrives",
+  );
+
+  /** Park on a chart at an exact LAP, converted through that chart's own axis. */
+  const parkLap = async (index, lap) => {
+    const host = hoverPage.locator(".chart").nth(index);
+    const hostBox = await host.boundingBox();
+    const px = await hoverPage.evaluate(
+      (args) =>
+        document
+          .querySelectorAll(".chart")
+          [args[0]].__pitwallChart.convertToPixel({ gridIndex: 0 }, [args[1], 0])[0],
+      [index, lap],
+    );
+    await hoverPage.mouse.move(hostBox.x + px - 1, hostBox.y + hostBox.height * 0.5);
+    await hoverPage.waitForTimeout(60);
+    await hoverPage.mouse.move(hostBox.x + px, hostBox.y + hostBox.height * 0.5);
+    await hoverPage.waitForTimeout(200);
+  };
+  const readout = async () =>
+    (await hoverPage.locator(".chart-readout").allInnerTexts()).map((text) =>
+      text.replace(/\s+/g, " ").trim(),
+    );
+
+  // --- the pace card, at a lap where EVERY field exists ---------------------
+  await parkLap(0, 22);
+  const full = await readout();
+  check(full.length === 1, `agents hover: exactly one readout is open (${full.length})`);
+  check(
+    full[0].startsWith("LAP 22"),
+    `agents hover: the lap comes from this chart's own axis, not the stack's inset (${full[0]})`,
+  );
+  check(
+    full[0].includes("81.4"),
+    `agents hover: the pace card reads the actual at the hovered lap (${full[0]})`,
+  );
+  check(
+    full[0].includes("81.1"),
+    `agents hover: and the prediction (${full[0]})`,
+  );
+  check(
+    full[0].includes("80.6-81.6"),
+    `agents hover: and the P10-P90 band whole, not one of its ends (${full[0]})`,
+  );
+
+  // --- the same card one lap earlier, where TWO of the three are absent ----
+  // The fixture's prediction starts at 22 and its actual at 21, so lap 21 is
+  // the state where a card that hid the whole box on one missing field, or
+  // printed a neighbouring lap's number, would be caught.
+  await parkLap(0, 21);
+  const partial = await readout();
+  check(
+    partial.length === 1 && partial[0].startsWith("LAP 21"),
+    `agents hover: the box stays open on a lap with missing fields (${partial[0]})`,
+  );
+  check(
+    partial[0].includes("81.2"),
+    `agents hover: the actual still reads at lap 21 (${partial[0]})`,
+  );
+  check(
+    (partial[0].match(/—/g) ?? []).length === 2,
+    `agents hover: the prediction and the band print an em dash each, not the previous lap's value (${partial[0]})`,
+  );
+
+  // --- the tyre card --------------------------------------------------------
+  await parkLap(1, 22);
+  const tyre = await readout();
+  check(
+    tyre.length === 1 && tyre[0].startsWith("LAP 22"),
+    `agents hover: the tyre card reads its own axis (${tyre[0]})`,
+  );
+  check(
+    tyre[0].includes("81.4"),
+    `agents hover: the observed value comes from the stint that covers the lap (${tyre[0]})`,
+  );
+  check(
+    tyre[0].includes("81.3"),
+    `agents hover: and the rolling trend (${tyre[0]})`,
+  );
+  check(
+    tyre[0].includes("L26-31"),
+    `agents hover: the cliff prints as the lap RANGE it is, not a value at this lap (${tyre[0]})`,
+  );
+
+  // --- it leaves ------------------------------------------------------------
+  await hoverPage.mouse.move(2, 2);
+  await hoverPage.waitForTimeout(250);
+  check(
+    (await hoverPage.locator(".chart-readout").count()) === 0 &&
+      (await hoverPage.locator(".chart-hover-cursor").count()) === 0,
+    "agents hover: box and cursor both go when the pointer leaves",
+  );
+
+  // --- hovering pushes no options -------------------------------------------
+  await hoverPage.evaluate(() => {
+    window.__pushes = 0;
+    document.querySelectorAll(".chart").forEach((host) => {
+      const chart = host.__pitwallChart;
+      const real = chart.setOption.bind(chart);
+      chart.setOption = (...args) => {
+        window.__pushes += 1;
+        return real(...args);
+      };
+    });
+  });
+  const sweep = await hoverPage.locator(".chart").first().boundingBox();
+  for (let i = 0; i < 60; i += 1) {
+    await hoverPage.mouse.move(sweep.x + 50 + i * 2, sweep.y + sweep.height * 0.5);
+  }
+  await hoverPage.waitForTimeout(150);
+  const pushes = await hoverPage.evaluate(() => window.__pushes);
+  check(
+    pushes === 0,
+    `agents hover: 60 mousemoves push ZERO options on either card (${pushes})`,
+  );
+  const stillOff = await hoverPage.evaluate(() =>
+    [...document.querySelectorAll(".chart")].map((h) => h.__pitwallChart.getOption().animation),
+  );
+  check(
+    stillOff.length === 2 && stillOff.every((value) => value === false),
+    `agents hover: and both cards still carry animation: false (${JSON.stringify(stillOff)})`,
+  );
+
+  await hoverCtx.close();
+}
+
 await browser.close();
 server.close();
 

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -5298,6 +5298,424 @@ check(
   await calmCtx.close();
 }
 
+
+// ---------------------------------------------------------------------------
+// The hover readout (#999).
+//
+// **Every guard below PARKS the pointer and holds it.** A probe that drags the
+// pointer across the plot passes over a completely broken readout: the design's
+// own measurement found an ECharts tooltip visible on 14 of 14 samples while
+// moving and 0 of 25 while parked, because `notMerge: true` destroys it about
+// 190 ms after each `mousemove` re-creates it. Parking is the population that
+// matters, since a reader stops on a lap in order to read it.
+// ---------------------------------------------------------------------------
+{
+  /**
+   * A span whose STEP channels actually change, which the shared fixture's
+   * cannot express: `MAIN_SPAN` holds `gear: 6` for its whole length and never
+   * sets `drs_open` at all, so a readout that interpolated both would agree
+   * with one that held them and no assertion could tell the two apart.
+   *
+   * DRS steps in BOTH directions on purpose. A linear lookup lands on 0.5
+   * between two samples either way, and the lane's readout is
+   * `value > 0.5 ? "OPEN" : "CLOSED"`, so the rising leg would print CLOSED and
+   * be WRONG while the falling leg would print CLOSED and be RIGHT. Only the
+   * rising leg fails a linear mutant, and only the falling one proves the
+   * assertion is not just reading a constant.
+   */
+  const STEP_SPAN = [
+    { lap: 24, t: 10, dist: 0, speed: 200, throttle: 50, brake: 0, gear: 5, drs: 0, drs_open: false },
+    { lap: 24, t: 11, dist: 100, speed: 210, throttle: 60, brake: 0, gear: 6, drs: 8, drs_open: true },
+    { lap: 24, t: 12, dist: 200, speed: 220, throttle: 70, brake: 0, gear: 7, drs: 0, drs_open: false },
+  ];
+  const STEP_SPAN_LONG = [
+    ...STEP_SPAN,
+    { lap: 24, t: 13, dist: 300, speed: 300, throttle: 80, brake: 0, gear: 8, drs: 0, drs_open: false },
+  ];
+
+  /** Move onto a chart at a DATA x, in two steps so the enter lands first. */
+  const park = async (page, selector, dataX, offsetY = 40) => {
+    const hostBox = await page.locator(selector).boundingBox();
+    const px = await page.evaluate(
+      (args) =>
+        document
+          .querySelector(args[0])
+          .__pitwallChart.convertToPixel({ gridIndex: 0 }, [args[1], 0])[0],
+      [selector, dataX],
+    );
+    await page.mouse.move(hostBox.x + px - 1, hostBox.y + offsetY);
+    await page.waitForTimeout(60);
+    await page.mouse.move(hostBox.x + px, hostBox.y + offsetY);
+    await page.waitForTimeout(160);
+    return px;
+  };
+
+  const values = (page) => page.locator(".trace-lane-value").allInnerTexts();
+
+  const hoverCtx = await browser.newContext({ viewport: CLIENT });
+  const hoverPage = await hoverCtx.newPage();
+  watchPage(hoverPage, failures, "hover");
+  // The pace grid and the race trace are BULK-fed, so the fixture carries one:
+  // without it those two tabs render their empty states and their guards would
+  // be asserting about a panel that is not there.
+  await hoverPage.addInitScript(
+    (args) => {
+      const [payload, bulk] = args;
+      window.__ticks = [payload];
+      window.__cursor = 0;
+      window.pywebview = {
+        api: {
+          get_tick: async (since) => {
+            if (window.__ticks[window.__cursor].seq === since) {
+              if (window.__cursor + 1 >= window.__ticks.length) return null;
+              window.__cursor += 1;
+            }
+            return window.__ticks[window.__cursor];
+          },
+          get_bulk: async (rev) => (rev === bulk.rev ? null : bulk),
+          get_live_lap: async () => null,
+          get_connection: async () => ({ label: "Connected", colour: "#10b981" }),
+        },
+      };
+    },
+    [
+      tick(1, { main: STEP_SPAN, rivalSpan: STEP_SPAN, drivers: paceField(), order: TOWER_ORDER }),
+      paceBulk(),
+    ],
+  );
+  await hoverPage.goto(url, { waitUntil: "domcontentloaded" });
+  await hoverPage.waitForSelector(".trace-stack-plot canvas", { timeout: 5000 });
+  await hoverPage.waitForTimeout(400);
+
+  // --- nothing before the pointer arrives ---------------------------------
+  check(
+    (await hoverPage.locator(".trace-cursor.is-hover").count()) === 0,
+    "hover: no hover cursor before the pointer enters",
+  );
+  const idle = await values(hoverPage);
+  check(
+    idle.length === 6 && idle[0] === "220",
+    `hover: idle, the lanes read the NEWEST sample (${idle[0]})`,
+  );
+
+  // --- GUARD 1: the step lanes hold, they do not interpolate ---------------
+  // 150 m sits strictly between the 100 m and 200 m samples, so a held gear is
+  // 6 and a held DRS is OPEN, while a linear lookup gives 6.5 -> "7" and
+  // 0.5 -> "CLOSED".
+  await park(hoverPage, ".trace-stack-plot", 150);
+  // Presence FIRST, and named. Without it a readout that never renders fails as
+  // a 30-second locator timeout with no check attached, which is a crash rather
+  // than a finding - and that is exactly how the \"cleared on every render\"
+  // mutant showed up before this line existed.
+  check(
+    (await hoverPage.locator(".trace-cursor.is-hover").count()) === 1 &&
+      (await hoverPage.locator(".trace-hover-dist").count()) === 1,
+    "hover: parking the pointer puts a cursor and a distance on the plot",
+  );
+  const held = await values(hoverPage);
+  check(
+    held[4].startsWith("6"),
+    `hover: GEAR holds its last sample between samples, not an interpolated one (${held[4]})`,
+  );
+  check(
+    held[5].startsWith("OPEN"),
+    `hover: DRS holds OPEN on the rising leg, where a linear lookup prints CLOSED (${held[5]})`,
+  );
+  // 50 m is strictly between the 0 m (closed) and 100 m (open) samples: the
+  // held answer is CLOSED and so is the interpolated one, which is why the
+  // rising leg above is the one that catches a linear mutant. Asserted anyway
+  // so the pair is complete and the rising case cannot be quietly deleted.
+  await park(hoverPage, ".trace-stack-plot", 50);
+  const early = await values(hoverPage);
+  check(
+    early[5].startsWith("CLOSED"),
+    `hover: DRS holds CLOSED before it opens (${early[5]})`,
+  );
+  check(
+    early[4].startsWith("5"),
+    `hover: GEAR holds 5 before the upshift (${early[4]})`,
+  );
+  // And the CURVES are still interpolated: speed at 50 m is halfway between 200
+  // and 210. A step rule applied to every lane would answer 200 here.
+  check(
+    early[0].startsWith("205"),
+    `hover: SPEED is still interpolated between samples (${early[0]})`,
+  );
+
+  // --- GUARD 3: the pixel mapping is this chart's own axis ------------------
+  await park(hoverPage, ".trace-stack-plot", 150);
+  // Read through `allInnerTexts`, never `innerText`: `innerText` WAITS, so a
+  // readout that never renders turns a failed check into a 30-second timeout
+  // that kills the run before any failure is printed. The presence check above
+  // has already recorded the real finding by then.
+  const chipTexts = await hoverPage.locator(".trace-hover-dist").allInnerTexts();
+  const chip = (chipTexts[0] ?? "").replace(/[^\d-]/g, "");
+  check(
+    Math.abs(Number(chip) - 150) <= 3,
+    `hover: the readout's distance is the pixel converted through THIS chart's axis (${chip} for 150)`,
+  );
+
+  // --- GUARD 2: it survives pushes with the pointer PARKED ------------------
+  // The whole point. The next tick moves the newest sample to 300 km/h, so
+  // `latest` and the hovered value diverge: without that this guard could not
+  // tell a live readout from one that never left `latest(...)`.
+  await hoverPage.evaluate(
+    (next) => window.__ticks.push(next),
+    tick(2, { ...{ main: STEP_SPAN_LONG, rivalSpan: STEP_SPAN }, drivers: paceField(), order: TOWER_ORDER }),
+  );
+  await park(hoverPage, ".trace-stack-plot", 150);
+  const before = await values(hoverPage);
+  await hoverPage.waitForTimeout(1200);
+  const after = await values(hoverPage);
+  const consumed = await hoverPage.evaluate(() => window.__cursor);
+  check(consumed >= 1, `hover: a real tick landed during the parked window (cursor ${consumed})`);
+  check(
+    after[0] === before[0] && after[0].startsWith("215"),
+    `hover: the parked readout still reads the HOVERED distance after a push (${before[0]} -> ${after[0]})`,
+  );
+  check(
+    (await hoverPage.locator(".trace-cursor.is-hover").count()) === 1,
+    "hover: the hover cursor survives a push with the pointer parked",
+  );
+  check(
+    !after[0].startsWith("300"),
+    `hover: and it is NOT the newest sample, which is now 300 (${after[0]})`,
+  );
+
+  // --- the cursor and the readout leave together ---------------------------
+  await hoverPage.mouse.move(2, 2);
+  await hoverPage.waitForTimeout(250);
+  check(
+    (await hoverPage.locator(".trace-cursor.is-hover").count()) === 0 &&
+      (await hoverPage.locator(".trace-hover-dist").count()) === 0,
+    "hover: cursor and distance chip both go when the pointer leaves",
+  );
+  const back = await values(hoverPage);
+  check(back[0] === "300", `hover: and the lanes go back to the newest sample (${back[0]})`);
+
+  // --- GUARD 6: hovering must never push an option -------------------------
+  await hoverPage.evaluate(() => {
+    const chart = document.querySelector(".trace-stack-plot").__pitwallChart;
+    window.__pushes = 0;
+    const real = chart.setOption.bind(chart);
+    chart.setOption = (...args) => {
+      window.__pushes += 1;
+      return real(...args);
+    };
+  });
+  const sweepBox = await hoverPage.locator(".trace-stack-plot").boundingBox();
+  for (let i = 0; i < 60; i += 1) {
+    await hoverPage.mouse.move(sweepBox.x + 60 + i * 3, sweepBox.y + 40);
+  }
+  await hoverPage.waitForTimeout(150);
+  const pushes = await hoverPage.evaluate(() => window.__pushes);
+  check(
+    pushes === 0,
+    `hover: 60 mousemoves push ZERO options, so hover state is not in the option memo (${pushes})`,
+  );
+  check(
+    (await hoverPage.evaluate(
+      () => document.querySelector(".trace-stack-plot").__pitwallChart.getOption().animation,
+    )) === false,
+    "hover: and `animation: false` still stands after the sweep",
+  );
+
+  // --- GUARD 5: frozen ------------------------------------------------------
+  // The overlays must not MOVE when the filter goes on. `.data-main.is-frozen`
+  // is a `filter`, and a filter is the containing block for `position: fixed`
+  // descendants, so a fixed overlay jumps by the header height - measured at
+  // 50 px on this window. An absolute one does not.
+  // Null-safe, so a readout that is not rendering at all fails the check above
+  // instead of throwing here and killing the run before any failure prints.
+  const chipBox = () =>
+    hoverPage.evaluate(() => {
+      const el = document.querySelector(".trace-hover-dist");
+      if (!el) return null;
+      const box = el.getBoundingClientRect();
+      return { x: Math.round(box.x), y: Math.round(box.y) };
+    });
+  await park(hoverPage, ".trace-stack-plot", 150);
+  const loose = await chipBox();
+  await hoverPage.evaluate(() => document.querySelector(".data-main").classList.add("is-frozen"));
+  await hoverPage.waitForTimeout(150);
+  const frozen = await chipBox();
+  check(
+    loose !== null && frozen !== null && loose.x === frozen.x && loose.y === frozen.y,
+    `hover: the readout does not move when the window freezes (${JSON.stringify(loose)} vs ${JSON.stringify(frozen)})`,
+  );
+  await hoverPage.evaluate(() =>
+    document.querySelector(".data-main").classList.remove("is-frozen"),
+  );
+
+  // --- GUARD 4: a rival that never reached this distance --------------------
+  // The #1066 state, on its OWN page, and that is the whole difficulty. The
+  // buffer ACCUMULATES: pushing a later tick whose rival span is shorter does
+  // not shorten the buffer, because `store` adds samples and never removes
+  // them. A first version of this guard did exactly that, and the rival read a
+  // real value at 150 m from the ticks before it - the fixture could not
+  // express the state it was written for.
+  //
+  // So the rival has to have been short from the FIRST tick.
+  const shortCtx = await browser.newContext({ viewport: CLIENT });
+  const shortPage = await shortCtx.newPage();
+  watchPage(shortPage, failures, "hover-rival");
+  await shortPage.addInitScript(
+    (args) => {
+      window.pywebview = {
+        api: {
+          get_tick: async (since) => (since === args[0].seq ? null : args[0]),
+          get_bulk: async (rev) => (rev === args[1].rev ? null : args[1]),
+          get_live_lap: async () => null,
+          get_connection: async () => ({ label: "Connected", colour: "#10b981" }),
+        },
+      };
+    },
+    [
+      tick(3, {
+        main: STEP_SPAN,
+        rivalSpan: STEP_SPAN.slice(0, 2),
+        drivers: paceField(),
+        order: TOWER_ORDER,
+      }),
+      paceBulk(),
+    ],
+  );
+  await shortPage.goto(url, { waitUntil: "domcontentloaded" });
+  await shortPage.waitForSelector(".trace-stack-plot canvas", { timeout: 5000 });
+  await shortPage.waitForTimeout(400);
+  // 50 m: BOTH cars have been there, so the rival prints a number. This is the
+  // control - without it the em dash below could be a rival series that is
+  // empty for some other reason entirely.
+  await park(shortPage, ".trace-stack-plot", 50);
+  const bothThere = await values(shortPage);
+  check(
+    bothThere[0].startsWith("205") && !bothThere[0].endsWith("—"),
+    `hover: inside the rival span, both cars read a number (${bothThere[0]})`,
+  );
+  await park(shortPage, ".trace-stack-plot", 150);
+  const short = await values(shortPage);
+  check(
+    short[0].startsWith("215") && short[0].endsWith("—"),
+    `hover: our car reads, the rival reads an em dash past the end of its span (${short[0]})`,
+  );
+  await shortCtx.close();
+
+  // --- GUARD 8: a tab switch takes the readout with it ----------------------
+  await hoverPage.locator(".tab", { hasText: "RACE PACE" }).first().click();
+  await hoverPage.waitForTimeout(400);
+  await hoverPage.locator(".tab", { hasText: "TRACES" }).first().click();
+  await hoverPage.waitForSelector(".trace-stack-plot canvas", { timeout: 5000 });
+  await hoverPage.waitForTimeout(400);
+  check(
+    (await hoverPage.locator(".trace-cursor.is-hover").count()) === 0,
+    "hover: a tab switch leaves no stale hover cursor on the remounted chart",
+  );
+
+
+  // --- GUARD: the race trace's list, and it must read FRONT TO BACK ---------
+  // The order is the one thing here a value assertion alone would miss: every
+  // number can be right and the list still upside down. It shipped that way for
+  // one build - sorted ascending, so in LEADER mode the leader sat on 0.0 at the
+  // BOTTOM and the tail-ender led the list - and only the screenshot said so.
+  await hoverPage.locator(".tab", { hasText: "RACE TRACE" }).first().click();
+  await hoverPage.waitForSelector(".trace-band-plot canvas", { timeout: 5000 });
+  await hoverPage.waitForTimeout(500);
+  const bandBox = await hoverPage.locator(".trace-band-hover").boundingBox();
+  await hoverPage.mouse.move(bandBox.x + bandBox.width * 0.5 - 1, bandBox.y + bandBox.height * 0.5);
+  await hoverPage.waitForTimeout(60);
+  await hoverPage.mouse.move(bandBox.x + bandBox.width * 0.5, bandBox.y + bandBox.height * 0.5);
+  await hoverPage.waitForTimeout(250);
+
+  const rows = await hoverPage.locator(".trace-band-box-row").allInnerTexts();
+  check(rows.length > 1, `hover: the race trace lists the field at the hovered lap (${rows.length})`);
+  const parsed = rows.map((row) => {
+    const [code, text] = row.split(/\s+/);
+    return { code, value: text === "—" ? null : Number(text) };
+  });
+  const known = parsed.filter((row) => row.value !== null).map((row) => row.value);
+  check(
+    known.length > 1 && known.every((value, i) => i === 0 || known[i - 1] >= value),
+    `hover: the list reads front to back, largest delta first (${known.slice(0, 4).join(", ")})`,
+  );
+  // Higher on this chart is further up the road, so the top of the list is the
+  // car nearest the reference. Asserted separately from the ordering above,
+  // because a list sorted the wrong way round is still monotonic.
+  check(
+    known[0] === Math.max(...known),
+    `hover: and the car at the top is the one furthest ahead (${known[0]} vs max ${Math.max(...known)})`,
+  );
+  const nulls = parsed.map((row, i) => (row.value === null ? i : -1)).filter((i) => i >= 0);
+  const lastKnown = parsed.map((row, i) => (row.value !== null ? i : -1)).filter((i) => i >= 0).pop();
+  check(
+    nulls.every((i) => i > lastKnown),
+    `hover: cars with no value at that lap sit BELOW every car that has one (${JSON.stringify(nulls)} after ${lastKnown})`,
+  );
+  const bandLap = (await hoverPage.locator(".trace-band-box-lap").allInnerTexts())[0] ?? "";
+  check(/^LAP \d+$/.test(bandLap), `hover: the box names the lap it is reading (${bandLap})`);
+  // It parks too. Same reason as the stack: this chart pushes on every reveal.
+  await hoverPage.waitForTimeout(1200);
+  check(
+    (await hoverPage.locator(".trace-band-box").count()) === 1,
+    "hover: the race trace box survives with the pointer parked",
+  );
+  await hoverPage.mouse.move(2, 2);
+  await hoverPage.waitForTimeout(250);
+  check(
+    (await hoverPage.locator(".trace-band-box").count()) === 0 &&
+      (await hoverPage.locator(".trace-band-cursor").count()) === 0,
+    "hover: the race trace box and cursor go together when the pointer leaves",
+  );
+
+  // --- GUARD 7: the pace grid's cross ---------------------------------------
+  // A cell that is NOT in the first row or the first column, because the lap
+  // header is cell 0 and the head row is row 0, so an off-by-one on either axis
+  // is the natural mutant and a corner cell hides both.
+  await hoverPage.locator(".tab", { hasText: "RACE PACE" }).first().click();
+  await hoverPage.waitForSelector(".pace-table", { timeout: 5000 });
+  await hoverPage.waitForTimeout(300);
+  const bodyRows = await hoverPage.locator(".pace-table tbody tr").count();
+  const headCells = await hoverPage.locator(".pace-table thead th").count();
+  check(
+    bodyRows >= 3 && headCells >= 3,
+    `hover: the pace fixture has a non-corner cell to hover (${bodyRows} rows, ${headCells} head cells)`,
+  );
+  const targetRow = 2;
+  const targetCol = 2;
+  await hoverPage
+    .locator(".pace-table tbody tr")
+    .nth(targetRow)
+    .locator("td")
+    .nth(targetCol - 1)
+    .hover();
+  await hoverPage.waitForTimeout(250);
+  const litHead = await hoverPage.locator(".pace-table thead th.is-cross").allInnerTexts();
+  const litLap = await hoverPage.locator(".pace-table th.pace-lapcol.is-cross").allInnerTexts();
+  const ring = await hoverPage.locator(".pace-table td.is-crosshair").count();
+  const expectHead = await hoverPage.locator(".pace-table thead th").nth(targetCol).innerText();
+  const expectLap = await hoverPage
+    .locator(".pace-table tbody tr")
+    .nth(targetRow)
+    .locator("th.pace-lapcol")
+    .innerText();
+  check(
+    litHead.length === 1 && litHead[0] === expectHead,
+    `hover: exactly the hovered driver's column header lights (${JSON.stringify(litHead)} vs ${expectHead})`,
+  );
+  check(
+    litLap.length === 1 && litLap[0] === expectLap,
+    `hover: exactly the hovered lap's row header lights (${JSON.stringify(litLap)} vs ${expectLap})`,
+  );
+  check(ring === 1, `hover: exactly one cell carries the crosshair ring (${ring})`);
+  await hoverPage.mouse.move(2, 2);
+  await hoverPage.waitForTimeout(250);
+  check(
+    (await hoverPage.locator(".pace-table th.is-cross").count()) === 0,
+    "hover: the cross clears when the pointer leaves the grid",
+  );
+
+  await hoverCtx.close();
+}
+
 await browser.close();
 server.close();
 

--- a/src/pitwall/ui/src/features/agents/ChartReadout.tsx
+++ b/src/pitwall/ui/src/features/agents/ChartReadout.tsx
@@ -1,0 +1,68 @@
+/**
+ * The hover box both AGENTS cards share (#999).
+ *
+ * One component rather than one per card, because the two boxes would otherwise
+ * be the same twenty lines twice - and a pair of copies where one gets a fix and
+ * the other does not is this repository's most productive defect.
+ *
+ * It is deliberately small. These two charts plot three or four quantities at a
+ * lap, not twenty, so the box is a lap number and a short list; the race trace's
+ * list of the whole field is a different shape and lives with that panel.
+ */
+
+import type { ChartHover } from "../../lib/chartHover";
+
+/** One quantity at the hovered lap. `null` prints an em dash. */
+export interface ReadoutRow {
+  label: string;
+  value: string | null;
+  /** The series' own colour, so a row and the line it describes agree. */
+  colour: string;
+}
+
+/**
+ * A series' y at an exact lap, formatted, or null where it has no point there.
+ *
+ * Laps are integers, so this is a lookup rather than an interpolation: a
+ * predicted lap time "at lap 23.4" is not a quantity these models produce.
+ */
+export function at(points: [number, number][], lap: number): string | null {
+  const found = points.find(([atLap]) => atLap === lap);
+  return found === undefined ? null : found[1].toFixed(1);
+}
+
+/**
+ * The box, opening on whichever side of the cursor has room.
+ *
+ * `position: absolute` inside the card, never `fixed`. The AGENTS body takes a
+ * `filter` when the feed freezes, exactly as the DATA window's does, and a
+ * filter becomes the containing block for fixed descendants - so a fixed box
+ * would jump the moment the feed stopped. Measured on the DATA window at 50 px.
+ */
+export function ChartReadout({
+  hover,
+  lap,
+  rows,
+}: {
+  hover: ChartHover;
+  lap: number;
+  rows: ReadoutRow[];
+}) {
+  const side =
+    hover.pixelX > hover.hostWidth / 2
+      ? { right: hover.hostWidth - hover.pixelX + 8 }
+      : { left: hover.pixelX + 8 };
+  return (
+    <div className="chart-readout" style={side}>
+      <span className="chart-readout-lap">LAP {lap}</span>
+      {rows.map((row) => (
+        <span key={row.label} className="chart-readout-row">
+          <span className="chart-readout-label" style={{ color: row.colour }}>
+            {row.label}
+          </span>
+          <span className="chart-readout-value">{row.value ?? "—"}</span>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/pitwall/ui/src/features/agents/PaceChart.tsx
+++ b/src/pitwall/ui/src/features/agents/PaceChart.tsx
@@ -15,6 +15,8 @@ import { useMemo } from "react";
 import type { EChartsOption } from "echarts";
 import type { PaceSeries } from "../../lib/agents";
 import { useEChart } from "../../lib/chart";
+import { useChartHover } from "../../lib/chartHover";
+import { ChartReadout, at } from "./ChartReadout";
 import { CHART_BASE, currentLapMark, lapAxis } from "./useEChart";
 
 export function PaceChart({ series }: { series: PaceSeries }) {
@@ -105,5 +107,36 @@ export function PaceChart({ series }: { series: PaceSeries }) {
     [series, stale],
   );
 
-  return <div className="chart" ref={useEChart(option)} />;
+  const [ref, instance] = useEChart(option);
+  const [hover, hoverProps] = useChartHover(instance, series.x_range);
+  const lap = hover === null ? null : Math.round(hover.dataX);
+  const band = lap === null ? undefined : series.band.find(([at]) => at === lap);
+
+  return (
+    <div className="chart-hover">
+      <div className="chart" ref={ref} {...hoverProps} />
+      {hover !== null && lap !== null ? (
+        <>
+          <div className="chart-hover-cursor" style={{ left: hover.pixelX }} />
+          <ChartReadout
+            hover={hover}
+            lap={lap}
+            rows={[
+              // Each field is independently absent at a lap: a tick can carry a
+              // lap time with no `per_agent` block, which is the whole reason
+              // this card dims and labels a stale prediction. So every row prints
+              // its own em dash rather than the box hiding when one is missing.
+              { label: "actual", value: at(series.actual, lap), colour: series.actual_colour },
+              { label: "pred", value: at(series.pred, lap), colour: series.pred_colour },
+              {
+                label: "P10-P90",
+                value: band ? `${band[1].toFixed(1)}-${band[2].toFixed(1)}` : null,
+                colour: series.band_colour,
+              },
+            ]}
+          />
+        </>
+      ) : null}
+    </div>
+  );
 }

--- a/src/pitwall/ui/src/features/agents/TireChart.tsx
+++ b/src/pitwall/ui/src/features/agents/TireChart.tsx
@@ -18,6 +18,8 @@ import { useMemo } from "react";
 import type { EChartsOption } from "echarts";
 import type { TireSeries } from "../../lib/agents";
 import { useEChart } from "../../lib/chart";
+import { useChartHover } from "../../lib/chartHover";
+import { ChartReadout, at } from "./ChartReadout";
 import { CHART_BASE, lapAxis, secondsAxis } from "./useEChart";
 
 export function TireChart({ series }: { series: TireSeries }) {
@@ -104,5 +106,57 @@ export function TireChart({ series }: { series: TireSeries }) {
     };
   }, [series]);
 
-  return <div className="chart" ref={useEChart(option)} />;
+  const [ref, instance] = useEChart(option);
+  const [hover, hoverProps] = useChartHover(instance, series.x_range);
+  const lap = hover === null ? null : Math.round(hover.dataX);
+  const cliff = series.cliff;
+
+  return (
+    <div className="chart-hover">
+      <div className="chart" ref={ref} {...hoverProps} />
+      {hover !== null && lap !== null ? (
+        <>
+          <div className="chart-hover-cursor" style={{ left: hover.pixelX }} />
+          <ChartReadout
+            hover={hover}
+            lap={lap}
+            rows={[
+              // The observed value comes from whichever STINT covers this lap.
+              // One series per stint is the chart's own shape - the break IS the
+              // compound change - so the lookup asks every stint and takes the
+              // one that has the lap, rather than assuming a single line.
+              {
+                label: "observed",
+                value: stintValue(series.stints, lap),
+                colour: series.stints.find((s) => at(s.points, lap) !== null)?.colour ?? "",
+              },
+              { label: "trend", value: at(series.trend, lap), colour: series.trend_colour },
+              {
+                label: "cliff",
+                // The band is a lap RANGE, not a value at this lap, so it prints
+                // whole and identically wherever the pointer is. Suppressed with
+                // its own bounds, which the host already nulls outside the sane
+                // horizon because the TCN emits tens of thousands of laps early
+                // in a stint.
+                value:
+                  cliff && cliff.lo !== null && cliff.hi !== null
+                    ? `L${Math.round(cliff.lo)}-${Math.round(cliff.hi)}`
+                    : null,
+                colour: series.cliff_colour,
+              },
+            ]}
+          />
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+/** The lap's observed time from whichever stint covers it. Null between stints. */
+function stintValue(stints: TireSeries["stints"], lap: number): string | null {
+  for (const stint of stints) {
+    const found = at(stint.points, lap);
+    if (found !== null) return found;
+  }
+  return null;
 }

--- a/src/pitwall/ui/src/features/data/RacePaceGrid.tsx
+++ b/src/pitwall/ui/src/features/data/RacePaceGrid.tsx
@@ -35,7 +35,7 @@
  * hides them globally.
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type MouseEvent } from "react";
 
 import { racePaceGrid } from "../../lib/racePace";
 import type { Bulk } from "../../lib/bridge";
@@ -255,6 +255,33 @@ export function RacePaceGrid({
     measure();
   }, [grid.revealedTo, grid.laps.length, measure]);
 
+  const [cell, setCell] = useState<{ row: number; column: number } | null>(null);
+  /**
+   * Which body cell the pointer is in, from the event's own target.
+   *
+   * `cellIndex` and `rowIndex` come from the DOM's table model rather than from
+   * a `data-` attribute per cell, so nothing has to be rendered onto 1,140
+   * elements to make them addressable. Column 0 is the lap header, so a
+   * `cellIndex` of 0 means the pointer is on the lap number itself: that still
+   * lights the row, and lights no column, which is the honest answer.
+   */
+  const onCellOver = useCallback((event: MouseEvent<HTMLTableElement>) => {
+    const target = (event.target as HTMLElement).closest("td, th");
+    const row = target?.parentElement as HTMLTableRowElement | undefined;
+    if (!target || !row || row.parentElement?.tagName !== "TBODY") {
+      setCell(null);
+      return;
+    }
+    const next = { row: row.rowIndex, column: (target as HTMLTableCellElement).cellIndex };
+    // Only when it actually moved. `mouseover` already fires per element rather
+    // than per pixel, and this drops the re-render for the bubbled events a
+    // single cell can produce.
+    setCell((held) =>
+      held && held.row === next.row && held.column === next.column ? held : next,
+    );
+  }, []);
+  const clearCell = useCallback(() => setCell(null), []);
+
   const total = bulk?.race.total_laps ?? grid.laps.length;
   const [first, last] = visible ?? [
     grid.laps[0],
@@ -295,12 +322,29 @@ export function RacePaceGrid({
         role="region"
         aria-label="Race pace by lap, scrollable"
       >
-        <table className="pace-table">
+        {/* **The grid's readout is a cross, not a box, because its axes are
+            already labelled.** The lap is in the row's own `th` and the driver
+            in the head; what a reader loses over 21 columns is which row and
+            column a cell belongs to, so lighting those two answers it, and a
+            floating box would only repeat what is already on screen.
+
+            ONE delegated listener on the table, not a handler per cell: there
+            are 1,140 of them. `mouseover` fires when the pointer crosses into a
+            new element rather than on every move, and `remember` drops the write
+            when the cell has not changed, so this is a state update per cell
+            entered - human-paced - and never one per mousemove. */}
+        <table className="pace-table" onMouseOver={onCellOver} onMouseLeave={clearCell}>
           <thead>
             <tr>
               <th className="pace-lapcol" />
-              {grid.columns.map((code) => (
-                <th key={code}>{code}</th>
+              {grid.columns.map((code, column) => (
+                // `column + 1` throughout: the lap header is cell 0, so a driver
+                // column's DOM index is one past its index in `grid.columns`.
+                // That off-by-one is the natural mutant here, which is why the
+                // guard hovers a cell that is not in the first column.
+                <th key={code} className={cell?.column === column + 1 ? "is-cross" : undefined}>
+                  {code}
+                </th>
               ))}
             </tr>
           </thead>
@@ -336,14 +380,28 @@ export function RacePaceGrid({
                  * confused. The label rides in the title for the reader who
                  * wonders which neutralisation it was. */}
                 <th
-                  className={`pace-lapcol${grid.neutralised[index] ? " is-neutralised" : ""}`}
+                  className={
+                    `pace-lapcol${grid.neutralised[index] ? " is-neutralised" : ""}` +
+                    // The lap number lights for the hovered ROW. `rowIndex` counts
+                    // from the whole table, so the head row is 0 and body row `i`
+                    // is `i + 1`.
+                    (cell?.row === index + 1 ? " is-cross" : "")
+                  }
                   title={grid.neutralised[index] ?? undefined}
                 >
                   {grid.laps[index]}
                 </th>
-                {row.map((cell, column) => (
-                  <td key={grid.columns[column]} className={`is-${cell.tone}`}>
-                    {cell.text}
+                {row.map((value, column) => (
+                  <td
+                    key={grid.columns[column]}
+                    className={
+                      `is-${value.tone}` +
+                      (cell?.row === index + 1 && cell?.column === column + 1
+                        ? " is-crosshair"
+                        : "")
+                    }
+                  >
+                    {value.text}
                   </td>
                 ))}
               </tr>

--- a/src/pitwall/ui/src/features/data/RaceTraceChart.tsx
+++ b/src/pitwall/ui/src/features/data/RaceTraceChart.tsx
@@ -40,10 +40,11 @@ import { useMemo, useState } from "react";
 import type { EChartsOption } from "echarts";
 
 import { AXIS_TEXT, CURSOR_LINE, NEUTRALISED_BAND, useEChart, valueAxis } from "../../lib/chart";
+import { useChartHover } from "../../lib/chartHover";
 import { driverStatus } from "../../lib/driverStatus";
 import { neutralisedLaps, neutralisedRanges } from "../../lib/neutralised";
 import { raceTrace } from "../../lib/raceTrace";
-import type { TraceReference } from "../../lib/raceTrace";
+import type { RaceTrace, TraceReference } from "../../lib/raceTrace";
 import type { ArcadeState, Bulk } from "../../lib/bridge";
 import { driverColour } from "../../lib/driverColour";
 
@@ -62,6 +63,45 @@ const NO_COLOUR = AXIS_TEXT;
 /** `+12.3` / `-4.5` - the sign is the whole reading, so it is always printed. */
 function signedSeconds(value: number): string {
   return `${value > 0 ? "+" : ""}${value.toFixed(1)}`;
+}
+
+/** One line's value at the hovered lap. `null` means that car has none there. */
+interface ReadoutRow {
+  code: string;
+  value: number | null;
+}
+
+/**
+ * Every car's gap at one lap, which is the vertical cut this panel exists for.
+ *
+ * **Sorted DESCENDING, because higher on this chart is further up the road.**
+ * That holds under all three references and is what makes the list read front
+ * to back like a timing tower: in LEADER mode the car in front sits on zero and
+ * the rest hang below it at negative values, so ascending would have put the
+ * leader last and the tail-ender first. The first version did exactly that and
+ * only the screenshot said so - the numbers were all correct and the order was
+ * upside down.
+ *
+ * A car with no value at that lap - retired before it, or the reveal has not
+ * reached it - goes to the BOTTOM with an em dash rather than being left out: a
+ * car that vanishes from the list reads as a car that is not in the race, and
+ * this panel is where a reader counts the field.
+ *
+ * Laps are integers on this axis, so the pointer's continuous x is rounded to
+ * the nearest one and the row is looked up by exact lap. No interpolation: a
+ * gap "at lap 23.4" is not a quantity the race has.
+ */
+function traceReadout(trace: RaceTrace, x: number): { lap: number; rows: ReadoutRow[] } | null {
+  const lap = Math.round(x);
+  if (!trace.laps.includes(lap)) return null;
+  const rows = trace.lines.map((line) => ({
+    code: line.code,
+    value: line.points.find(([pointLap]) => pointLap === lap)?.[1] ?? null,
+  }));
+  const known = rows.filter((row) => row.value !== null);
+  const missing = rows.filter((row) => row.value === null);
+  known.sort((a, b) => (b.value as number) - (a.value as number));
+  return { lap, rows: [...known, ...missing] };
 }
 
 export function RaceTraceChart({ bulk, arcade }: { bulk: Bulk | null; arcade: ArcadeState }) {
@@ -218,7 +258,12 @@ export function RaceTraceChart({ bulk, arcade }: { bulk: Bulk | null; arcade: Ar
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [trace, own]);
 
-  const host = useEChart(trace.lines.length ? option : null);
+  const [host, instance] = useEChart(trace.lines.length ? option : null);
+  const lapDomain: [number, number] | null = trace.laps.length
+    ? [trace.laps[0], trace.laps[trace.laps.length - 1]]
+    : null;
+  const [hover, hoverProps] = useChartHover(instance, lapDomain);
+  const readout = hover === null ? null : traceReadout(trace, hover.dataX);
 
   return (
     <section className="card trace-band">
@@ -249,7 +294,45 @@ export function RaceTraceChart({ bulk, arcade }: { bulk: Bulk | null; arcade: Ar
         </nav>
       </header>
       {trace.lines.length ? (
-        <div className="trace-band-plot" ref={host} />
+        <div className="trace-band-hover">
+          <div className="trace-band-plot" ref={host} {...hoverProps} />
+          {/* The vertical cut, made with the mouse. Twenty lines is the one case
+              on either window where a floating list is the right shape: the
+              values are spread over the whole plot height and no per-line label
+              could hold them.
+
+              It opens on whichever side of the cursor has room, and it is
+              absolutely positioned inside the card - never fixed, because
+              `.data-main.is-frozen`'s filter would become its containing block
+              and move it 50 px the moment the feed froze. */}
+          {hover !== null && readout !== null ? (
+            <>
+              <div className="trace-band-cursor" style={{ left: hover.pixelX }} />
+              <div
+                className="trace-band-box"
+                style={
+                  hover.pixelX > hover.hostWidth / 2
+                    ? { right: hover.hostWidth - hover.pixelX + 8 }
+                    : { left: hover.pixelX + 8 }
+                }
+              >
+                <span className="trace-band-box-lap">LAP {readout.lap}</span>
+                {readout.rows.map((row) => (
+                  <span key={row.code} className="trace-band-box-row">
+                    {/* The CODE identifies the car, not the colour: ten team
+                        colours cover twenty drivers, so every hue here is shared
+                        by exactly two of them. The same reason the end labels
+                        are drawn in the axis grey. */}
+                    <span className="trace-band-box-code">{row.code}</span>
+                    <span className="trace-band-box-value">
+                      {row.value === null ? "—" : signedSeconds(row.value)}
+                    </span>
+                  </span>
+                ))}
+              </div>
+            </>
+          ) : null}
+        </div>
       ) : (
         // A trace with nothing to draw SAYS so. An empty plot and a race whose
         // field has not yet completed a common lap are the same pixels

--- a/src/pitwall/ui/src/features/data/TraceStack.tsx
+++ b/src/pitwall/ui/src/features/data/TraceStack.tsx
@@ -43,7 +43,8 @@ import { useCallback, useMemo, useRef, useState } from "react";
 import type { EChartsOption } from "echarts";
 
 import { CURSOR_LINE, useEChart, valueAxis } from "../../lib/chart";
-import type { SortedTrace } from "./traceBuffer";
+import { useChartHover } from "../../lib/chartHover";
+import { lerpSorted, stepSorted, type SortedTrace } from "./traceBuffer";
 
 /**
  * One lane: its label, its locked y range, its own-car colour, and its share of the
@@ -283,6 +284,45 @@ function channel(trace: SortedTrace, lane: Lane): [number, number][] {
   return trace.xs.map((x, i) => [x, trace.rows[i][key]]);
 }
 
+/**
+ * One lane's channel as a plain `ys` array, aligned to `trace.xs`.
+ *
+ * `channel` above builds `[x, y]` pairs because that is what ECharts eats; the
+ * two lookups want the y values on their own. Same source, one derivation, so
+ * a lane cannot be plotted from one array and read from another.
+ */
+function values(trace: SortedTrace, lane: Lane): number[] {
+  return channel(trace, lane).map(([, y]) => y);
+}
+
+/**
+ * What a lane reads at distance `x`, or null where the car has not been.
+ *
+ * The branch on `lane.step` is the whole point: `stepSorted` for the two
+ * staircases, `lerpSorted` for the four curves. Its reasoning is in
+ * `stepSorted`'s own docstring, where the DRS case is - an interpolated 0.5
+ * prints CLOSED through the lane's readout, so a linear lookup here does not
+ * report an unknown, it reports the wrong state.
+ *
+ * The delta lane has no per-sample rows of its own; it arrives already
+ * interpolated onto the main car's x, and it is a curve.
+ */
+function valueAt(
+  lane: Lane,
+  main: SortedTrace,
+  delta: [number, number][],
+  x: number,
+): number | null {
+  if (lane.key === "delta")
+    return lerpSorted(
+      delta.map(([dx]) => dx),
+      delta.map(([, dy]) => dy),
+      x,
+    );
+  const ys = values(main, lane);
+  return lane.step ? stepSorted(main.xs, ys, x) : lerpSorted(main.xs, ys, x);
+}
+
 /** The newest main-span value for a lane, for its label row. Null when starved. */
 function latest(
   lane: Lane,
@@ -446,7 +486,11 @@ export function TraceStack(props: TraceStackProps) {
     };
   }, [box, main, rival, delta, xMax, rivalCode, rivalColour]);
 
-  const chart = useEChart(box > 0 && !placeholder ? option : null);
+  const [chart, instance] = useEChart(box > 0 && !placeholder ? option : null);
+  // Grid 0's x axis, which every lane shares. The domain is the locked circuit
+  // length, so a pointer in the axis gutter converts out of range and the
+  // readout and its cursor disappear together.
+  const [hover, hoverProps] = useChartHover(instance, xMax > 0 ? [0, xMax] : null);
   const boxes = laneLayout(box);
   const stackBottom = boxes.length
     ? boxes[boxes.length - 1].top + boxes[boxes.length - 1].height
@@ -462,7 +506,7 @@ export function TraceStack(props: TraceStackProps) {
         <div className="trace-placeholder">{placeholder}</div>
       ) : (
         <>
-          <div className="trace-stack-plot" ref={chart} />
+          <div className="trace-stack-plot" ref={chart} {...hoverProps} />
           {/* The label rows and the cursor are HTML over the canvas, not ECharts
               graphics: `notMerge: true` would restart them ten times a second. */}
           {/* **Single-driver mode captions the Δ LANE, not the whole panel.** In the
@@ -499,11 +543,48 @@ export function TraceStack(props: TraceStackProps) {
                   <span className="trace-lane-unit"> {LANES[index].unit}</span>
                 ) : null}
               </span>
+              {/* **The readout IS this row.** No floating box: the six values
+                  are already where a reader looks for them, and a box tall
+                  enough for six labelled values would cover two or three of the
+                  38-145 px lanes it is reporting on.
+
+                  Hovering swaps what the number MEANS, from the newest sample
+                  to the sample under the cursor, which is the stacked-trace
+                  convention every client the spec surveyed uses. The hover
+                  cursor being on screen is what says which of the two is
+                  showing. */}
               <span className="trace-lane-value">
-                {(() => {
-                  const value = latest(LANES[index], main, delta);
-                  return value === null ? "—" : LANES[index].readout(value);
-                })()}
+                {hover === null ? (
+                  (() => {
+                    const value = latest(LANES[index], main, delta);
+                    return value === null ? "—" : LANES[index].readout(value);
+                  })()
+                ) : (
+                  <>
+                    {(() => {
+                      const value = valueAt(LANES[index], main, delta, hover.dataX);
+                      return value === null ? "—" : LANES[index].readout(value);
+                    })()}
+                    {/* The rival's own value at the SAME distance, which is the
+                        comparison the panel exists for, and in the rival's team
+                        colour so it cannot be confused with our car's.
+
+                        An em dash where the rival has not reached this distance
+                        - the ordinary state since #1066 let the tower pin any
+                        car, measured at 25.8 % of car-ticks - because
+                        `lerpSorted` and `stepSorted` both answer null outside
+                        their span rather than clamping to an edge value. The
+                        delta lane is skipped: it IS the comparison already. */}
+                    {rivalCode !== null && LANES[index].key !== "delta" ? (
+                      <span className="trace-lane-rival" style={{ color: rivalColour }}>
+                        {(() => {
+                          const value = valueAt(LANES[index], rival, delta, hover.dataX);
+                          return value === null ? "—" : LANES[index].readout(value);
+                        })()}
+                      </span>
+                    ) : null}
+                  </>
+                )}
               </span>
             </div>
           ))}
@@ -521,6 +602,52 @@ export function TraceStack(props: TraceStackProps) {
                 background: CURSOR_LINE,
               }}
             />
+          )}
+          {/* **The SECOND cursor, and it is a third stroke rather than a reuse.**
+              Both are on screen at once: moving the car's mark to the pointer
+              would delete "now" at exactly the moment a reader is comparing a
+              past point of the lap against it.
+
+              A third treatment was free. This window's strokes are already
+              spoken for - solid 1 px #9ca3af vertical is the car, dashed means
+              broadcast-tier data, solid 2 px blue horizontal is the delta zero
+              line - and nothing on either window draws a solid white vertical.
+              Brighter than the car's mark on purpose: it is only on screen
+              while the reader is asking for it, so it can afford to be the
+              thing the eye goes to, and it is the colour of the numbers it
+              produces one row over. */}
+          {hover === null ? null : (
+            <>
+              <div
+                className="trace-cursor is-hover"
+                style={{ left: hover.pixelX, top: 0, height: stackBottom }}
+              />
+              {/* WHERE on the lap the six values were read, which the lane rows
+                  cannot say.
+
+                  **Below the stack, over the distance axis, and NOT at the top.**
+                  At the top it shares a 12 px band with the lane name on the left
+                  and the two values on the right, so it reads clear only while the
+                  cursor is near the middle: carried to either end it lands on top
+                  of the very numbers it is captioning. The axis band below has
+                  nothing in it but tick labels, and the chip is opaque, so it
+                  covers one `2k` with the exact metre - strictly more than the
+                  tick it hides, and only while the pointer is down.
+
+                  It still opens to whichever side has room, because the chip is
+                  wider than the plot's right margin and would be cut in half at
+                  the end of the lap. */}
+              <div
+                className="trace-hover-dist"
+                style={
+                  hover.pixelX > hover.hostWidth / 2
+                    ? { right: hover.hostWidth - hover.pixelX, top: stackBottom }
+                    : { left: hover.pixelX, top: stackBottom }
+                }
+              >
+                {Math.round(hover.dataX)} m
+              </div>
+            </>
           )}
         </>
       )}

--- a/src/pitwall/ui/src/features/data/traceBuffer.ts
+++ b/src/pitwall/ui/src/features/data/traceBuffer.ts
@@ -237,6 +237,45 @@ export function lerpSorted(xs: number[], ys: number[], x: number): number | null
 }
 
 /**
+ * The value a STEP channel holds at `x`: the last sample at or before it.
+ *
+ * The sibling of `lerpSorted`, and it lives beside it rather than in the panel
+ * so there is one place that answers "what was this channel at x". Same
+ * contract: null outside `[xs[0], xs[last]]`, so a pointer past where the car
+ * has driven gets an honest absence rather than an edge value.
+ *
+ * **Two of the six trace lanes must NOT be interpolated, and one of them fails
+ * silently.** `gear` and `drs` are staircases - the lane table marks them
+ * `step: true` and the series draws them `step: "end"` - so a linear value
+ * between two samples is a state the channel cannot hold. Gear reads 5.4
+ * between fifth and sixth. Worse, DRS between a closed sample and an open one
+ * interpolates to exactly 0.5, and the lane's own readout is
+ * `value > 0.5 ? "OPEN" : "CLOSED"`, so the boundary value resolves to a REAL
+ * state rather than to an unknown one: the readout prints CLOSED over an
+ * opening. That is this repo's sentinel-collision class - a computed value
+ * landing on something the code also legitimately finds, with nothing
+ * downstream able to tell them apart.
+ *
+ * The rule applies only where `lane.step` is set. Samples are keyed per integer
+ * metre, so adjacent ones are about 6 m apart at racing speed and interpolating
+ * SPEED, THROTTLE or BRAKE between them is honest.
+ */
+export function stepSorted(xs: number[], ys: number[], x: number): number | null {
+  if (xs.length === 0 || x < xs[0] || x > xs[xs.length - 1]) return null;
+  // The last index whose x is at or before the pointer. `<=` rather than `<`
+  // is the whole difference from `lerpSorted`'s search: landing exactly on a
+  // sample must take THAT sample's value, not the one before it.
+  let lo = 0;
+  let hi = xs.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (xs[mid] <= x) lo = mid + 1;
+    else hi = mid;
+  }
+  return ys[lo - 1];
+}
+
+/**
  * The delta series along the main driver's x, RE-BASED to lap-relative time.
  *
  * Main is the flat reference at y=0, so a POSITIVE trace means the rival is

--- a/src/pitwall/ui/src/lib/chart.ts
+++ b/src/pitwall/ui/src/lib/chart.ts
@@ -25,7 +25,7 @@
  * `tests/surfaces/test_pitwall_tokens.py`.
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
 import * as echarts from "echarts";
 
 /** `palette.TEXT_SECONDARY` - axis names and tick labels. */
@@ -75,7 +75,9 @@ export const NEUTRALISED_BAND = "rgba(245, 158, 11, 0.08)";
  * swap the effect never re-ran, the instance pointed at a detached node, and
  * the chart was dead for the rest of the session with no error anywhere.
  */
-export function useEChart(option: echarts.EChartsOption | null) {
+export function useEChart(
+  option: echarts.EChartsOption | null,
+): [(node: HTMLDivElement | null) => void, RefObject<echarts.ECharts | null>] {
   const [host, setHost] = useState<HTMLDivElement | null>(null);
   const chart = useRef<echarts.ECharts | null>(null);
   const ref = useCallback((node: HTMLDivElement | null) => setHost(node), []);
@@ -90,6 +92,15 @@ export function useEChart(option: echarts.EChartsOption | null) {
     // the mechanism - and the sprint-3 exit gate's whole lesson was that a
     // check written against the mechanism passes over a broken effect. An
     // ECharts instance is not reachable from outside the module otherwise.
+    //
+    // **Smoke only. Production reads the instance from the ref this hook
+    // RETURNS.** The hover readout needs `convertFromPixel`, and reading it
+    // off the node here was the obvious way to get it. A gate refuted that:
+    // this handle is documented as a test seam, so using it in production
+    // makes it an undocumented API that a later cleanup deletes; and the
+    // instance is per-MOUNT, so a caller would have to re-read the node
+    // after every remount through a second ref, duplicating the lifecycle
+    // this hook already owns. The tuple return costs four call sites once.
     (host as HTMLDivElement & { __pitwallChart?: echarts.ECharts }).__pitwallChart = instance;
     const observer = new ResizeObserver(() => instance.resize());
     observer.observe(host);
@@ -108,7 +119,7 @@ export function useEChart(option: echarts.EChartsOption | null) {
     chart.current.setOption({ ...option, animationDurationUpdate: 0 }, { notMerge: true });
   }, [option, host]);
 
-  return ref;
+  return [ref, chart];
 }
 
 export interface AxisSpec {

--- a/src/pitwall/ui/src/lib/chartHover.ts
+++ b/src/pitwall/ui/src/lib/chartHover.ts
@@ -1,0 +1,111 @@
+/**
+ * Where the pointer is on a chart's x axis, for the hover readouts (#999).
+ *
+ * One hook for all four ECharts surfaces on both windows. Every chart here is
+ * read with a VERTICAL cut - six lanes at one distance, twenty cars at one lap,
+ * a prediction against an actual at one lap - so the only quantity a readout
+ * needs from the pointer is its position on the x axis, and the pixel to put a
+ * cursor at.
+ *
+ * **Why this is not an ECharts `tooltip` with an `axisPointer`.** That is the
+ * mechanism #999 proposed and it does not survive this window. `useEChart`
+ * pushes every option with `notMerge: true`, which rebuilds the components, and
+ * the tooltip goes with them. Measured on the real host with the pointer
+ * PARKED: visible on 0 of 25 samples while the app pushed, 25 of 25 with
+ * `setOption` frozen mid-session, 0 of 25 with it restored. It is re-created on
+ * `mousemove` and destroyed by the next push, so it exists only while the mouse
+ * is physically moving - and a reader parks the pointer to read a number.
+ *
+ * A moving-pointer probe sees it 14 times out of 14 and passes the broken
+ * design, which is why the guards park.
+ *
+ * `alwaysShowContent` plus a re-dispatched `showTip` after every push does
+ * reach 25 of 25, at the price of tracking the hovered index in our own state
+ * and firing an action five times a second on the data path. That is the whole
+ * of the hover state, owned here, with ECharts drawing the box - so the box may
+ * as well be ours and land where each panel wants it.
+ */
+
+import { useCallback, useState, type PointerEvent, type RefObject } from "react";
+import type * as echarts from "echarts";
+
+/** The pointer, resolved onto one chart's x axis. */
+export interface ChartHover {
+  /** The x axis value under the pointer, in that axis's own units. */
+  dataX: number;
+  /** Where that sits on the host element, in px from its left edge. */
+  pixelX: number;
+  /**
+   * The host's own width, so a readout can decide which side of the cursor to
+   * open on.
+   *
+   * Reported rather than measured again by each caller: it is already in the
+   * `getBoundingClientRect` this hook takes on every move, and a panel that
+   * measured it separately would be reading a different box on the tick a
+   * resize lands.
+   */
+  hostWidth: number;
+}
+
+/**
+ * Track the pointer over a chart and report its x axis position.
+ *
+ * `domain` is the axis's locked `[min, max]`, and it is what keeps the readout
+ * out of the axis gutter: `convertFromPixel` answers happily for a pixel
+ * outside the grid, so the value it returns there is out of domain rather than
+ * absent. Comparing against the range the caller locked is the guard, and it
+ * costs nothing because the caller already owns both numbers. A null domain
+ * means the chart has no range yet, so there is nothing to hover.
+ *
+ * Deliberately NOT `containPixel`: on the six-grid trace stack the label rows
+ * and the gaps between lanes are outside every grid, so containment on the
+ * pointer's own y would drop the cursor five times on the way down a panel that
+ * exists to be read with ONE cut. The cut is horizontal; y is not part of it.
+ *
+ * The returned handlers go on the same element as the chart's ref. The state
+ * lives here, in the chart's own component, so it dies with the unmount - a
+ * DATA tab switch disposes the instance and creates a new one, and hover state
+ * lifted any higher would outlive it and paint a stale readout onto a fresh
+ * chart.
+ */
+export function useChartHover(
+  chart: RefObject<echarts.ECharts | null>,
+  domain: readonly [number, number] | null,
+  gridIndex = 0,
+): [ChartHover | null, {
+  onPointerMove: (event: PointerEvent<HTMLDivElement>) => void;
+  onPointerLeave: () => void;
+}] {
+  const [hover, setHover] = useState<ChartHover | null>(null);
+
+  const onPointerMove = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      const instance = chart.current;
+      if (!instance || !domain) {
+        setHover(null);
+        return;
+      }
+      const box = event.currentTarget.getBoundingClientRect();
+      const pixelX = event.clientX - box.left;
+      const converted = instance.convertFromPixel({ gridIndex }, [
+        pixelX,
+        event.clientY - box.top,
+      ]);
+      const dataX = Array.isArray(converted) ? converted[0] : null;
+      if (dataX === null || !Number.isFinite(dataX) || dataX < domain[0] || dataX > domain[1]) {
+        setHover(null);
+        return;
+      }
+      setHover({ dataX, pixelX, hostWidth: box.width });
+    },
+    // `domain` is a tuple rebuilt per render by most callers, so it is spread
+    // into the dependency list by value. Depending on the array identity would
+    // rebuild the handler on every tick.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [chart, gridIndex, domain?.[0], domain?.[1]],
+  );
+
+  const onPointerLeave = useCallback(() => setHover(null), []);
+
+  return [hover, { onPointerMove, onPointerLeave }];
+}

--- a/src/pitwall/ui/src/styles/agents.css
+++ b/src/pitwall/ui/src/styles/agents.css
@@ -778,10 +778,59 @@
  * column now: the two chart consoles stretch to their grid row (`agents.css`'s
  * `.agents-grid > .slot-pace`) and the chart fills what the headline and body
  * do not take. */
+/* The wrapper is the positioning context for the hover readout (#999); the
+ * chart fills it. Absolute, never fixed: the agents body takes a `filter` when
+ * the feed freezes, and a filter becomes the containing block for fixed
+ * descendants, so a fixed box would jump the moment the feed stopped. */
+.chart-hover {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-height: 140px;
+}
 .chart {
   width: 100%;
   height: 100%;
   min-height: 140px;
+}
+.chart-hover-cursor {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--qt-fg-1);
+  pointer-events: none;
+}
+/* Small on purpose: these two cards plot three or four quantities at a lap, not
+ * twenty, so the box is a lap and a short list. The field's whole list is the
+ * race trace's shape and lives with that panel. */
+.chart-readout {
+  position: absolute;
+  top: 6px;
+  display: flex;
+  flex-direction: column;
+  padding: 4px 6px;
+  background: var(--qt-elevated);
+  border: 1px solid var(--qt-border);
+  font-family: var(--qt-mono);
+  font-size: 9px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.3;
+  pointer-events: none;
+}
+.chart-readout-lap {
+  margin-bottom: 3px;
+  color: var(--qt-fg-1);
+  font-weight: 700;
+  letter-spacing: 0.5px;
+}
+.chart-readout-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+}
+.chart-readout-value {
+  color: var(--qt-fg-2);
 }
 
 /* Opting the tooltip back INTO a scrollbar, against `qt-base.css`'s blanket

--- a/src/pitwall/ui/src/styles/data.css
+++ b/src/pitwall/ui/src/styles/data.css
@@ -783,6 +783,109 @@ td.col-drv {
   width: 1px;
   pointer-events: none;
 }
+/* The hover cursor (#999), brighter than the car's mark because it is only on
+ * screen while the reader is asking for it. `--qt-fg-1` is also the colour of
+ * the lane values it produces, so the mark and its numbers read as one thing.
+ *
+ * The colour is set here rather than inline, unlike `.trace-cursor`'s, because
+ * it has a token and the car's is `CURSOR_LINE` from the shared chart palette. */
+.trace-cursor.is-hover {
+  background: var(--qt-fg-1);
+}
+/* The hovered distance. `position: absolute`, never `fixed`: `.data-main.is-frozen`
+ * applies a `filter`, and a filter creates a containing block for fixed
+ * descendants, so a fixed overlay JUMPS by the header height the moment the feed
+ * freezes. Measured at 50 px. The same rule holds for every readout overlay on
+ * both windows. */
+.trace-hover-dist {
+  position: absolute;
+  padding: 1px 4px;
+  background: var(--qt-elevated);
+  color: var(--qt-fg-1);
+  font-family: var(--qt-mono);
+  font-size: 9px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  pointer-events: none;
+}
+/* The rival's value beside our car's. A gap rather than a separator glyph: the
+ * two are already told apart by colour, and a slash would be a fourth thing to
+ * read in a 12 px row. */
+.trace-lane-rival {
+  margin-left: 6px;
+}
+
+/* ---- The race trace's hover readout (#999) ---------------------------------
+ * The wrapper only exists to be the positioning context: the plot fills it, and
+ * the cursor and the box are absolute inside it. Absolute, never fixed - a
+ * `filter` on an ancestor becomes the containing block for fixed descendants,
+ * and this window applies one when the feed freezes. */
+.trace-band-hover {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+.trace-band-cursor {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--qt-fg-1);
+  pointer-events: none;
+}
+.trace-band-box {
+  position: absolute;
+  top: 8px;
+  display: flex;
+  flex-direction: column;
+  padding: 4px 6px;
+  background: var(--qt-elevated);
+  border: 1px solid var(--qt-border);
+  font-family: var(--qt-mono);
+  font-size: 9px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.25;
+  pointer-events: none;
+}
+.trace-band-box-lap {
+  margin-bottom: 3px;
+  color: var(--qt-fg-1);
+  font-weight: 700;
+  letter-spacing: 0.5px;
+}
+.trace-band-box-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+}
+.trace-band-box-code {
+  color: var(--qt-fg-3);
+}
+.trace-band-box-value {
+  color: var(--qt-fg-2);
+}
+
+/* ---- The pace grid's cross-highlight (#999) --------------------------------
+ * A background wash on the hovered cell's row header and column header, and a
+ * ring on the cell itself. No floating box: this panel's axes are already on
+ * screen, so the readout is knowing WHICH of them the cell belongs to.
+ *
+ * The wash is `--qt-elevated` rather than an accent because the cell colours
+ * already carry the ranking, and a hue here would be a fifth thing competing
+ * with the three tone thirds and the neutralised rail. */
+.pace-table th.is-cross {
+  background: var(--qt-elevated);
+  color: var(--qt-fg-1);
+}
+.pace-table td.is-crosshair {
+  outline: 1px solid var(--qt-fg-2);
+  outline-offset: -1px;
+}
+/* The row itself, which costs nothing and needs no state. */
+.pace-table tbody tr:hover td {
+  background: rgba(255, 255, 255, 0.04);
+}
 
 /* `_delta_placeholder`, one lane deep. Centred, italic, tertiary - the Qt treatment,
  * scoped to the lane that actually has nothing to draw instead of to a whole cell.
@@ -1649,12 +1752,15 @@ td.col-drv {
   min-height: 0;
 }
 
-/* The plot takes whatever the header leaves, and `min-height: 0` is what makes
- * that true inside a flex column: without it the div takes its content height,
- * ECharts measures zero and renders a canvas nothing ever appears on. */
+/* The plot fills `.trace-band-hover`, which is the flex child that takes
+ * whatever the header leaves. It used to be that child itself, with `flex: 1`
+ * and the `min-height: 0` that makes a flex item shrinkable - without which the
+ * div takes its content height, ECharts measures zero, and renders a canvas
+ * nothing ever appears on. The wrapper carries both now, because the hover
+ * cursor and the readout box need a positioning context that is not the canvas. */
 .trace-band-plot {
-  flex: 1;
-  min-height: 0;
+  position: absolute;
+  inset: 0;
 }
 
 .trace-band-empty {


### PR DESCRIPTION
## What

Adds a hover readout to all five charts on the two PITWALL windows. Parking the pointer over a
chart now reports the values at that position: six lanes at one distance on the TRACES stack, the
whole field at one lap on the race trace, a lap's row and column on the race pace grid, and the
predicted/actual/band and observed/trend/cliff on the two AGENTS cards.

Refs #999.

## Why the mechanism is not the one the issue proposed

#999 proposed ECharts' `axisPointer` plus a shared tooltip, on the grounds that the window is
ECharts already. It is, and the tooltip does not work here.

`useEChart` pushes every option with `notMerge: true`, which rebuilds the components and takes the
tooltip with them. Measured on the real host, with the pointer PARKED:

| condition | tooltip visible |
|---|---|
| the app pushing normally | 0 / 25 samples |
| `setOption` frozen mid-session, nothing else changed | 25 / 25 |
| `setOption` restored | 0 / 25 |

Reversible in both directions inside one session, so the cause is the push. The tooltip is
re-created on `mousemove` and destroyed about 190 ms later, which means it exists only while the
mouse is physically moving. A reader parks the pointer in order to read a value, and that is the
one state that shows nothing. A probe that swept the pointer instead saw it 14 times out of 14 and
would have passed the broken version.

`alwaysShowContent` alone is also 0 / 25. It reaches 25 / 25 only with a `showTip` re-dispatched
after every push, which means tracking the hovered index in our own state and firing an action on
the data path several times a second. At that price the readout may as well be ours and land where
each panel wants it, so it is HTML over the canvas, which is what `TraceStack` already does for its
lane labels and its cursor.

## How

- `lib/chartHover.ts`, new. Tracks the pointer over one chart and reports its x-axis value and
  pixel. The mapping goes through `convertFromPixel`, so it is the chart's own axis rather than
  four hand-rolled copies of four different grid insets. Out-of-domain values are what keep the
  readout out of the axis gutter.
- `lib/chart.ts`: `useEChart` now returns `[ref, instance]`. Four call sites. Production reads the
  instance from that ref; `__pitwallChart` stays what its docstring says it is, a seam for the
  headless smoke.
- `traceBuffer.ts`: `stepSorted`, beside `lerpSorted`. `gear` and `drs` are step channels, and a
  linear lookup on them invents states the channel cannot hold. The DRS case fails silently: an
  interpolated 0.5 between a closed sample and an open one renders as CLOSED through the lane's own
  `value > 0.5` readout, so it reports a real state rather than an unknown one.
- `TraceStack.tsx`: the six existing lane rows become the readout, showing the value at the cursor
  instead of the newest one and reverting when the pointer leaves. A second cursor in a third
  stroke (solid 1 px white) sits beside the car's (solid 1 px `#9ca3af`); both are visible at once,
  because moving the car's mark to the pointer would delete "now" exactly when a reader is
  comparing a past point against it. The rival's value prints beside ours in its team colour, and
  an em dash where the rival has not reached that distance.
- `RaceTraceChart.tsx`: a floating list of the field at the hovered lap, sorted so it reads front
  to back. Twenty lines is the one case here where a box is the right shape.
- `RacePaceGrid.tsx`: a row-and-column cross, not a box, because the panel's axes are already on
  screen and what a reader loses over 21 columns is which of them a cell belongs to. One delegated
  listener, and the state only moves when the pointer enters a different cell.
- `PaceChart.tsx` / `TireChart.tsx`: a small box, through a shared `ChartReadout` so the two cards
  cannot drift apart.

Every readout overlay is `position: absolute` inside its card and carries `pointer-events: none`.
Both are load-bearing: a CSS filter is the containing block for `position: fixed` descendants, and
`.data-main.is-frozen` is a filter, so a fixed box would jump 50 px the moment the feed froze.

## Design gate

Ran before any code was written, on the design plus the measurements behind it. No P0. All seven
mechanism decisions survived execution; three of the sentences justifying them did not, and are
corrected in the code comments:

- the trace stack's series SET never changes (it is always 12 series, with the rival's data emptied
  rather than removed), so the reason for keeping `notMerge` is the race trace and the tyre chart,
  plus the tyre chart naming stint series by compound, which makes merge-by-name unreliable;
- `lapAxis(null)` is a dead path on this wire, so "the x axes autorange" was never a reason for
  anything. `convertFromPixel` earns its place by being one mapping instead of four;
- 5.25 Hz is the loopback bridge's push rate, not the product's. `lib/chart.ts` documents 10 Hz on
  the in-process bridge the real windows use.

It also refuted the plan to read `__pitwallChart` from production code, and named the
`position: fixed` hazard, which was measured rather than argued.

## Checks

- `smoke-data` 337 -> 370, `smoke-agents` 78 -> 95, `tests/surfaces/` 288 unchanged.
- **Twelve mutants, every one seen RED with named checks**, on builds that compile: a mutant that
  fails `tsc` leaves `dist/` stale and the smoke then measures unmutated code, so the harness
  reports that as no evidence rather than as a pass. Two mutants had to be rewritten for exactly
  that reason.
- The mutants: step lookup becomes linear · the readout never leaves `latest()` · the readout is
  cleared on every render (what an ECharts tooltip does) · the trace list sorted ascending · nulls
  sorted first · the grid column off by one · the overlay becomes `position: fixed` · the lookups
  clamp instead of returning null · the mapping hardwires one surface's grid inset · hovering
  pushes an option · the cliff prints a value instead of a range · a missing field borrows the next
  lap's value.
- Driven on the real windows through the loopback host with the real producer, and screenshots read
  with the pointer placed on each of the five surfaces. That is what caught the race-trace list
  being sorted upside down: every number in it was right.
