### PR TITLE
feat(pitwall): render the orchestrator's contingencies and key risks in AGENTS

### DIFF
--- a/scripts/dev_pitwall_producer.py
+++ b/scripts/dev_pitwall_producer.py
@@ -83,15 +83,50 @@ def decision(lap: int, action: str, confidence: float) -> LapDecisionDTO:
         # fixture that omits a field the real producer sends is the drift #853
         # was about: the window gets developed against a payload thinner than
         # the one it will receive.
+        # **FOUR branches and FIVE risks, which is what a real lap emits.**
+        # Measured on an LLM run of Melbourne laps 20-22: every lap came back
+        # with the orchestrator's maximum of both (`max_length=4` and five
+        # bullets). This carried ONE branch and two risks, so the card was
+        # developed against a payload a quarter the size of the one it receives,
+        # and the empty space under it read as a design problem rather than as a
+        # thin fixture.
+        #
+        # The rationales are about a hundred characters because the
+        # orchestrator's own prompt asks for that ("kept short, ideally under
+        # 100 chars, so the UI can render a full contingency list").
         contingencies=[
+            {
+                "trigger": "if a Safety Car is confirmed before lap 30",
+                "switch_to": "PIT_NOW",
+                "priority": "HIGH",
+                "rationale": "the neutralised pit loss is 11 s cheaper and the stop is due inside three laps",
+            },
             {
                 "trigger": "if RUS pits within two laps",
                 "switch_to": "PIT_NOW",
                 "priority": "HIGH",
-                "rationale": "the undercut window shuts once he clears traffic",
-            }
+                "rationale": "the undercut window shuts once he clears traffic and the gap is inside the pit loss",
+            },
+            {
+                "trigger": "if the front-left graining does not clear by lap 26",
+                "switch_to": "PIT_NOW",
+                "priority": "MEDIUM",
+                "rationale": "N26 puts the cliff at lap 28 P50 and the degradation slope has doubled since lap 18",
+            },
+            {
+                "trigger": "if rain reaches the circuit before the stop",
+                "switch_to": "STAY_OUT",
+                "priority": "LOW",
+                "rationale": "a dry stop into a wet track wastes the set, and the intermediates window opens later",
+            },
         ],
-        key_risks=["rejoin into traffic", "the cliff arrives before the stop"],
+        key_risks=[
+            "SC probability is elevated and a stop under green loses eleven seconds more",
+            "rejoin into traffic behind the two-stoppers",
+            "the cliff arrives before the stop if the graining does not clear",
+            "the undercut from RUS lands first if he pits on the next lap",
+            "no second set of this compound left for a late neutralisation",
+        ],
         # `None`, not the STRING "none". A non-empty string is truthy, so the
         # window rendered `⚠ Guardrail: none` in the alarm colour on every lap
         # of every dev run - a red warning whose content is that there is

--- a/scripts/dev_pitwall_producer.py
+++ b/scripts/dev_pitwall_producer.py
@@ -202,7 +202,14 @@ def decision(lap: int, action: str, confidence: float) -> LapDecisionDTO:
             # The routing layer emits agent IDs, not block names
             # (`_decide_agents_to_call` in strategy_orchestrator.py), and the
             # cards gate on exactly these two tokens.
-            active=["N28", "N30"],
+            #
+            # **It VARIES per lap, and a constant here would misrepresent the
+            # real producer.** N30 is consulted every lap; N28 only routes when
+            # a stop is live, which is what the routing strip exists to show. A
+            # fixture that sent both on every lap would render a solid block and
+            # nothing on that strip could be judged by eye - the same drift a
+            # dev fixture caused in #853.
+            active=["N30"] + (["N28"] if lap % 3 else []),
         ),
         memory_block=(
             f"lap {lap - 1}: {fixture_call(lap - 1)[0]} "
@@ -256,9 +263,27 @@ view = SimpleNamespace(
 )
 view._build_arcade_snapshot = partial(F1ArcadeView._build_arcade_snapshot, view)
 
+# How long a lap lasts here, in wall-clock seconds at this playback speed.
+#
+# **The decision LAP advances, and it did not use to.** `state.latest` was
+# pinned to lap 23 for the whole run while only the frame index moved, so every
+# lap-keyed accumulator in the AGENTS window saw exactly one lap forever: the
+# routing strip rendered a single column and nothing about it could be judged by
+# eye. The real producer advances, so a fixture that does not is the drift #853
+# is about.
+#
+# Forty-five seconds is one Melbourne lap at the 2x playback above, which keeps
+# the fixture's own clock and its decisions telling the same story.
+LAP_SECONDS = 45.0
+
 print(f"producing {SECONDS:.0f}s with a POPULATED strategy block", flush=True)
-deadline = time.perf_counter() + SECONDS
+started = time.perf_counter()
+deadline = started + SECONDS
 while time.perf_counter() < deadline:
+    lap = min(23 + int((time.perf_counter() - started) / LAP_SECONDS), state.start.lap_end)
+    if lap != state.latest.lap_number:
+        state.history.append(state.latest)
+        state.latest = decision(lap, *fixture_call(lap))
     view._frame_index += (1.0 / ON_UPDATE_HZ) * FPS * view.playback_speed
     F1ArcadeView._broadcast_if_due(view)
     time.sleep(1.0 / ON_UPDATE_HZ)

--- a/src/pitwall/agents_view/builder.py
+++ b/src/pitwall/agents_view/builder.py
@@ -19,7 +19,11 @@ import logging
 from typing import Any
 
 from src.pitwall.agents_view.charts import build_pace_series, build_tire_series, own_car_colour
-from src.pitwall.agents_view.decision import build_orchestrator, build_scenarios
+from src.pitwall.agents_view.decision import (
+    build_contingencies,
+    build_orchestrator,
+    build_scenarios,
+)
 from src.pitwall.agents_view.history import LapHistory
 from src.pitwall.agents_view.panels import build_cards, build_header, build_status_bar
 from src.pitwall.agents_view.reasoning import build_reasoning
@@ -112,6 +116,12 @@ class AgentsViewBuilder:
                 latest.get("scenario_scores") if latest else None,
                 latest.get("action") if latest else None,
             ),
+            # The branch plans, filling the side column's empty region. The
+            # risks ride as the card TITLE's tooltip rather than as rows of
+            # their own: they answer a different question from "what do we do
+            # instead", and a card-level target would nest with the per-row
+            # ones and open two popups at once.
+            "contingencies": build_contingencies(latest or None),
             "reasoning": build_reasoning(latest or None),
             "cards": build_cards(latest or None),
             "charts": charts,

--- a/src/pitwall/agents_view/decision.py
+++ b/src/pitwall/agents_view/decision.py
@@ -216,6 +216,100 @@ def _why_detail(latest: dict[str, Any]) -> dict[str, Any] | None:
     return {"sections": sections, "footer": None}
 
 
+def _contingency_detail(row: dict[str, Any]) -> dict[str, Any] | None:
+    """One branch's whole text as a tooltip, or None when there is none to expand.
+
+    The row on the glass clamps the rationale to two lines; this is where the
+    rest of it lives. `None` when the row carries nothing beyond what is already
+    printed, which is also what keeps it out of the tab order rather than
+    offering a keyboard user an empty popup.
+    """
+    rows = [
+        {"lead": lead, "text": text}
+        for lead, text in (
+            ("When", row["trigger"]),
+            ("Then", row["switch_to"]),
+            ("Why", row["rationale"]),
+        )
+        if text and text != "--"
+    ]
+    if not rows:
+        return None
+    return {"sections": [{"title": "Contingency", "rows": rows}], "footer": None}
+
+
+def _risks_detail(latest: dict[str, Any]) -> dict[str, Any] | None:
+    """The orchestrator's risk bullets, as the CARD TITLE's popup.
+
+    They hang off the title rather than off the card, and that is not a
+    placement preference: a card-level target would nest with the per-row
+    targets inside it, so one hover would open two portaled popups at once.
+    The title is a sibling of the rows, so it cannot.
+    """
+    risks = [clean(risk) for risk in (latest.get("key_risks") or [])]
+    kept = [risk for risk in risks if risk]
+    if not kept:
+        return None
+    return {
+        "sections": [{"title": "Key risks", "rows": [{"lead": "", "text": risk} for risk in kept]}],
+        "footer": None,
+    }
+
+
+def build_contingencies(latest: dict[str, Any] | None) -> dict[str, Any]:
+    """The orchestrator's branch plans: what it does IF, rather than what it does.
+
+    `contingencies` and `key_risks` arrived with #1048's schema bump and rode the
+    wire unrendered ever since. They are the if-then logic a strategist keeps in
+    their head, and the band this card sits in stops at PLAN - what happens next -
+    without ever saying what happens instead.
+
+    **Data, never markup.** Every string here is LLM free text and every one of
+    them reaches the window as a React text node, so nothing is escaped: this is
+    `_why_detail`'s shape, and the reason `reasoning.py` gives for preferring it
+    is that an escaped `<` renders as the characters `&lt;` on the glass.
+    `clean` is length discipline, not a security control.
+
+    **The action label comes from `classify_action`; its COLOUR does not.** The
+    label has to be the orchestrator's own word, so `PIT_NOW` reads `PIT NOW`
+    here exactly as it does on the badge one card up. The colour must not follow
+    it: this branch is not happening, and dressing a hypothetical in the live
+    call's identity colours makes the card look like it is announcing a decision.
+    The enumeration above this file's constants lists who owns DANGER; nothing
+    here becomes the next one. `priority` is carried by the WORD for the same
+    reason.
+
+    **Two empties, two sentences.** No decision at all and a decision that
+    planned no branches are different facts, and the no-LLM profile makes the
+    second one routine rather than exceptional.
+    """
+    if not latest:
+        return {"rows": [], "risks": None, "empty": "— no call yet —"}
+
+    rows: list[dict[str, Any]] = []
+    for item in latest.get("contingencies") or []:
+        if not isinstance(item, dict):
+            continue
+        # No cap. The orchestrator already caps the list at four, and the card's
+        # body scrolls, so a fifth branch would be amputated here rather than
+        # merely pushed out of sight.
+        _, switch_label = classify_action(str(item.get("switch_to") or "--"))
+        row = {
+            "trigger": clean(item.get("trigger")),
+            "switch_to": switch_label,
+            "priority": str(item.get("priority") or "--").upper(),
+            "rationale": clean(item.get("rationale")),
+        }
+        row["detail"] = _contingency_detail(row)
+        rows.append(row)
+
+    return {
+        "rows": rows,
+        "risks": _risks_detail(latest),
+        "empty": None if rows else "no branch plans this lap",
+    }
+
+
 def build_orchestrator(
     latest: dict[str, Any] | None, history_tail: list[dict[str, Any]] | None = None
 ) -> dict[str, Any]:

