### PR TITLE
fix(pitwall): paint the own car in its own team colour

### DIFF
--- a/src/pitwall/agents_view/builder.py
+++ b/src/pitwall/agents_view/builder.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from src.pitwall.agents_view.charts import build_pace_series, build_tire_series
+from src.pitwall.agents_view.charts import build_pace_series, build_tire_series, own_car_colour
 from src.pitwall.agents_view.decision import build_orchestrator, build_scenarios
 from src.pitwall.agents_view.history import LapHistory
 from src.pitwall.agents_view.panels import build_cards, build_header, build_status_bar
@@ -76,7 +76,12 @@ class AgentsViewBuilder:
             (latest.get("per_agent") or {}).get("tire") if latest else None,
         )
         charts = {
-            "pace": build_pace_series(self._history.pace, tire["x_range"], current_lap),
+            "pace": build_pace_series(
+                self._history.pace,
+                tire["x_range"],
+                current_lap,
+                own_car_colour(payload.get("arcade") or {}),
+            ),
             "tire": tire,
         }
 

--- a/src/pitwall/agents_view/charts.py
+++ b/src/pitwall/agents_view/charts.py
@@ -35,7 +35,42 @@ SANE_LAP_TIME_S: tuple[float, float] = (30.0, 200.0)
 # thousands of laps.
 CLIFF_MAX_SANE_LAPS: float = 100.0
 
+# The own car's actual lap time, when the wire has not said which car it is.
+#
+# **A DEGRADE, not the colour.** The car's own team colour is what identifies it,
+# and `driver_colors` carries it on every tick; this is what the chart draws
+# before the first tick lands and for a driver the colour map has no entry for.
+# It is also the boot view's value, so there is one no-wire colour rather than
+# two.
+#
+# INFO is kept as that value rather than a neutral grey because it has to be a
+# sentinel a reader cannot mistake for a real answer: it sits an RGB distance of
+# 70.8 from the nearest team colour on the wire, which is Williams blue, and that
+# is the largest separation any candidate gets. The tower's border grey would sit
+# 37.4 from Haas, inside look-alike range.
 ACTUAL_COLOUR = hex_str(INFO)
+
+
+def own_car_colour(arcade: dict[str, Any]) -> str:
+    """The main driver's team colour from one tick, or the no-wire degrade.
+
+    Both halves come from the same block, so a tick that names a driver it has
+    no colour for degrades rather than raising, and a tick with neither reads
+    as "not known yet" instead of as a car.
+
+    The colour is a TEAM colour, so it is shared by exactly two drivers and
+    cannot identify one of them on its own. That is fine here and it is why the
+    lookup lives on this chart alone: the pace card draws ONE car, named in the
+    window header, so the colour agrees with the tower rather than identifying
+    anything by itself.
+    """
+    colours = arcade.get("driver_colors") or {}
+    rgb = colours.get(arcade.get("driver_main") or "")
+    if not isinstance(rgb, (list, tuple)) or len(rgb) != 3:
+        return ACTUAL_COLOUR
+    return hex_str((int(rgb[0]), int(rgb[1]), int(rgb[2])))
+
+
 PRED_COLOUR = hex_str(ACCENT)
 BAND_COLOUR = hex_str(ACCENT)
 TREND_COLOUR = hex_str(TEXT_PRIMARY)
@@ -88,6 +123,7 @@ def build_pace_series(
     history: dict[int, dict[str, Any]],
     x_range: list[float] | None = None,
     current_lap: int | None = None,
+    actual_colour: str = ACTUAL_COLOUR,
 ) -> dict[str, Any]:
     """Actual, predicted and the P10-P90 band, each skipping what it lacks.
 
@@ -95,6 +131,23 @@ def build_pace_series(
     the window connected carry only an actual, and the predicted line has
     to start where the per-agent payload first arrived rather than draw a
     line through zero.
+
+    Args:
+        actual_colour: the OWN car's team colour, resolved by the caller from
+            `driver_colors[driver_main]`. A parameter rather than the module
+            constant it defaults to, because this series is the one mark on
+            this window that identifies a CAR: everything else here is the
+            model's identity (the prediction and its band) or the tyre's (the
+            stints and the plan strip), and none of those belong to a driver.
+
+            The tower, the track ring and the race trace already take the
+            colour from the wire. This chart did not, so one window rendered
+            the same car in two colours at once.
+
+    --- WHERE TO CHANGE IF THE OWN-CAR COLOUR MOVES ---
+    `AgentsViewBuilder` resolves it; `src/arcade/app.py` puts `driver_colors`
+    and `driver_main` on the wire; the DATA window's own chip resolves the same
+    pair client-side through `driverColour`.
     """
     actual: list[list[float]] = []
     pred: list[list[float]] = []