--- a/src/pitwall/agents_view/decision.py
+++ b/src/pitwall/agents_view/decision.py
@@ -238,22 +238,16 @@ def _contingency_detail(row: dict[str, Any]) -> dict[str, Any] | None:
     return {"sections": [{"title": "Contingency", "rows": rows}], "footer": None}
 
 
-def _risks_detail(latest: dict[str, Any]) -> dict[str, Any] | None:
-    """The orchestrator's risk bullets, as the CARD TITLE's popup.
+def _risks(latest: dict[str, Any]) -> list[str]:
+    """The orchestrator's risk bullets, for the card BODY.
 
-    They hang off the title rather than off the card, and that is not a
-    placement preference: a card-level target would nest with the per-row
-    targets inside it, so one hover would open two portaled popups at once.
-    The title is a sibling of the rows, so it cannot.
+    In the body beside the branches rather than behind a hover on the title,
+    which is where these started. Hidden there they were content nobody would
+    go looking for, and on the fixture that ships - one branch - the card had a
+    void under it. Two blocks of real text read better than one block and a
+    tooltip.
     """
-    risks = [clean(risk) for risk in (latest.get("key_risks") or [])]
-    kept = [risk for risk in risks if risk]
-    if not kept:
-        return None
-    return {
-        "sections": [{"title": "Key risks", "rows": [{"lead": "", "text": risk} for risk in kept]}],
-        "footer": None,
-    }
+    return [risk for risk in (clean(item) for item in (latest.get("key_risks") or [])) if risk]
 
 
 def build_contingencies(latest: dict[str, Any] | None) -> dict[str, Any]:
@@ -284,7 +278,7 @@ def build_contingencies(latest: dict[str, Any] | None) -> dict[str, Any]:
     second one routine rather than exceptional.
     """
     if not latest:
-        return {"rows": [], "risks": None, "empty": "— no call yet —"}
+        return {"rows": [], "risks": [], "empty": "— no call yet —"}
 
     rows: list[dict[str, Any]] = []
     for item in latest.get("contingencies") or []:
@@ -305,7 +299,7 @@ def build_contingencies(latest: dict[str, Any] | None) -> dict[str, Any]:
 
     return {
         "rows": rows,
-        "risks": _risks_detail(latest),
+        "risks": _risks(latest),
         "empty": None if rows else "no branch plans this lap",
     }
 

--- a/src/pitwall/agents_view/panels.py
+++ b/src/pitwall/agents_view/panels.py
@@ -41,6 +41,7 @@ from src.pitwall.agent_formatters import (
     rag_tooltip,
     with_model_detail,
 )
+from src.pitwall.agents_view.routing import ROUTING_LANES
 
 # The three socket states and their colours, for BOTH windows.
 #