@@ -117,7 +170,7 @@ def build_pace_series(
         "actual": actual,
         "pred": pred,
         "band": band,
-        "actual_colour": ACTUAL_COLOUR,
+        "actual_colour": actual_colour,
         "pred_colour": PRED_COLOUR,
         "band_colour": BAND_COLOUR,
         # The SAME lap axis the tyre chart draws, and the same current-lap

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -4814,12 +4814,14 @@ check(
     page.evaluate(() => {
       const chart = document.querySelector(".trace-stack-plot").__pitwallChart;
       const chip = document.querySelector(".driver-chip-rival");
+      const own = document.querySelector(".driver-chip-main");
       return {
         series: chart
           .getOption()
           .series.filter((s) => s.name.endsWith("-rival"))
           .map((s) => s.lineStyle?.color),
         chip: chip ? getComputedStyle(chip).color : null,
+        own: own ? getComputedStyle(own).color : null,
       };
     });
 
@@ -4857,6 +4859,29 @@ check(
   check(
     before.series[0] !== after.series[0] && before.chip !== after.chip,
     `and the colour actually changed across the pin (${before.series[0]} -> ${after.series[0]})`,
+  );
+
+  // **The OWN car's chip, and it can only be checked HERE.** #1070 fixed the
+  // rival chip and left this one carrying palette.INFO in the stylesheet, five
+  // lines above its own explanatory comment, on a window whose tower, ring and
+  // race trace all paint that same car in its team colour.
+  //
+  // Before the pin the fixture cannot express the defect: the producer's rival
+  // is the TEAM-MATE, so main and rival are both papaya at an RGB distance of
+  // 0.0 and a chip reading either car's colour looks right. After pinning VER
+  // the two differ, so this is the reading that fails against a main chip which
+  // is a constant, and against one that resolves the wrong car.
+  check(
+    before.own === rgbOf("NOR"),
+    `the own chip is the main driver's own team colour (${before.own})`,
+  );
+  check(
+    after.own === rgbOf("NOR"),
+    `and it stays the MAIN car's colour when the rival changes (${after.own})`,
+  );
+  check(
+    after.own !== after.chip,
+    `so the two chips disagree once the cars do (own ${after.own} vs rival ${after.chip})`,
   );
   await ctx.close();
 }

--- a/src/pitwall/ui/src/features/data/DataWindow.tsx
+++ b/src/pitwall/ui/src/features/data/DataWindow.tsx
@@ -85,6 +85,22 @@ export function DataWindow() {
   // of the consumers is an ECharts canvas, which cannot resolve a custom
   // property and would silently fall back to its own palette (#1070).
   const rivalColour = driverColour(tick?.arcade.driver_colors ?? {}, rival, AXIS_TEXT);
+  // **And the OWN car's, from the same map, for the same reason.** #1070 gave the
+  // rival its team colour and left the main chip on a palette blue in the
+  // stylesheet, five lines above its own explanatory comment - so this window
+  // painted NOR blue on the traces chip while its tower, its ring and its race
+  // trace all painted the same car papaya.
+  //
+  // The fallback is INFO rather than the axis grey the rival degrades to, and
+  // the two are deliberately different: an unknown RIVAL is one of nineteen and
+  // reads as "not identified", while the main car is always named right beside
+  // the chip, so its degrade only has to be a colour no team owns. Measured, INFO
+  // sits 70.8 from the nearest team colour on the wire.
+  const mainColour = driverColour(
+    tick?.arcade.driver_colors ?? {},
+    tick?.arcade.driver_main ?? null,
+    "#3b82f6",
+  );
 
   // The pin releases when its car retires, or when the code stops being on the
   // wire at all - a relaunched arcade pointed at another race is the second
@@ -180,6 +196,7 @@ export function DataWindow() {
               frame={traceFrame}
               rival={rival}
               rivalColour={rivalColour}
+              mainColour={mainColour}
               frozen={frozen}
             />
                   )}

--- a/src/pitwall/ui/src/features/data/OwnCarTraces.tsx
+++ b/src/pitwall/ui/src/features/data/OwnCarTraces.tsx
@@ -77,6 +77,8 @@ interface OwnCarTracesProps {
    * disagree in the first place.
    */
   rivalColour: string;
+  /** The own car's team colour, resolved from the same map (#1070's twin). */
+  mainColour: string;
   /** The producer is gone; these buffers will not fill. */
   frozen?: boolean;
 }
@@ -86,6 +88,7 @@ export function OwnCarTraces({
   frame,
   rival,
   rivalColour,
+  mainColour,
   frozen = false,
 }: OwnCarTracesProps) {
   const { arcade } = tick;
@@ -122,7 +125,13 @@ export function OwnCarTraces({
 
   return (
     <section className="traces card">
-      <TracesHeader tick={tick} rival={rival} rivalColour={rivalColour} frame={frame} />
+      <TracesHeader
+          tick={tick}
+          rival={rival}
+          rivalColour={rivalColour}
+          mainColour={mainColour}
+          frame={frame}
+        />
       <TraceStack
         main={frame.main}
         rival={frame.rival}
@@ -148,12 +157,16 @@ function TracesHeader({
   tick,
   rival: rivalCode,
   rivalColour,
+  mainColour,
   frame,
 }: {
   tick: Tick;
   rival: string | null;
   /** The chip paints in the rival's own team colour; the border follows it. */
   rivalColour: string;
+  /** And the own car's, from the same map. Both chips take their colour from the
+   * wire, so neither can disagree with the tower about a car. */
+  mainColour: string;
   /** The buffers themselves: every note below is about what the DELTA lane has. */
   frame: TraceFrame;
 }) {
@@ -216,7 +229,9 @@ function TracesHeader({
           ? `  ·  NO TRACK IN COMMON WITH ${rivalCode} YET`
           : ""}
       </span>
-      <span className="driver-chip driver-chip-main">{arcade.driver_main || "—"}</span>
+      <span className="driver-chip driver-chip-main" style={{ color: mainColour }}>
+        {arcade.driver_main || "—"}
+      </span>
       {rivalCode ? (
         <>
           <span className="traces-vs">vs</span>

--- a/src/pitwall/ui/src/styles/data.css
+++ b/src/pitwall/ui/src/styles/data.css
@@ -696,11 +696,15 @@ td.col-drv {
   padding: 2px 8px;
 }
 
-/* palette.INFO, the own car's chip colour `TelemetryPanel` constructs with.
- * Guarded by `test_pitwall_tokens.py`. */
-.driver-chip-main {
-  color: #3b82f6;
-}
+/* **The main chip has no colour here either, for the same reason as the rival's
+ * below.** It carried palette.INFO, the blue `TelemetryPanel` builds its own-car
+ * pen from, on a window whose tower, ring and race trace all paint that same car
+ * in its team colour - so one window rendered NOR blue in one corner and papaya
+ * in three others. A stylesheet cannot know which car is main any more than it
+ * can know which is pinned; `DataWindow` resolves both from `driver_colors` and
+ * passes them down.
+ *
+ * #1070 fixed the rival and left this one, five lines above its own comment. */
 
 /* **The rival chip has no colour here, and that is the fix for #1070.** It used
  * to carry palette.WARNING beside the rule above, matching the fixed amber the

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -2016,3 +2016,51 @@ def test_the_stale_lap_that_setdefault_would_have_made_permanent():
     assert lap18 is not None and lap18["actual"] == 92.18, (
         f"lap 18 kept the dead race's number: {lap18}"
     )
+
+
+def test_the_pace_chart_paints_the_own_car_in_its_own_team_colour():
+    """The actual line identifies a CAR, so it takes the car's colour off the wire.
+
+    It used to be `palette.INFO` unconditionally, on a window whose sibling
+    already painted the same car in its team colour: the DATA tower, the track
+    ring and the race trace all render NOR papaya, and this chart rendered him
+    blue. `driver_colors` has been on every tick since the arcade published it;
+    nothing under `src/pitwall` read it.
+
+    Compared against the WIRE value rather than against membership of the
+    palette, because every team colour is in the palette and a membership check
+    cannot tell papaya from the blue it replaced.
+    """
+    payload = _payload()
+    payload["arcade"]["driver_colors"] = {"NOR": [255, 128, 0], "PIA": [255, 128, 0]}
+
+    view = _host(payload).get_agents_view(-1)
+
+    assert view["charts"]["pace"]["actual_colour"] == "#ff8000", (
+        "the actual line must be the main driver's team colour from the wire"
+    )
+    # The prediction is the MODEL's identity, not the car's, so it must not move
+    # with the driver. Asserted here rather than in its own test because the
+    # thing worth pinning is that the two did not become one colour.
+    assert view["charts"]["pace"]["pred_colour"] != "#ff8000"
+
+
+def test_the_pace_chart_degrades_when_the_wire_has_no_colour_for_the_car():
+    """Three absences, one answer, and it must not be a team's colour.
+
+    A driver missing from the map, an empty map, and a tick before the arcade
+    block carries either. The degrade is `palette.INFO`, which is also the boot
+    view's value, so the window has ONE no-wire colour rather than two - and it
+    sits far enough from every colour on the wire that a reader cannot mistake
+    it for a real answer.
+    """
+    from src.pitwall.agents_view.charts import ACTUAL_COLOUR
+
+    absent = _payload()
+    absent["arcade"]["driver_colors"] = {"PIA": [255, 128, 0]}
+    empty = _payload()
+    empty["arcade"]["driver_colors"] = {}
+
+    for name, payload in (("driver absent", absent), ("empty map", empty), ("no key", _payload())):
+        colour = _host(payload).get_agents_view(-1)["charts"]["pace"]["actual_colour"]
+        assert colour == ACTUAL_COLOUR, f"{name} must degrade, not raise or invent: {colour}"

--- a/tests/surfaces/test_pitwall_tokens.py
+++ b/tests/surfaces/test_pitwall_tokens.py
@@ -392,19 +392,25 @@ def test_the_data_stylesheets_raw_hexes_are_guarded_too():
         }
     )
 
-    assert raw == ["#10b981", "#3b82f6", "#a78bfa", "#ef4444", "#f59e0b"], (
+    # **Four, not five: INFO left with the main driver chip.** That chip carried
+    # `#3b82f6` while the same window's tower, ring and race trace painted the
+    # same car in its team colour, so `DataWindow` now resolves it from
+    # `driver_colors` and the stylesheet has no opinion about which car is main.
+    # The census shrinks with the defect rather than being widened to keep
+    # pinning it, exactly as #1070's amber assertions were deleted when the
+    # rival chip stopped having a constant to pin.
+    assert raw == ["#10b981", "#a78bfa", "#ef4444", "#f59e0b"], (
         f"a new raw hex entered the DATA stylesheet: {raw}. Either use a --qt-* token or add it "
         "here with the palette name it copies."
     )
     assert raw[0] == _rgb_to_hex(palette.SUCCESS), (
         "band 1's Connected chip and the tower's personal-best sector copy SUCCESS"
     )
-    assert raw[1] == _rgb_to_hex(palette.INFO), "the main driver chip copies INFO"
-    assert raw[2] == _rgb_to_hex(palette.ACCENT), (
+    assert raw[1] == _rgb_to_hex(palette.ACCENT), (
         "a session-best sector is purple, and purple here is the arcade's ACCENT"
     )
-    assert raw[3] == _rgb_to_hex(palette.DANGER), "band 1's Disconnected chip copies DANGER"
-    assert raw[4] == _rgb_to_hex(palette.WARNING), (
+    assert raw[2] == _rgb_to_hex(palette.DANGER), "band 1's Disconnected chip copies DANGER"
+    assert raw[3] == _rgb_to_hex(palette.WARNING), (
         "band 1's PROVISIONAL chip, a slower-than-own-best sector, the neutralised-lap "
         "rail and the radio's SC / flag category chips copy WARNING"
     )


### PR DESCRIPTION
## What

Our own driver is drawn in his team colour on the two surfaces that were painting him
`palette.INFO` regardless of which car he is. Reported from the shipped window: NOR came out blue.

## Why

`driver_colors` has been on every tick since the arcade published it, and **nothing under
`src/pitwall/**.py` read it**. Two separate sites hardcoded the blue:

| site | what it did |
|---|---|
| `agents_view/charts.py:38` | `ACTUAL_COLOUR = hex_str(INFO)`, published as `actual_colour` for every driver |
| `styles/data.css` | `.driver-chip-main { color: #3b82f6 }` |

The DATA one is the sharper defect: that window's tower, track ring and race trace all render NOR
papaya from the wire, so **one window painted the same car in two colours at once**.

This is #1070's twin. That PR gave the rival chip its team colour and left the main chip's constant
sitting five lines above its own explanatory comment; its scope list read "DATA window sites only",
so the AGENTS constant was never in view.

The reported symptom overstated it slightly, and the corrected version is worth having: the tower,
the ring and the race trace were already correct. Three surfaces, not "everywhere".

## How

- `own_car_colour()` in `charts.py`, beside the constant it degrades to, so the lookup and its
  fallback live together. `build_pace_series` takes `actual_colour` as a parameter defaulting to
  that constant; `builder.py` resolves it once per tick.
- **The client needed no change on AGENTS.** `PaceChart.tsx` and the hover readout already read
  `series.actual_colour`.
- `DataWindow` resolves `mainColour` through `driverColour` beside the rival's; `OwnCarTraces` puts
  it on the chip and the `currentColor` border follows. The colour rule leaves `data.css`.

## Out of scope, deliberately

**The trace stack's six lanes.** They are CHANNEL identity (speed blue, throttle green, brake red,
gear purple), not car identity. And the producer's default rival is the TEAM-MATE: measured on the
live wire, NOR and PIA are both `[255,128,0]`, an RGB distance of **0.0**. Team-colouring the main
lanes would make the solid main and the dashed rival the same hue on all six.

The prediction and its band stay `ACCENT`, and the tyre stints and plan segments stay compound
colours. None of those identify a car.

## Checks

- `tests/surfaces/` 288 -> **290**, `smoke-data` 370 -> **373**, `smoke-agents` 95 unchanged.
- **Four mutants, all seen RED**, on builds that compile. One had to be rewritten because removing
  the style prop left `mainColour` unused, `tsc` stopped and `dist/` kept the previous bundle.
  - host back to the constant · host resolves the rival's car · chip back to a stylesheet constant
    · chip resolves the rival
- The chip guard can only discriminate **after a rival from another team is pinned**. Before the
  pin the fixture cannot express the defect, because main and rival are both McLaren.
- The raw-hex census in `test_pitwall_tokens.py` shrinks from five hexes to four: the literal left
  with the defect rather than the guard being widened to keep pinning it, which is the precedent
  #1070 set when its amber assertions were deleted.
- Read off the running window: the pace chart's `actual` series is `#ff8000` with `predicted` still
  `#a78bfa`; the DATA chips read `NOR = rgb(255,128,0)` and `PIA = rgb(255,128,0)`.

## Contrast, and what it costs

Papaya is **6.94:1** on the card against INFO's 4.75:1, so for McLaren this is a legibility upgrade.
Two teams fall below the 3:1 WCAG graphical floor: **Red Bull 1.88:1** and **Aston Martin 2.55:1**,
four drivers. Accepted rather than lightened, because the tower and the race trace already render
those exact colours on the same background and diverging here would put this chart in disagreement
with them about a car, which is the disagreement this PR exists to remove.

Two notes for whoever touches this next: with a Haas driver as the main car the actual line sits an
RGB distance of 37.4 from the current-lap cursor grey, inside look-alike range (different shapes, 2
px series against a 1 px vertical). And the INFO fallback sits 70.8 from the nearest team colour on
the wire, the largest separation any candidate degrade value gets.