@@ -174,7 +175,11 @@ def build_cards(latest: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
     # `rag` is the structured payload; `regulation_context` stays as a
     # legacy fallback for producers that have not been updated.
     rag_block = per.get("rag") or per.get("regulation_context")
-    rag_active = "N30" in active
+    # The ids come from the router's own roster, not from literals here. A
+    # second place that knows "N28 means pit" is the twin this repository
+    # produces most, and the strip below the contingencies reads the same table.
+    pit_id, rag_id = (agent_id for agent_id, _ in ROUTING_LANES)
+    rag_active = rag_id in active
 
     # **Every card carries its model detail now, and four of them had no
     # tooltip at all.** The band's WHY module replaces the reasoning tabs, and
@@ -197,7 +202,7 @@ def build_cards(latest: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
             with_model_detail(None, "situation", per.get("situation")),
         ),
         "pit": _card(
-            format_pit(per.get("pit"), active="N28" in active),
+            format_pit(per.get("pit"), active=pit_id in active),
             with_model_detail(None, "pit", per.get("pit")),
         ),
         "radio": _card(

--- a/src/pitwall/agents_view/routing.py
+++ b/src/pitwall/agents_view/routing.py
@@ -1,0 +1,28 @@
+"""Which conditional agents the router picked, lap by lap.
+
+The six consoles say what every agent produced NOW. This says which ones were
+consulted over the last stretch of race, which is the only per-lap variation the
+routing layer has and the one thing the cards cannot show.
+
+**Only the CONDITIONAL agents get a lane.** The four always-on ones have exactly
+one live state - they all ran, or the whole lap errored and the status bar says
+so - and a row of permanently lit marks would be decoration rather than a
+reading.
+
+**This is not a trace and does not pretend to be one.** Nothing on the wire says
+in what ORDER the agents ran or how long each took: `active` is serialised from a
+Python set, and the per-stage timings are measured and then deliberately dropped
+(#1045, a pit wall does not show model latency). The order is a compile-time
+constant of the pipeline, so drawing a path would convey nothing per lap. What
+varies, and therefore what is drawn, is membership.
+"""
+
+from __future__ import annotations
+
+# The router's own conditional agents, defined ONCE.
+#
+# `panels.build_cards` gates the PIT and RAG cards on these same two ids and used
+# to carry its own copies of the strings. A second place that knows "N28 means
+# pit" is this repository's most productive defect, so the cards read this table
+# rather than repeating it.
+ROUTING_LANES: tuple[tuple[str, str], ...] = (("N28", "PIT"), ("N30", "RAG"))

--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -236,6 +236,66 @@ const VIEW = {
       cursor_colour: "#9ca3af",
     },
   },
+  // Two branches, and they are not interchangeable. The first's `switch_to`
+  // differs from its label so the label assertion can fail; the second carries
+  // NO rationale, which is the row whose `detail` is null - the fixture that
+  // makes "an unexpandable row is not a tab stop" able to fail. The first's
+  // rationale is long enough to exceed two lines at this client, without which
+  // the clamp assertion is about text that already fits.
+  contingencies: {
+    rows: [
+      {
+        trigger: "if RUS pits within two laps",
+        switch_to: "PIT NOW",
+        priority: "HIGH",
+        rationale:
+          "the undercut window shuts once he clears traffic and the gap to the car " +
+          "behind is inside the pit loss, so the stop has to happen on this lap or " +
+          "the position is gone until the second stint and the tyre delta stops " +
+          "paying for the track position it cost to build",
+        detail: {
+          sections: [
+            {
+              title: "Contingency",
+              rows: [
+                { lead: "When", text: "if RUS pits within two laps" },
+                { lead: "Then", text: "PIT NOW" },
+                {
+                  lead: "Why",
+                  text:
+                    "the undercut window shuts once he clears traffic and the gap to " +
+                    "the car behind is inside the pit loss, so the stop has to happen " +
+                    "on this lap or the position is gone until the second stint and " +
+                    "the tyre delta stops paying for the track position it cost to build",
+                },
+              ],
+            },
+          ],
+          footer: null,
+        },
+      },
+      {
+        trigger: "if the safety car is deployed before L28",
+        switch_to: "STAY OUT",
+        priority: "MEDIUM",
+        rationale: "",
+        detail: null,
+      },
+    ],
+    risks: {
+      sections: [
+        {
+          title: "Key risks",
+          rows: [
+            { lead: "", text: "rejoin into traffic" },
+            { lead: "", text: "the cliff arrives before the stop" },
+          ],
+        },
+      ],
+      footer: null,
+    },
+    empty: null,
+  },
   plan_timeline: {
     total_laps: 57,
     first_known_lap: 11,
@@ -1293,6 +1353,219 @@ check(
   );
 
   await hoverCtx.close();
+}
+
+
+// ---------------------------------------------------------------------------
+// The CONTINGENCIES card, filling the side column's empty region.
+//
+// The fixture's two rows are not interchangeable: one has a rationale long
+// enough to exceed two lines at this client and a `detail` to expand, the other
+// has neither. Without the long one the clamp assertion is about text that
+// already fits; without the empty one, "an unexpandable row is not a tab stop"
+// cannot fail.
+// ---------------------------------------------------------------------------
+// **PIT is trimmed for this block, and that is not a convenience.** The shared
+// fixture gives PIT 40 body lines deliberately, to guarantee the scroll check
+// an overflow - and 40 lines eat the whole side column, so the contingencies
+// card correctly collapses and none of its own rendering can be asserted. The
+// full-PIT view is kept for the phantom-box block below, where that overfull
+// card is exactly what creates the small residual worth testing.
+const CTY_VIEW = {
+  ...structuredClone(VIEW),
+  cards: {
+    ...structuredClone(VIEW.cards),
+    pit: { ...structuredClone(VIEW.cards.pit), lines: VIEW.cards.pit.lines.slice(0, 2) },
+  },
+};
+{
+  const ctyCtx = await browser.newContext({ viewport: CLIENT });
+  const ctyPage = await ctyCtx.newPage();
+  watchPage(ctyPage, failures, "contingencies");
+  await ctyPage.addInitScript((view) => {
+    window.pywebview = {
+      api: {
+        get_agents_view: async (since) => (since >= view.seq ? null : view),
+        get_connection: async () => ({ label: "Connected", colour: "#10b981" }),
+      },
+    };
+  }, CTY_VIEW);
+  await ctyPage.goto(`http://127.0.0.1:${server.address().port}/agents.html`, {
+    waitUntil: "domcontentloaded",
+  });
+  // `attached`, never `visible`: a collapsed card is an empty `aria-hidden`
+  // section, and a build that wrongly collapses it must FAIL a named check
+  // rather than hang this waiter for ten seconds and kill the run.
+  await ctyPage.waitForSelector(".contingencies", { state: "attached", timeout: 10000 });
+  await ctyPage.waitForTimeout(400);
+
+  // --- it renders, and it is a real card at this client ---------------------
+  // Presence FIRST, named, and everything after it is gated on the answer.
+  // Playwright's `hover` and `innerText` WAIT, so a card that renders nothing
+  // becomes a 30-second timeout that kills the run before the failure above is
+  // ever printed - a crash reported as a mutation result rather than a finding.
+  const hasRows = (await ctyPage.locator(".cty-row").count()) > 0;
+  check(hasRows, "contingencies: the card renders its rows at all");
+  const shape = await ctyPage.evaluate(() => {
+    const card = document.querySelector(".contingencies");
+    const style = getComputedStyle(card);
+    return {
+      collapsed: card.classList.contains("is-collapsed"),
+      border: Math.round(parseFloat(style.borderTopWidth)),
+      rows: document.querySelectorAll(".cty-row").length,
+      count: document.querySelector(".cty-count")?.innerText ?? null,
+      switchTo: [...document.querySelectorAll(".cty-switch")].map((n) => n.innerText.trim()),
+    };
+  });
+  check(
+    !shape.collapsed && shape.border === 1,
+    `contingencies: a real bordered card at the wide client (${JSON.stringify(shape)})`,
+  );
+  check(
+    shape.rows === CTY_VIEW.contingencies.rows.length,
+    `contingencies: every branch on the wire is drawn (${shape.rows})`,
+  );
+  check(
+    shape.count === String(CTY_VIEW.contingencies.rows.length),
+    `contingencies: the header states the TOTAL, so a scrolled body still says how many (${shape.count})`,
+  );
+  // The label, not the enum. A row printing PIT_NOW would disagree with the
+  // badge two cards up about the same vocabulary.
+  check(
+    shape.switchTo[0] === "PIT NOW" && !shape.switchTo[0].includes("_"),
+    `contingencies: the action reads as the orchestrator's own label (${shape.switchTo[0]})`,
+  );
+
+  // --- the clamped copy is not the ONLY copy --------------------------------
+  // **`scrollHeight` cannot see this.** `-webkit-line-clamp` sizes the box to the
+  // clamped lines, so the scroll height equals the client height and a check on
+  // their difference reads 0 whether the text overflows or not. The honest
+  // measurement is the same text, same width, same font, WITHOUT the clamp.
+  const clamp = await ctyPage.evaluate(() => {
+    const el = document.querySelector(".cty-rationale");
+    if (!el) return { clamp: "NONE", clipped: -1 };
+    const style = getComputedStyle(el);
+    const probe = el.cloneNode(true);
+    probe.style.webkitLineClamp = "unset";
+    probe.style.display = "block";
+    probe.style.position = "absolute";
+    probe.style.visibility = "hidden";
+    probe.style.width = `${el.clientWidth}px`;
+    el.parentElement.appendChild(probe);
+    const full = probe.getBoundingClientRect().height;
+    const shown = el.getBoundingClientRect().height;
+    probe.remove();
+    return { clamp: style.webkitLineClamp, clipped: Math.round(full - shown) };
+  });
+  check(clamp.clamp === "2", `contingencies: the rationale is clamped to two lines (${clamp.clamp})`);
+  check(
+    clamp.clipped > 0,
+    `contingencies: and the fixture's text actually EXCEEDS two lines, or the clamp asserts nothing (${clamp.clipped} px hidden)`,
+  );
+  if (hasRows) await ctyPage.locator(".cty-row").first().hover();
+  await ctyPage.waitForTimeout(250);
+  const popup = await ctyPage.evaluate(() => {
+    const tips = [...document.querySelectorAll(".agent-tooltip")];
+    return { n: tips.length, text: (tips[0]?.innerText ?? "").replace(/\s+/g, " ") };
+  });
+  check(popup.n === 1, `contingencies: hovering a row opens exactly one popup (${popup.n})`);
+  check(
+    popup.text.includes("the position is gone until the second stint"),
+    `contingencies: and it carries the WHOLE rationale, not the clamped half (${popup.text.slice(-60)})`,
+  );
+
+  // --- no empty tab stops ---------------------------------------------------
+  const stops = await ctyPage.evaluate(() =>
+    [...document.querySelectorAll(".cty-row")].map((r) => r.tabIndex),
+  );
+  check(
+    stops[0] === 0 && stops[1] === -1,
+    `contingencies: a row with nothing to expand is not a tab stop (${JSON.stringify(stops)})`,
+  );
+
+  // --- ⭐ the fit cannot move what it measures ------------------------------
+  // The card is `flex: 1 1 0`, so its contents are outside its own sizing
+  // calculation and its height is the column's residual. Hiding everything
+  // inside it must therefore change nothing. This is the property #1083 does
+  // NOT have: the BESTS panel's decision changes the height it re-measures.
+  const before = await ctyPage.evaluate(
+    () => document.querySelector(".contingencies").getBoundingClientRect().height,
+  );
+  await ctyPage.addStyleTag({ content: ".cty-body, .cty-title { display: none !important }" });
+  await ctyPage.waitForTimeout(250);
+  const after = await ctyPage.evaluate(
+    () => document.querySelector(".contingencies").getBoundingClientRect().height,
+  );
+  check(
+    Math.abs(before - after) < 0.5,
+    `contingencies: emptying the card does not change the height it measures itself by (${before} -> ${after})`,
+  );
+  await ctyCtx.close();
+}
+
+// --- the phantom box: the card exists iff there is room for it ---------------
+//
+// **Asserted as the RULE, not as a client size.** The first version of this
+// expected the laptop client to collapse, and it did with the shared fixture's
+// deliberately overfull 40-line PIT card - but with a SHORT pit the same laptop
+// has 106 px and correctly shows the card. The thing being tested is the room,
+// so the sweep varies both the client and the column's own weight, asserts the
+// implication at each point, and then asserts that it actually reached BOTH
+// outcomes. Without that last line a build that never rendered the card, or one
+// that always did, would pass whichever arm it happened to satisfy.
+//
+// It deliberately does not read `MIN_ROOM`: a copy of that constant here is the
+// twin this project produces most. The implication holds without knowing it.
+{
+  const shownAt = [];
+  for (const [w, h, view, label] of [
+    [1485, 913, CTY_VIEW, "1080p, short pit"],
+    [1311, 641, CTY_VIEW, "laptop, short pit"],
+    [1311, 641, VIEW, "laptop, the overfull pit the product really renders"],
+  ]) {
+    const ctx = await browser.newContext({ viewport: { width: w, height: h } });
+    const page = await ctx.newPage();
+    watchPage(page, failures, `contingencies ${label}`);
+    await page.addInitScript((fixture) => {
+      window.pywebview = {
+        api: {
+          get_agents_view: async (since) => (since >= fixture.seq ? null : fixture),
+          get_connection: async () => ({ label: "Connected", colour: "#10b981" }),
+        },
+      };
+    }, view);
+    await page.goto(`http://127.0.0.1:${server.address().port}/agents.html`, {
+      waitUntil: "domcontentloaded",
+    });
+    // `attached`, never the default `visible`: a collapsed card is deliberately
+    // an empty `aria-hidden` section, and Playwright is right to call that
+    // invisible. Waiting for visible would time out on the very behaviour this
+    // block exists to assert.
+    await page.waitForSelector(".contingencies", { state: "attached", timeout: 10000 });
+    await page.waitForTimeout(500);
+    const seen = await page.evaluate(() => {
+      const card = document.querySelector(".contingencies");
+      const style = getComputedStyle(card);
+      return {
+        room: Math.round(card.getBoundingClientRect().height),
+        rows: document.querySelectorAll(".cty-row").length,
+        border: Math.round(parseFloat(style.borderTopWidth)),
+        padding: Math.round(parseFloat(style.paddingTop)),
+      };
+    });
+    const drawn = seen.rows > 0;
+    shownAt.push(drawn);
+    check(
+      drawn ? seen.border === 1 : seen.border === 0 && seen.padding === 0,
+      `contingencies (${label}): a card with rows has its chrome, one without has NONE - ` +
+        `not a heading over a cut-off row (${JSON.stringify(seen)})`,
+    );
+  }
+  check(
+    shownAt.some(Boolean) && shownAt.some((drawn) => !drawn),
+    `contingencies: the sweep reached BOTH outcomes, so neither arm passed by never ` +
+      `running (${JSON.stringify(shownAt)})`,
+  );
 }
 
 await browser.close();

--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -236,7 +236,13 @@ const VIEW = {
       cursor_colour: "#9ca3af",
     },
   },
-  // Two branches, and they are not interchangeable. The first's `switch_to`
+  // FOUR branches and FIVE risks, which is what a real LLM lap returns:
+  // measured on Melbourne 20-22, every lap came back with the orchestrator's
+  // maximum of both. A thinner fixture develops the card against a payload a
+  // quarter the size of the one it receives, and its empty space then reads as
+  // a design problem rather than as a thin stub.
+  //
+  // They are not interchangeable. The first's `switch_to`
   // differs from its label so the label assertion can fail; the second carries
   // NO rationale, which is the row whose `detail` is null - the fixture that
   // makes "an unexpandable row is not a tab stop" able to fail. The first's
@@ -281,8 +287,44 @@ const VIEW = {
         rationale: "",
         detail: null,
       },
+      {
+        trigger: "if the front-left graining does not clear by L26",
+        switch_to: "PIT NOW",
+        priority: "MEDIUM",
+        rationale: "the cliff P50 sits at L28 and the degradation slope has doubled since L18",
+        detail: {
+          sections: [
+            {
+              title: "Contingency",
+              rows: [{ lead: "When", text: "if the front-left graining does not clear by L26" }],
+            },
+          ],
+          footer: null,
+        },
+      },
+      {
+        trigger: "if rain reaches the circuit before the stop",
+        switch_to: "STAY OUT",
+        priority: "LOW",
+        rationale: "a dry stop into a wet track wastes the set and the inters window opens later",
+        detail: {
+          sections: [
+            {
+              title: "Contingency",
+              rows: [{ lead: "When", text: "if rain reaches the circuit before the stop" }],
+            },
+          ],
+          footer: null,
+        },
+      },
     ],
-    risks: ["rejoin into traffic", "the cliff arrives before the stop"],
+    risks: [
+      "SC probability is elevated and a green stop loses eleven seconds more",
+      "rejoin into traffic behind the two-stoppers",
+      "the cliff arrives before the stop if the graining does not clear",
+      "the undercut from RUS lands first if he pits next lap",
+      "no second set of this compound left for a late neutralisation",
+    ],
     empty: null,
   },
   plan_timeline: {
@@ -1498,6 +1540,44 @@ const CTY_VIEW = {
     stops[0] === 0 && stops[1] === -1,
     `contingencies: a row with nothing to expand is not a tab stop (${JSON.stringify(stops)})`,
   );
+
+  // --- what is below the fold SAYS so --------------------------------------
+  // A real lap returns more branches and risks than the reference client's 214
+  // px can hold, so the body scrolls - that is the shipped answer rather than a
+  // shortfall. What makes it acceptable is the affordance: this window hides
+  // every scrollbar, so without the fade the hidden half is simply lost, which
+  // is the defect #1077 fixed on the consoles one card over.
+  const fold = await ctyPage.evaluate(() => {
+    const body = document.querySelector(".cty-body");
+    if (!body) return null;
+    return {
+      hidden: Math.round(body.scrollHeight - body.clientHeight),
+      below: body.classList.contains("has-below"),
+      above: body.classList.contains("has-above"),
+    };
+  });
+  check(
+    fold !== null && fold.hidden > 0,
+    `contingencies: the fixture actually OVERFLOWS, or the affordance below asserts ` +
+      `nothing (${JSON.stringify(fold)})`,
+  );
+  check(
+    fold !== null && fold.below && !fold.above,
+    `contingencies: and the bottom fade says there is more, with no top fade at ` +
+      `the start of the list (${JSON.stringify(fold)})`,
+  );
+  if (fold && fold.hidden > 0) {
+    await ctyPage.locator(".cty-body").evaluate((node) => node.scrollTo(0, node.scrollHeight));
+    await ctyPage.waitForTimeout(250);
+    const bottom = await ctyPage.evaluate(() => {
+      const body = document.querySelector(".cty-body");
+      return { below: body.classList.contains("has-below"), above: body.classList.contains("has-above") };
+    });
+    check(
+      bottom.above && !bottom.below,
+      `contingencies: scrolled to the end, the fade flips to the top (${JSON.stringify(bottom)})`,
+    );
+  }
 
   // --- ⭐ the fit cannot move what it measures ------------------------------
   // The card is `flex: 1 1 0`, so its contents are outside its own sizing

--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -282,18 +282,7 @@ const VIEW = {
         detail: null,
       },
     ],
-    risks: {
-      sections: [
-        {
-          title: "Key risks",
-          rows: [
-            { lead: "", text: "rejoin into traffic" },
-            { lead: "", text: "the cliff arrives before the stop" },
-          ],
-        },
-      ],
-      footer: null,
-    },
+    risks: ["rejoin into traffic", "the cliff arrives before the stop"],
     empty: null,
   },
   plan_timeline: {
@@ -1474,6 +1463,33 @@ const CTY_VIEW = {
     `contingencies: and it carries the WHOLE rationale, not the clamped half (${popup.text.slice(-60)})`,
   );
 
+  // --- the risks are IN THE BODY, not behind a hover ------------------------
+  // They started as the title's tooltip, which made them content nobody would
+  // find. Asserted against the wire's own list, never against a count: a block
+  // that rendered the right NUMBER of wrong lines would pass a count.
+  const risks = await ctyPage.locator(".cty-risk").allInnerTexts();
+  check(
+    JSON.stringify(risks) === JSON.stringify(CTY_VIEW.contingencies.risks),
+    `contingencies: every risk on the wire is a line in the body (${JSON.stringify(risks)})`,
+  );
+  check(
+    await ctyPage.evaluate(() => {
+      const block = document.querySelector(".cty-risks");
+      return Boolean(block) && Boolean(block.closest(".cty-body"));
+    }),
+    "contingencies: and the block sits in the scrolling body beside the branches",
+  );
+  // The title stopped being a tooltip target when they moved, so it must have
+  // stopped being a tab stop too - an empty stop is the defect the row check
+  // below guards on the other side.
+  const titleTab = hasRows
+    ? await ctyPage.locator(".cty-title").getAttribute("tabindex")
+    : null;
+  check(
+    titleTab === null,
+    `contingencies: the title is not a tab stop now that it expands nothing (${titleTab})`,
+  );
+
   // --- no empty tab stops ---------------------------------------------------
   const stops = await ctyPage.evaluate(() =>
     [...document.querySelectorAll(".cty-row")].map((r) => r.tabIndex),
@@ -1567,6 +1583,7 @@ const CTY_VIEW = {
       `running (${JSON.stringify(shownAt)})`,
   );
 }
+
 
 await browser.close();
 server.close();

--- a/src/pitwall/ui/src/features/agents/AgentCard.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentCard.tsx
@@ -17,52 +17,11 @@
  * are the same debt one layer down and are filed separately.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 
 import type { AgentCardView } from "../../lib/agents";
+import { useScrollEdges } from "../../lib/useScrollEdges";
 import { Tooltip, useTooltipTarget } from "./Tooltip";
-
-/**
- * Which edges of a scrolling body have content beyond them.
- *
- * **The card body has always been `overflow: auto` and never said so.**
- * `qt-base.css` hides every scrollbar, deliberately, and its own comment ends
- * by admitting the cost: nothing hints that a card has more below. Measured at
- * the 720p client the product opens on, that costs the PACE and TIRE cards
- * 51 px each, which is their entire Lap axis, and cuts a line through the
- * middle of its glyphs on SITUATION and PIT. The content is wheel-reachable
- * the whole time; it is the absence of any signal that makes it lost.
- *
- * Measured rather than keyed on a breakpoint, so a card that happens to fit
- * shows nothing, and the same mask the pace grid uses so the two panels speak
- * one visual language.
- */
-function useScrollEdges(body: HTMLElement | null) {
-  const [edges, setEdges] = useState({ above: false, below: false });
-
-  const measure = useCallback(() => {
-    if (!body) return;
-    const overflows = body.scrollHeight - body.clientHeight > 1;
-    setEdges({
-      above: overflows && body.scrollTop > 1,
-      below: overflows && body.scrollTop < body.scrollHeight - body.clientHeight - 1,
-    });
-  }, [body]);
-
-  useEffect(() => {
-    if (!body) return;
-    measure();
-    // The card resizes with the window and its CONTENT changes every lap, so
-    // both have to be watched: a card that grew a line is as much a change as
-    // a window that shrank.
-    const observer = new ResizeObserver(measure);
-    observer.observe(body);
-    for (const child of body.children) observer.observe(child);
-    return () => observer.disconnect();
-  }, [body, measure]);
-
-  return { edges, measure };
-}
 
 export function AgentCard({
   title,

--- a/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
@@ -183,7 +183,7 @@ const IDLE_VIEW: AgentsView = {
   // Before the first tick there is no call, so the card's own "no call yet"
   // sentence is the honest one - not "no branch plans", which asserts that a
   // decision was made and planned none.
-  contingencies: { rows: [], risks: null, empty: "— no call yet —" },
+  contingencies: { rows: [], risks: [], empty: "— no call yet —" },
   history: { pace: [], tire: [] },
   // Replaced by `waitingStatus(connection)` while `view` is null: the idle
   // view cannot know whether the socket is up, and this window has no other

--- a/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
@@ -37,6 +37,7 @@ import { AgentCard } from "./AgentCard";
 import { OrchestratorCard } from "./OrchestratorCard";
 import { WhyPanel } from "./WhyPanel";
 import { ScenarioBars } from "./ScenarioBars";
+import { ContingenciesCard } from "./ContingenciesCard";
 import { PlanPanel } from "./PlanPanel";
 import { HeaderBar } from "./HeaderBar";
 import { PaceChart } from "./PaceChart";
@@ -179,6 +180,10 @@ const IDLE_VIEW: AgentsView = {
     current_pct: null,
     caption: "Pit: — · Next: — · UCUT: —",
   },
+  // Before the first tick there is no call, so the card's own "no call yet"
+  // sentence is the honest one - not "no branch plans", which asserts that a
+  // decision was made and planned none.
+  contingencies: { rows: [], risks: null, empty: "— no call yet —" },
   history: { pace: [], tire: [] },
   // Replaced by `waitingStatus(connection)` while `view` is null: the idle
   // view cannot know whether the socket is up, and this window has no other
@@ -317,6 +322,12 @@ export function AgentsWindow() {
           <div className="agents-side">
             <Console slot="situation" title="Situation" card={shown.cards.situation ?? IDLE_CARD} />
             <Console slot="pit" title="Pit" card={shown.cards.pit ?? IDLE_CARD} />
+            {/* The branch plans, filling what was window background under PIT.
+                The `??` is the stale-bundle guard the cards already carry: a
+                new bundle served an old view would otherwise throw on
+                `.rows.map`, which is what makes it safe not to bump
+                `AGENTS_VIEW_VERSION` for an added key. */}
+            <ContingenciesCard view={shown.contingencies ?? IDLE_VIEW.contingencies} />
           </div>
           <Console slot="radio" title="Radio" card={shown.cards.radio ?? IDLE_CARD} />
           <Console slot="rag" title="RAG" card={shown.cards.rag ?? IDLE_CARD} />

--- a/src/pitwall/ui/src/features/agents/ContingenciesCard.tsx
+++ b/src/pitwall/ui/src/features/agents/ContingenciesCard.tsx
@@ -1,0 +1,162 @@
+/**
+ * The orchestrator's branch plans, in the side column's empty region.
+ *
+ * The band this card closes runs decision, scores, plan: what we are doing and
+ * why. It never said what we do INSTEAD. `contingencies` and `key_risks` have
+ * ridden the wire since #1048's schema bump with nothing rendering them.
+ *
+ * **A bespoke card rather than a `Console`.** `AgentCard` has no footer slot,
+ * and the routing strip has to sit BELOW the scrolling body rather than inside
+ * it; its `children` land in a 140 px `.agent-chart` instead. `WhyPanel` is the
+ * precedent for a card that is its own component and still reuses the tooltip.
+ *
+ * **It uses `overflow: hidden`, which `.agent-card` deliberately does not.**
+ * That card keeps `overflow: visible` under a comment about a scrolling
+ * ancestor clipping its popup. `Tooltip` portals to `document.body` now, so no
+ * ancestor can clip it, and the comment is describing a constraint that has
+ * been gone since sprint 8. Do not "restore" `visible` here.
+ *
+ * The frozen-feed `filter: brightness(0.72)` reaches this card through
+ * `.agents-body`, and that is correct: a contingency is exactly as stale as the
+ * call above it.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+import type { ContingenciesView, ContingencyRow } from "../../lib/agents";
+import { useScrollEdges } from "../../lib/useScrollEdges";
+import { Tooltip, useTooltipTarget } from "./Tooltip";
+
+/**
+ * The room below which the card renders nothing at all.
+ *
+ * Measured by hand at the wide client, adding the parts: 13 px of title, a 6 px
+ * gap, and one row at about 45 px (trigger 13, action 12, two clamped rationale
+ * lines 22), inside 20 px of padding and 2 px of border. Below that the card can
+ * only show a title over a cut-off row.
+ *
+ * The three clients the product actually opens at leave 302, 222 and **30** px.
+ * The last one is a 1366x768 laptop, where a card that rendered anyway would be
+ * a heading with nothing under it, which is the phantom-box defect this window
+ * already removed once.
+ */
+const MIN_ROOM = 86;
+
+const TOOLTIP_ID = "tip-contingencies";
+
+/**
+ * How much room the column left this card, and whether that is enough.
+ *
+ * **The measured quantity cannot be moved by the decision, and that is the
+ * whole design.** The card is `flex: 1 1 0` with `min-height: 0`, so its
+ * flex basis is zero and its contents never enter the sizing calculation: its
+ * used height is exactly the column's free space and nothing it renders can
+ * change it. The callback therefore depends on the node alone.
+ *
+ * `useFitsRanked` in the DATA window is the counter-example, and #1083 is open
+ * because of it: its decision changes the height it then re-measures, and its
+ * callback depends on its own fit state, so the observer is torn down and
+ * rebuilt on every decision and a resize landing in that window is missed.
+ *
+ * The rect, not `clientHeight`: with `box-sizing: border-box` the border-box
+ * height is the same whether the card is showing its border or not, so the
+ * reading does not jump by 2 px across the decision.
+ */
+function useRoom(node: HTMLElement | null): number {
+  const [room, setRoom] = useState(0);
+
+  const measure = useCallback(() => {
+    if (!node) return;
+    setRoom(node.getBoundingClientRect().height);
+  }, [node]);
+
+  useEffect(() => {
+    if (!node) return;
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(node, { box: "border-box" });
+    return () => observer.disconnect();
+  }, [node, measure]);
+
+  return room;
+}
+
+export function ContingenciesCard({ view }: { view: ContingenciesView }) {
+  const [host, setHost] = useState<HTMLElement | null>(null);
+  const [body, setBody] = useState<HTMLElement | null>(null);
+  const room = useRoom(host);
+  const { edges, measure } = useScrollEdges(body);
+  const { anchor, props, hold } = useTooltipTarget(TOOLTIP_ID, view.risks !== null);
+
+  // Below the floor the element stays in the flow, holding the residual, and
+  // drops everything that makes it look like a panel. Window background reads
+  // as nothing; an empty bordered box reads as content that failed to arrive.
+  const shown = room >= MIN_ROOM;
+
+  return (
+    <section
+      ref={setHost}
+      className={shown ? "card contingencies" : "contingencies is-collapsed"}
+      aria-hidden={shown ? undefined : true}
+    >
+      {shown ? (
+        <>
+          <h2 className={`cty-title${view.risks ? " has-detail" : ""}`} {...props}>
+            CONTINGENCIES
+            {view.rows.length ? <span className="cty-count">{view.rows.length}</span> : null}
+          </h2>
+          {view.risks && anchor ? (
+            <Tooltip view={view.risks} anchor={anchor} id={TOOLTIP_ID} hold={hold} />
+          ) : null}
+          <div
+            ref={setBody}
+            className={`cty-body${edges.above ? " has-above" : ""}${
+              edges.below ? " has-below" : ""
+            }`}
+            onScroll={measure}
+            tabIndex={0}
+            role="region"
+            aria-label="Contingency plans"
+          >
+            {view.empty ? (
+              <p className="cty-empty">{view.empty}</p>
+            ) : (
+              view.rows.map((row, index) => (
+                <ContingencyRowView key={`${row.trigger}-${index}`} row={row} index={index} />
+              ))
+            )}
+          </div>
+        </>
+      ) : null}
+    </section>
+  );
+}
+
+/**
+ * One branch.
+ *
+ * The hover affordance is gated on a class this component sets, NOT on
+ * `:has(.agent-tooltip)`. That selector is what the six consoles use and it has
+ * never matched anything: the popup is portaled to `document.body`, so it is
+ * not a descendant of the card whose hover it was meant to drive.
+ *
+ * Hover changes the BACKGROUND only. This card sits in a flex column above
+ * nothing and below PIT, so anything that changes its box moves a neighbour.
+ */
+function ContingencyRowView({ row, index }: { row: ContingencyRow; index: number }) {
+  const id = `tip-cty-${index}`;
+  const { anchor, props, hold } = useTooltipTarget(id, row.detail !== null);
+  return (
+    <article className={`cty-row${row.detail ? " has-detail" : ""}`} {...props}>
+      {row.detail && anchor ? (
+        <Tooltip view={row.detail} anchor={anchor} id={id} hold={hold} />
+      ) : null}
+      <p className="cty-trigger">
+        <span className="cty-priority">{row.priority}</span>
+        {row.trigger}
+      </p>
+      <p className="cty-switch">{row.switch_to}</p>
+      <p className="cty-rationale">{row.rationale}</p>
+    </article>
+  );
+}

--- a/src/pitwall/ui/src/features/agents/ContingenciesCard.tsx
+++ b/src/pitwall/ui/src/features/agents/ContingenciesCard.tsx
@@ -42,8 +42,6 @@ import { Tooltip, useTooltipTarget } from "./Tooltip";
  */
 const MIN_ROOM = 86;
 
-const TOOLTIP_ID = "tip-contingencies";
-
 /**
  * How much room the column left this card, and whether that is enough.
  *
@@ -86,7 +84,6 @@ export function ContingenciesCard({ view }: { view: ContingenciesView }) {
   const [body, setBody] = useState<HTMLElement | null>(null);
   const room = useRoom(host);
   const { edges, measure } = useScrollEdges(body);
-  const { anchor, props, hold } = useTooltipTarget(TOOLTIP_ID, view.risks !== null);
 
   // Below the floor the element stays in the flow, holding the residual, and
   // drops everything that makes it look like a panel. Window background reads
@@ -101,13 +98,10 @@ export function ContingenciesCard({ view }: { view: ContingenciesView }) {
     >
       {shown ? (
         <>
-          <h2 className={`cty-title${view.risks ? " has-detail" : ""}`} {...props}>
+          <h2 className="cty-title">
             CONTINGENCIES
             {view.rows.length ? <span className="cty-count">{view.rows.length}</span> : null}
           </h2>
-          {view.risks && anchor ? (
-            <Tooltip view={view.risks} anchor={anchor} id={TOOLTIP_ID} hold={hold} />
-          ) : null}
           <div
             ref={setBody}
             className={`cty-body${edges.above ? " has-above" : ""}${
@@ -125,6 +119,19 @@ export function ContingenciesCard({ view }: { view: ContingenciesView }) {
                 <ContingencyRowView key={`${row.trigger}-${index}`} row={row} index={index} />
               ))
             )}
+            {/* Beside the branches, not behind a hover on the title. A risk the
+                orchestrator flagged is content, and content a reader has to go
+                hunting for may as well not be on the wire. */}
+            {view.risks.length ? (
+              <section className="cty-risks">
+                <h3 className="cty-risks-title">RISKS</h3>
+                {view.risks.map((risk) => (
+                  <p key={risk} className="cty-risk">
+                    {risk}
+                  </p>
+                ))}
+              </section>
+            ) : null}
           </div>
         </>
       ) : null}

--- a/src/pitwall/ui/src/lib/agents.ts
+++ b/src/pitwall/ui/src/lib/agents.ts
@@ -229,6 +229,53 @@ export interface PlanTimelineView {
   caption: string;
 }
 
+/**
+ * One branch plan: what the orchestrator does INSTEAD, and when.
+ *
+ * Every string is LLM free text and every one of them is rendered as a React
+ * text node. Nothing here is markup and nothing here is escaped, which is the
+ * same contract the tooltips already carry.
+ */
+export interface ContingencyRow {
+  /** The condition that activates the branch, in the orchestrator's words. */
+  trigger: string;
+  /**
+   * The replacement action through `classify_action`'s own label table, so it
+   * reads `PIT NOW` exactly as the badge one card up does.
+   *
+   * It carries NO colour, deliberately: this branch is not the call, and a
+   * hypothetical wearing the live decision's identity colours reads as an
+   * announcement.
+   */
+  switch_to: string;
+  /** `HIGH` / `MEDIUM` / `LOW`. The word carries it; there is no alarm hue. */
+  priority: string;
+  /** One line of why, clamped to two lines on the glass. */
+  rationale: string;
+  /**
+   * The whole of the row, one hover or one keypress away. `null` when the row
+   * has nothing to expand, which is also what keeps it out of the tab order
+   * rather than offering an empty popup.
+   */
+  detail: TooltipView | null;
+}
+
+export interface ContingenciesView {
+  rows: ContingencyRow[];
+  /**
+   * The orchestrator's risk bullets, as the card TITLE's popup. `null` when it
+   * flagged none, so a title that cannot be expanded does not look as if it can.
+   */
+  risks: TooltipView | null;
+  /**
+   * What to print instead of rows, and `null` when there ARE rows so a renderer
+   * cannot show both. The two sentences differ on purpose: no call has been made
+   * yet, versus a call that planned no branches, which is the ordinary state on
+   * the no-LLM profile.
+   */
+  empty: string | null;
+}
+
 export interface AgentsView {
   view_version: number;
   seq: number | null;
@@ -239,6 +286,7 @@ export interface AgentsView {
   cards: Record<string, AgentCardView>;
   charts: { pace: PaceSeries; tire: TireSeries };
   plan_timeline: PlanTimelineView;
+  contingencies: ContingenciesView;
   history: { pace: PaceHistoryRow[]; tire: TireHistoryRow[] };
   status_bar: { text: string; transient: boolean };
 }

--- a/src/pitwall/ui/src/lib/agents.ts
+++ b/src/pitwall/ui/src/lib/agents.ts
@@ -263,10 +263,13 @@ export interface ContingencyRow {
 export interface ContingenciesView {
   rows: ContingencyRow[];
   /**
-   * The orchestrator's risk bullets, as the card TITLE's popup. `null` when it
-   * flagged none, so a title that cannot be expanded does not look as if it can.
+   * The orchestrator's risk bullets, rendered in the BODY beside the branches.
+   *
+   * Empty when it flagged none, and the card then shows no risks block at all
+   * rather than an empty heading. They began behind a hover on the title, which
+   * made them content nobody would find.
    */
-  risks: TooltipView | null;
+  risks: string[];
   /**
    * What to print instead of rows, and `null` when there ARE rows so a renderer
    * cannot show both. The two sentences differ on purpose: no call has been made

--- a/src/pitwall/ui/src/lib/useScrollEdges.ts
+++ b/src/pitwall/ui/src/lib/useScrollEdges.ts
@@ -1,0 +1,51 @@
+/**
+ * The scroll-edge mask, shared by every card whose body can overflow.
+ *
+ * Lifted out of `AgentCard` when the CONTINGENCIES card needed the same
+ * affordance. A second copy would have been the shape this repository produces
+ * most: one gets a fix and its twin does not.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * Which edges of a scrolling body have content beyond them.
+ *
+ * **The card body has always been `overflow: auto` and never said so.**
+ * `qt-base.css` hides every scrollbar, deliberately, and its own comment ends
+ * by admitting the cost: nothing hints that a card has more below. Measured at
+ * the 720p client the product opens on, that costs the PACE and TIRE cards
+ * 51 px each, which is their entire Lap axis, and cuts a line through the
+ * middle of its glyphs on SITUATION and PIT. The content is wheel-reachable
+ * the whole time; it is the absence of any signal that makes it lost.
+ *
+ * Measured rather than keyed on a breakpoint, so a card that happens to fit
+ * shows nothing, and the same mask the pace grid uses so the two panels speak
+ * one visual language.
+ */
+export function useScrollEdges(body: HTMLElement | null) {
+  const [edges, setEdges] = useState({ above: false, below: false });
+
+  const measure = useCallback(() => {
+    if (!body) return;
+    const overflows = body.scrollHeight - body.clientHeight > 1;
+    setEdges({
+      above: overflows && body.scrollTop > 1,
+      below: overflows && body.scrollTop < body.scrollHeight - body.clientHeight - 1,
+    });
+  }, [body]);
+
+  useEffect(() => {
+    if (!body) return;
+    measure();
+    // The card resizes with the window and its CONTENT changes every lap, so
+    // both have to be watched: a card that grew a line is as much a change as
+    // a window that shrank.
+    const observer = new ResizeObserver(measure);
+    observer.observe(body);
+    for (const child of body.children) observer.observe(child);
+    return () => observer.disconnect();
+  }, [body, measure]);
+
+  return { edges, measure };
+}

--- a/src/pitwall/ui/src/styles/agents.css
+++ b/src/pitwall/ui/src/styles/agents.css
@@ -766,7 +766,6 @@
  * `:focus-visible` rather than `:focus`, so a mouse click does not paint one. */
 .why-panel:focus-visible,
 .agent-card:focus-visible,
-.cty-title:focus-visible,
 .cty-row:focus-visible,
 .cty-body:focus-visible {
   outline: 2px solid var(--qt-accent);
@@ -937,8 +936,7 @@
  * Background only. This card sits in a flex column under PIT, so anything that
  * changes its box moves a neighbour - the same reason the consoles' own hover is
  * a border and not a size. */
-.cty-row.has-detail,
-.cty-title.has-detail {
+.cty-row.has-detail {
   cursor: help;
 }
 
@@ -994,4 +992,29 @@
   margin: auto 0;
   color: var(--qt-fg-3);
   font-size: 11px;
+}
+
+/* The risks, in the body under the branches. A heading and dim lines, so the
+ * block reads as a second kind of content rather than as more branches. */
+.cty-risks {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding-top: 6px;
+  border-top: 1px solid var(--qt-border);
+}
+
+.cty-risks-title {
+  margin: 0 0 2px;
+  color: var(--qt-fg-3);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 1px;
+}
+
+.cty-risk {
+  margin: 0;
+  color: var(--qt-fg-2);
+  font-size: 10px;
+  line-height: 1.35;
 }

--- a/src/pitwall/ui/src/styles/agents.css
+++ b/src/pitwall/ui/src/styles/agents.css
@@ -404,15 +404,18 @@
  * a mask rather than an overlay leaves the content its own colours and puts
  * nothing new in the hit-testing path, and the classes come from measured
  * overflow rather than a breakpoint, so a card that fits shows nothing. */
-.agent-card-body.has-below {
+.agent-card-body.has-below,
+.cty-body.has-below {
   mask-image: linear-gradient(to bottom, #000 calc(100% - 18px), transparent 100%);
 }
 
-.agent-card-body.has-above {
+.agent-card-body.has-above,
+.cty-body.has-above {
   mask-image: linear-gradient(to bottom, transparent 0, #000 14px);
 }
 
-.agent-card-body.has-above.has-below {
+.agent-card-body.has-above.has-below,
+.cty-body.has-above.has-below {
   mask-image: linear-gradient(
     to bottom,
     transparent 0,
@@ -762,7 +765,10 @@
 /* Both tooltip targets are keyboard targets now, so both need a focus ring.
  * `:focus-visible` rather than `:focus`, so a mouse click does not paint one. */
 .why-panel:focus-visible,
-.agent-card:focus-visible {
+.agent-card:focus-visible,
+.cty-title:focus-visible,
+.cty-row:focus-visible,
+.cty-body:focus-visible {
   outline: 2px solid var(--qt-accent);
   outline-offset: 2px;
 }
@@ -846,4 +852,146 @@
 }
 .agent-tooltip::-webkit-scrollbar-track {
   background: transparent;
+}
+
+/* ---- CONTINGENCIES (the side column's empty region) ----------------------
+ *
+ * **`flex: 1 1 0` is what makes the collapse decision loop-free.** A flex basis
+ * of zero keeps this card's CONTENTS out of the sizing calculation, so its used
+ * height is exactly the column's free space, `column - situation - pit - gaps`,
+ * and nothing it renders can move the number it measures itself against. The
+ * DATA window's BESTS panel is the counter-example: its decision changes its own
+ * height and #1083 is open because of it.
+ *
+ * `min-height: 0` removes the automatic content minimum that would put the
+ * contents back into that calculation. `box-sizing: border-box` is NOT global in
+ * this stylesheet, so it is declared: without it the padding and border land
+ * outside the residual and the card overflows the column, and it is also what
+ * keeps the measured height identical whether the border is drawn or not.
+ *
+ * This is its own rule rather than a comma added to `.agents-side > .agent-card`
+ * above. That rule means "a content-height console must be allowed to shrink";
+ * this one means "fill the residual and ignore your content". Two intents that
+ * happen to share a declaration. */
+.contingencies {
+  flex: 1 1 0;
+  min-height: 0;
+  box-sizing: border-box;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+/* Below the floor the element keeps its place in the flow and stops looking like
+ * a panel. Window background reads as nothing; an empty bordered box reads as
+ * content that failed to arrive. */
+.contingencies.is-collapsed {
+  padding: 0;
+  border: 0;
+  background: none;
+}
+
+.cty-title {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--qt-fg-2);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 1px;
+}
+
+/* The count is the TOTAL, so a body that scrolls still says how many there are. */
+.cty-count {
+  color: var(--qt-fg-3);
+  font-family: var(--qt-mono);
+  font-weight: 400;
+}
+
+.cty-body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.cty-row {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 2px 4px;
+  margin: 0 -4px;
+  border-radius: 4px;
+}
+
+/* **Gated on a class the component sets, never on `:has(.agent-tooltip)`.** That
+ * selector drives the six consoles' hover and has never matched anything: the
+ * popup is portaled to `<body>`, so it is not a descendant of the card it was
+ * meant to describe.
+ *
+ * Background only. This card sits in a flex column under PIT, so anything that
+ * changes its box moves a neighbour - the same reason the consoles' own hover is
+ * a border and not a size. */
+.cty-row.has-detail,
+.cty-title.has-detail {
+  cursor: help;
+}
+
+.cty-row.has-detail {
+  transition: background-color var(--motion-fast) var(--motion-ease);
+}
+
+.cty-row.has-detail:hover {
+  background: var(--qt-elevated);
+}
+
+.cty-trigger {
+  margin: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  color: var(--qt-fg-1);
+  font-size: 11px;
+}
+
+/* The WORD carries the priority. No alarm hue: red on this window belongs to the
+ * live call's action, and a branch that is not happening must not wear it. */
+.cty-priority {
+  flex: none;
+  color: var(--qt-fg-3);
+  font-family: var(--qt-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+}
+
+.cty-switch {
+  margin: 0;
+  color: var(--qt-fg-2);
+  font-family: var(--qt-mono);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+/* Two lines, and the rest one hover away. The full text is never only here. */
+.cty-rationale {
+  margin: 0;
+  color: var(--qt-fg-3);
+  font-size: 10px;
+  line-height: 1.35;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+}
+
+.cty-empty {
+  margin: auto 0;
+  color: var(--qt-fg-3);
+  font-size: 11px;
 }

--- a/tests/surfaces/test_arcade_wire_contract.py
+++ b/tests/surfaces/test_arcade_wire_contract.py
@@ -629,7 +629,18 @@ def test_the_dev_producer_uses_the_same_real_field_names():
         assert not unknown, f"the dev producer invents {sorted(unknown)} in {block}"
 
     active = next(keyword for keyword in call.keywords if keyword.arg == "active")
-    tokens = [element.value for element in active.value.elts]
+    # **Every string constant under the expression, whatever its shape.** This
+    # used to read `.elts` off a plain list literal, which stopped parsing the
+    # day the producer began VARYING its routing per lap - a change made so the
+    # AGENTS routing strip would not render a solid block. The assertion is
+    # unchanged and the reachable set is now strictly larger: every token the
+    # producer can emit has to be an agent id, not merely the ones in the first
+    # branch.
+    tokens = [
+        node.value
+        for node in ast.walk(active.value)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    ]
     assert tokens and all(t.startswith("N") and t[1:].isdigit() for t in tokens), tokens
 
 

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -2105,7 +2105,10 @@ def test_a_contingency_reaches_the_window_with_the_orchestrators_own_action_labe
     # Producer order, not sorted: the orchestrator owns the ordering signal.
     assert [row["priority"] for row in rows] == ["HIGH", "MEDIUM"]
     assert view["contingencies"]["empty"] is None, "rows and an empty sentence cannot coexist"
-    assert view["contingencies"]["risks"] is not None
+    assert view["contingencies"]["risks"] == [
+        "rejoin into traffic",
+        "the cliff arrives before the stop",
+    ], "the risks reach the body as plain lines, not as a popup"
 
 
 def test_a_contingency_reaches_the_window_as_text_and_never_as_markup():
@@ -2164,4 +2167,77 @@ def test_two_kinds_of_empty_are_two_different_sentences():
     assert no_call["empty"] != planned_none["empty"], (
         f"one sentence for two facts: {no_call['empty']!r}"
     )
-    assert planned_none["risks"] is None, "no risks means no popup on a title that looks live"
+    assert planned_none["risks"] == [], "no risks means no block, not an empty heading"
+
+
+def test_every_rolling_per_lap_store_is_trimmed():
+    """The trim iterates a hardcoded tuple, so a new store is silently unbounded.
+
+    Introspected rather than listed, so the NEXT store cannot be forgotten
+    either. `_compound_by_lap` is the one named exception and it is exempt for a
+    reason the class docstring gives: the PLAN lane draws the whole race, so a
+    lap-1 stint must still be describable on lap 57.
+    """
+    from src.pitwall.agents_view.history import KEEP_LAPS, LapHistory
+
+    history = LapHistory()
+    for lap in range(1, KEEP_LAPS + 11):
+        history.ingest_latest(
+            {
+                "lap_number": lap,
+                "lap_time_s": 81.0,
+                "compound": "MEDIUM",
+            }
+        )
+
+    rolling = {
+        name: store
+        for name, store in vars(history).items()
+        if isinstance(store, dict) and store and all(isinstance(key, int) for key in store)
+    }
+    assert len(rolling) >= 3, f"the introspection found no stores to check: {list(rolling)}"
+    for name, store in rolling.items():
+        if name == "_compound_by_lap":
+            assert len(store) > KEEP_LAPS, "the compound map is deliberately unbounded"
+            continue
+        assert len(store) == KEEP_LAPS, (
+            f"{name} is a rolling store and is not being trimmed: {len(store)} laps"
+        )
+
+
+def test_the_routing_roster_is_the_routers_own_conditional_agents():
+    """`ROUTING_LANES` and the router's `activate.add(...)` must be one list.
+
+    `build_cards` gates the PIT and RAG cards on these ids and used to carry its
+    own copies of the strings. Parsed with `ast` rather than imported: importing
+    the orchestrator pulls the whole LLM stack, which is why the wire-contract
+    tests next door use the same technique. A router that learns a third
+    conditional agent must not leave a card permanently idle.
+    """
+    import ast
+
+    source = (
+        Path(__file__).resolve().parents[2] / "src/agents/strategy_orchestrator.py"
+    ).read_text("utf-8")
+    tree = ast.parse(source)
+    router = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "_decide_agents_to_call"
+    )
+    added = {
+        call.args[0].value
+        for call in ast.walk(router)
+        if isinstance(call, ast.Call)
+        and isinstance(call.func, ast.Attribute)
+        and call.func.attr == "add"
+        and call.args
+        and isinstance(call.args[0], ast.Constant)
+    }
+    assert added, "the ast walk found no `activate.add(...)`; the router moved"
+
+    from src.pitwall.agents_view.routing import ROUTING_LANES
+
+    assert {agent_id for agent_id, _ in ROUTING_LANES} == added, (
+        f"the roster and the router disagree: {ROUTING_LANES} vs {sorted(added)}"
+    )

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -12,6 +12,7 @@ import re
 import subprocess
 import sys
 import textwrap
+from pathlib import Path
 
 import pytest
 
@@ -85,7 +86,6 @@ def _qt_token(name: str) -> str:
     which is the whole subject of `test_pitwall_tokens.py` next door.
     """
     import re
-    from pathlib import Path
 
     css = (
         Path(__file__).resolve().parents[2]
@@ -842,6 +842,25 @@ def _latest(lap: int = 23) -> dict:
         "undercut_target": "RUS",
         "memory_block": f"lap {lap - 1}: STAY_OUT (0.58)",
         "plan_changed": True,
+        # **Two branches and two risks, without which every contingency assertion
+        # below is about the empty set.** The first carries a `switch_to` whose
+        # wire form differs from its label, which is what makes the label
+        # assertion able to fail.
+        "contingencies": [
+            {
+                "trigger": "if RUS pits within two laps",
+                "switch_to": "PIT_NOW",
+                "priority": "HIGH",
+                "rationale": "the undercut window shuts once he clears traffic",
+            },
+            {
+                "trigger": "if the safety car is deployed before L28",
+                "switch_to": "STAY_OUT",
+                "priority": "MEDIUM",
+                "rationale": "track position beats the tyre delta under neutralisation",
+            },
+        ],
+        "key_risks": ["rejoin into traffic", "the cliff arrives before the stop"],
         "per_agent": {
             "pace": {
                 "lap_time_pred": 81.0,
@@ -2064,3 +2083,85 @@ def test_the_pace_chart_degrades_when_the_wire_has_no_colour_for_the_car():
     for name, payload in (("driver absent", absent), ("empty map", empty), ("no key", _payload())):
         colour = _host(payload).get_agents_view(-1)["charts"]["pace"]["actual_colour"]
         assert colour == ACTUAL_COLOUR, f"{name} must degrade, not raise or invent: {colour}"
+
+
+def test_a_contingency_reaches_the_window_with_the_orchestrators_own_action_label():
+    """`PIT_NOW` on the wire must read `PIT NOW` on the glass, as the badge does.
+
+    Through `classify_action`, never a hand-written table: a second copy of the
+    action labels is the twin this file's own module docstring warns about. The
+    COLOUR is deliberately not taken from it - a branch that is not happening
+    must not wear the live call's identity.
+    """
+    view = _host(_payload()).get_agents_view(-1)
+    rows = view["contingencies"]["rows"]
+
+    assert len(rows) == 2, f"the fixture's two branches must both arrive: {rows}"
+    assert rows[0]["switch_to"] == "PIT NOW", (
+        f"the wire's enum must reach the glass as the orchestrator's own label: {rows[0]}"
+    )
+    assert rows[1]["switch_to"] == "STAY OUT"
+    assert rows[0]["priority"] == "HIGH"
+    # Producer order, not sorted: the orchestrator owns the ordering signal.
+    assert [row["priority"] for row in rows] == ["HIGH", "MEDIUM"]
+    assert view["contingencies"]["empty"] is None, "rows and an empty sentence cannot coexist"
+    assert view["contingencies"]["risks"] is not None
+
+
+def test_a_contingency_reaches_the_window_as_text_and_never_as_markup():
+    """LLM free text, rendered as a React text node, so nothing is escaped here.
+
+    Both halves matter and each catches the opposite mistake. Escaping in the
+    builder would put the characters `&lt;img` on the glass; a
+    `dangerouslySetInnerHTML` in the card would execute the tag. The card is
+    checked as SOURCE because no Python test can see the TSX.
+    """
+    hostile = _latest()
+    hostile["contingencies"] = [
+        {
+            "trigger": _HOSTILE,
+            "switch_to": "PIT_NOW",
+            "priority": "HIGH",
+            "rationale": _HOSTILE,
+        }
+    ]
+    hostile["key_risks"] = [_HOSTILE]
+
+    row = _host(_payload(latest=hostile)).get_agents_view(-1)["contingencies"]["rows"][0]
+
+    assert "<img" in row["trigger"], "the text arrives verbatim, as data"
+    assert "&lt;" not in row["trigger"], (
+        "escaped here it would render as the characters &lt;img on the glass"
+    )
+    assert "&lt;" not in row["rationale"]
+
+    card = (
+        Path(__file__).resolve().parents[2]
+        / "src/pitwall/ui/src/features/agents/ContingenciesCard.tsx"
+    ).read_text("utf-8")
+    assert "dangerouslySetInnerHTML" not in card, (
+        "the card renders text nodes; raw HTML here would execute what the LLM wrote"
+    )
+
+
+def test_two_kinds_of_empty_are_two_different_sentences():
+    """No call at all and a call that planned no branches are different facts.
+
+    The no-LLM profile emits `contingencies=[]` by construction, so the second is
+    routine rather than an error. Both branches carry the SAME key set, which is
+    the house empty-state rule: a renderer must never have to test for a missing
+    key.
+    """
+    no_call = _host(_payload(latest={})).get_agents_view(-1)["contingencies"]
+    no_branches = _latest()
+    no_branches["contingencies"] = []
+    no_branches["key_risks"] = []
+    planned_none = _host(_payload(latest=no_branches)).get_agents_view(-1)["contingencies"]
+
+    assert set(no_call) == set(planned_none) == {"rows", "risks", "empty"}
+    assert no_call["rows"] == planned_none["rows"] == []
+    assert no_call["empty"] and planned_none["empty"], "both branches say something"
+    assert no_call["empty"] != planned_none["empty"], (
+        f"one sentence for two facts: {no_call['empty']!r}"
+    )
+    assert planned_none["risks"] is None, "no risks means no popup on a title that looks live"


### PR DESCRIPTION
## What

Fills the empty region in the AGENTS window's right column with the orchestrator's
**contingencies** and **key risks** — its if-then branch plans, and what it flagged as the top
risks. Both shipped on the wire with #1048's schema bump and **no code under `src/pitwall`
rendered either**.

Refs #999.

## Why not the agent graph

A design gate looked at filling that space with a multi-agent graph first and refused, on two
independent grounds. There is no runtime graph to draw: no `StateGraph` or `add_node` exists
anywhere in `src/`, and the topology is a fixed five-stage sequence in
`strategy/inference/engine.py::_run_rich`, so the panel would be a diagram of code rather than a
trace of a run. And the only per-lap variation it could show — which conditional agent routed — is
already the PIT and RAG cards' state two inches to the left.

A per-lap routing strip was built for that space and then removed for the same reason: `active` is
the routing layer's membership, not a trace, and "RAG was consulted on laps 25 to 28" is
observability rather than anything a strategist acts on. `routing.py` survives as the router's
roster, which `build_cards` now reads instead of its own `"N28"`/`"N30"` literals.

## How

- `decision.py` gains `build_contingencies`, shaped like `_why_detail`: typed data with **raw
  strings**, rendered as React text nodes. Nothing is escaped, because an escaped `<` renders as
  the characters `&lt;` on the glass — the preference `reasoning.py` already states.
- `switch_to` goes through `classify_action` for its **label only**, so a branch reads `PIT NOW`
  exactly as the badge two cards up does. It takes **no colour**, and `priority` is carried by the
  word: red on this window belongs to the live call's action, and a branch that is not happening
  must not wear it.
- The risks are a block in the **body**, not behind a hover. They started on the title's tooltip,
  which made them content nobody would find.
- `useScrollEdges` moved out of `AgentCard` into `lib` and both import it, rather than the new card
  growing a second copy.

## The collapse cannot feed itself

The card is `flex: 1 1 0` with `min-height: 0` and `box-sizing: border-box`. A flex basis of zero
keeps its contents out of its own sizing calculation, so its height is exactly the column's
residual and **nothing it renders can move the number it is judged by**. Below 86 px it renders
nothing at all rather than a heading over a cut-off row; the 1366x768 laptop leaves 22.

That property is the point. **#1083 is open on the DATA window's BESTS panel for the opposite
shape**: its decision changes the height it then re-measures, and its `fit` callback depends on its
own state, so its ResizeObserver is rebuilt on every decision. A smoke check here hides the card's
contents, re-reads the rect, and asserts it did not move.

## Measured on a real LLM run, not assumed

The fixtures carried one branch and two risks. `f1-sim Melbourne NOR McLaren --laps 20-22` on the
real OpenAI path came back with the orchestrator's **maximum on every lap: four contingencies and
five risks**. So the card had been developed against a payload a quarter the size of the one it
receives, and the space under it read as a design problem rather than as a thin stub.

Sized to that, the card overflows by 134 px at the reference client and 54 at 1080p, and the body
scrolls. That is the shipped answer: capping the list would drop a branch plan the orchestrator
made because a card is short. What makes it acceptable is the fade, which now has a guard — this
window hides every scrollbar globally, so without it the half below the fold is simply lost, which
is the defect #1077 fixed on the consoles one card over.

The run also settled the clamp: real rationales come back around a hundred characters, because the
prompt asks for that, so the two-line clamp does not fire at this width on real text. It stays as
the guard against a model that ignores its own instruction, and the smoke keeps a deliberately long
rationale so that path is still exercised.

## Also fixed, because a fixture that misrepresents the producer is its own defect

`dev_pitwall_producer.py` never advanced its decision lap — `state.latest` stayed on lap 23 for the
whole run, so every lap-keyed accumulator in the window saw exactly one lap forever. It now advances
one lap every 45 s, which is one Melbourne lap at its own 2x playback, and varies which agents route
so the PIT and RAG cards exercise both states.

The wire contract's parser read `active=` as a plain list literal and stopped parsing the moment the
value became an expression. It now collects every string constant under it, so the assertion covers
both branches instead of only the first. Checked by planting a block name in the second branch and
watching it go red.

## Checks

- `tests/surfaces/` 288 -> **295**, `smoke-agents` 95 -> **116**, `smoke-data` 373 unchanged.
- **Twelve mutants, each watched RED with named checks**, on builds that compile. Three had to be
  rewritten first: two produced a crash rather than a finding, because Playwright's `hover` and
  `getAttribute` WAIT and a card that renders nothing turns a failed check into a 30-second timeout
  that kills the run before any failure prints.
- The mutants: the raw enum instead of the label · the builder escaping the text · one empty
  sentence for two facts · rendering with no room · never rendering · the fit measuring its own
  content · empty rows becoming tab stops · the clamped text being the only copy · the risks back
  behind a hover · the risks rendering the wrong source · the host dropping them · the fade removed
  from an overflowing body.
- Read on the real windows over the loopback host with the producer, at all three client sizes.
