### PR TITLE
fix: close the four defects the writing sweep filed, and the three they surfaced

### DIFF
--- a/docs/pages/meet-the-author.md
+++ b/docs/pages/meet-the-author.md
@@ -39,8 +39,8 @@ and a plan for the next pit window.
 The same engine drives three operator surfaces: a React web app
 for analysts (backed by a FastAPI/MCP API for programmatic access and
 chat tool-calling), a CLI for headless replays, and a multi-window
-arcade (race replay, strategy dashboard, live telemetry) built in
-PySide6 + pyglet for the demo experience. The whole stack is open
+arcade (race replay plus the two PITWALL windows, agents and live
+telemetry) built in pyglet and React for the demo experience. The whole stack is open
 under Apache-2.0 and shipped as wheels and GitHub releases through
 release-please automation.
 

--- a/documents/dev_docs/diagrams/README.md
+++ b/documents/dev_docs/diagrams/README.md
@@ -8,7 +8,7 @@ All of these were last edited on 2026-05-13, before two releases landed: v2.0.0 
 
 | Diagram | State |
 |---|---|
-| `system_architecture` | updated: Surface 3 is the React web app, not Streamlit |
+| `system_architecture` | updated 2026-08-26 (#1090): Surface 2's windows 2 and 3 said `Dashboard (Qt)` and `Telemetry (Qt)` over a description reading `pyglet Arcade + PySide6 dashboard`. They are the two PITWALL webview windows in one process. Surface 3 is the React web app, not Streamlit |
 | `backend_api` | updated: the `/voice` router and its two endpoints removed |
 | `chat_mcp_flow` | updated: voice input path removed, the chat UI is the React tab |
 | `docker_deployment` | updated: `f1_webapp` on nginx, host 8501 to container 80 |
@@ -17,20 +17,25 @@ All of these were last edited on 2026-05-13, before two releases landed: v2.0.0 
 | `arcade_3window_architecture_qt_legacy` | **renamed and marked retired**: it is the PySide6 pair PITWALL replaced in sprint 7. Not relabelled into the new topology, because that is not a relabel - the DATA window is not shaped like the Qt telemetry window. The live picture is the Mermaid graph in `docs/pages/multi-agent.md` |
 | `multi_agent_architecture` | updated 2026-08-02: N25's box no longer says "LangGraph ReAct", because pace's scaffold was formally retired in #781, N25 is now shown as a direct XGBoost call, same as the sub-agents header line |
 | `multi_agent_flow` | updated 2026-08-26: its routing, draw count and synthesis model match the orchestrator, but its Layer 2 box did not. The four candidates are `STAY_OUT` / `PIT_NOW` / `UNDERCUT` / `OVERCUT` (`strategy_orchestrator.py:272`), not one STAY OUT and three PIT NOW compound variants, and the score is `payoff(project_positions(rivals))` per draw (`:1308-1323`), not a sample from the sub-agent distributions |
-| `strategy_pipeline_flow` | updated 2026-08-26: its Layer 3 said `gpt-4.1-mini`, which is what the SUB-AGENTS use, while the synthesis it labels is the orchestrator's own `gpt-5.4-mini` (`strategy_orchestrator.py:139`); and its pace MAE of 0.392 s is the notebook-era value the metrics registry marks `canonical: false`, superseded by 0.4104 s |
-| `subprocess_launch_sequence` | updated sprint 7: the sequence is unchanged, the follower it launches is `python -m src.pitwall` and the two windows share one reader |
-| `tcp_broadcast_dataflow` | updated sprint 7: the subscriber is PITWALL, and the 2x2 grid is ECharts |
+| `strategy_pipeline_flow` | updated 2026-08-26: its Layer 3 said `gpt-4.1-mini`, which is what the SUB-AGENTS use, while the synthesis it labels is the orchestrator's own `gpt-5.4-mini` (`strategy_orchestrator.py:138`); and its pace MAE of 0.392 s is the notebook-era value the metrics registry marks `canonical: false`, superseded by 0.4104 s |
+| `subprocess_launch_sequence` | updated 2026-08-26 (#1090): the actor columns already said PITWALL while four messages still described the Qt pair. Step 6b spawned `src.arcade.telemetry`, a module that does not exist, and step 14 sent a second TCP tick to it; `app.py:501` opens ONE subprocess and `src/pitwall/__main__.py` builds ONE `ArcadeStreamClient` for both windows, so both arrows now start at the PITWALL column. Step 7 is `PitwallHost(ArcadeStreamClient)`, and step 15's "tabs" went with the reasoning panel in #1020 |
+| `tcp_broadcast_dataflow` | updated 2026-08-26 (#1090): the live subscriber box read `QMainWindow` / `QThread` / `pyqtSignal` beside a second box correctly marked RETIRED. It is one pywebview process reading one socket for both windows. The 2x2 grid is ECharts |
 | `data_pipeline` | current on the surfaces; note the FastF1 cache is one directory now, not two |
 | `agents/` | one per sub-agent (N25 to N30) plus the `StrategyRecommendation` schema; `N25_pace_agent` updated 2026-08-02 to drop the ReAct-tool boxes it never actually used (#781) |
 
 Verified 2026-08-26: all 20 files parse as XML, and no label, tab name or XML comment carries an em dash.
 
-**Three diagrams not marked legacy still name the retired Qt surface**, tracked in #1090:
-`subprocess_launch_sequence` step 7 (`QApplication + MainWindow`, where step 6a already spawns
-`python -m src.pitwall`), `tcp_broadcast_dataflow`'s live subscriber box (`QMainWindow` / `QThread`
-/ `pyqtSignal`), and `system_architecture` (`PySide6 dashboard`). Relabelling them is not a rename,
-for the reason the `arcade_3window_architecture_qt_legacy` row gives: the DATA window is not shaped
-like the Qt telemetry window.
+The three that still named the retired Qt surface were redrawn in #1090, and the rule they broke is
+now checked rather than asserted: `tests/surfaces/test_diagrams_no_retired_surface.py` parses the
+`value=` attributes of every diagram outside the two `*_legacy.drawio` files and fails on
+`PySide6`, `QApplication`, `QMainWindow`, `QThread`, `pyqtSignal` or `src.arcade.telemetry`. A box
+whose own label carries the word RETIRED is exempt, because drawing the dead surface beside the
+live one is how `tcp_broadcast_dataflow` shows what was replaced. It also fails a diagram that
+yields no labels at all, which is what a compressed draw.io save looks like from the outside.
+
+The check is the parse half only. Whether a diagram means what the code does is still a reading
+against the source, which is how the four defects above were found and how the drift in
+`multi_agent_flow` was found running the opposite way.
 
 **How this audit is made.** Labels are parsed out of the `value=` attributes and the tab names, never grepped from the raw XML. A grep counts matches inside style attributes and colour names, which both over-reports (a file whose only hit is a colour) and under-reports (`docker_deployment`, whose defect was a container named `f1_telemetry_frontend`, containing neither search word). Each figure is then checked against the code it describes rather than against a sibling diagram, because the drift runs in both directions.
 

--- a/documents/dev_docs/diagrams/subprocess_launch_sequence.drawio
+++ b/documents/dev_docs/diagrams/subprocess_launch_sequence.drawio
@@ -150,15 +150,15 @@
             <mxPoint x="1460" y="595" as="targetPoint"/>
           </mxGeometry>
         </mxCell>
-        <mxCell id="m6b" value="6b. subprocess.Popen([sys.executable, &quot;-m&quot;, &quot;src.arcade.telemetry&quot;])" style="endArrow=classic;html=1;strokeColor=#06B6D4;strokeWidth=3;fontColor=#E6E8EF;fontSize=10;fontStyle=1;" edge="1" parent="1">
+        <mxCell id="m6b" value="6b. the SAME process opens the second window &#183; webview.create_window() per config.WINDOWS" style="endArrow=classic;html=1;strokeColor=#06B6D4;strokeWidth=3;fontColor=#E6E8EF;fontSize=10;fontStyle=1;" edge="1" parent="1">
           <mxGeometry relative="1" as="geometry">
-            <mxPoint x="940" y="645" as="sourcePoint"/>
+            <mxPoint x="1460" y="645" as="sourcePoint"/>
             <mxPoint x="1720" y="645" as="targetPoint"/>
           </mxGeometry>
         </mxCell>
 
         <!-- Step 7: Dashboard process creates clients -->
-        <mxCell id="m7" value="7. QApplication + MainWindow &#183; TelemetryStreamClient(QThread).start(), connects to 127.0.0.1:9998" style="endArrow=classic;html=1;strokeColor=#F59E0B;strokeWidth=2;fontColor=#E6E8EF;fontSize=10;" edge="1" parent="1">
+        <mxCell id="m7" value="7. PitwallHost(ArcadeStreamClient).start() &#183; ONE TCP client for both windows, connects to 127.0.0.1:9998" style="endArrow=classic;html=1;strokeColor=#F59E0B;strokeWidth=2;fontColor=#E6E8EF;fontSize=10;" edge="1" parent="1">
           <mxGeometry relative="1" as="geometry">
             <mxPoint x="1460" y="690" as="sourcePoint"/>
             <mxPoint x="940" y="690" as="targetPoint"/>
@@ -218,26 +218,26 @@
           <mxGeometry x="960" y="1058" width="280" height="30" as="geometry"/>
         </mxCell>
 
-        <mxCell id="m13" value="13. TCP send &#8594; PITWALL host (~10 Hz)" style="endArrow=classic;html=1;strokeColor=#F59E0B;strokeWidth=3;fontColor=#E6E8EF;fontSize=10;fontStyle=1;" edge="1" parent="1">
+        <mxCell id="m13" value="13. TCP send &#8594; ArcadeStreamClient (~10 Hz)" style="endArrow=classic;html=1;strokeColor=#F59E0B;strokeWidth=3;fontColor=#E6E8EF;fontSize=10;fontStyle=1;" edge="1" parent="1">
           <mxGeometry relative="1" as="geometry">
             <mxPoint x="940" y="1125" as="sourcePoint"/>
             <mxPoint x="1460" y="1125" as="targetPoint"/>
           </mxGeometry>
         </mxCell>
-        <mxCell id="m14" value="14. TCP send &#8594; Telemetry (~10 Hz)" style="endArrow=classic;html=1;strokeColor=#06B6D4;strokeWidth=3;fontColor=#E6E8EF;fontSize=10;fontStyle=1;" edge="1" parent="1">
+        <mxCell id="m14" value="14. the same tick, read by the second window &#183; one socket, one seq, no second connection" style="endArrow=classic;html=1;strokeColor=#06B6D4;strokeWidth=3;fontColor=#E6E8EF;fontSize=10;fontStyle=1;" edge="1" parent="1">
           <mxGeometry relative="1" as="geometry">
-            <mxPoint x="940" y="1165" as="sourcePoint"/>
+            <mxPoint x="1460" y="1165" as="sourcePoint"/>
             <mxPoint x="1720" y="1165" as="targetPoint"/>
           </mxGeometry>
         </mxCell>
 
-        <mxCell id="m15" value="15. Host parses newline-JSON &#8594; both windows poll it by seq &#8594; Orchestrator card, MC bars, 6 sub-agent cards, tabs" style="endArrow=classic;html=1;strokeColor=#F59E0B;strokeWidth=2;fontColor=#E6E8EF;fontSize=10;" edge="1" parent="1">
+        <mxCell id="m15" value="15. Host parses newline-JSON &#8594; both windows poll it by seq &#8594; decision band, MC bars, 6 sub-agent consoles" style="endArrow=classic;html=1;strokeColor=#F59E0B;strokeWidth=2;fontColor=#E6E8EF;fontSize=10;" edge="1" parent="1">
           <mxGeometry relative="1" as="geometry">
             <mxPoint x="1460" y="1200" as="sourcePoint"/>
             <mxPoint x="1460" y="1225" as="targetPoint"/>
           </mxGeometry>
         </mxCell>
-        <mxCell id="m15-self" value="self-call: pyqtSignal.emit(dict) &#8594; widgets update" style="text;html=1;align=left;verticalAlign=middle;fontSize=10;fontColor=#F59E0B;" vertex="1" parent="1">
+        <mxCell id="m15-self" value="self-call: get_tick(seq) over the pywebview bridge &#8594; React re-render" style="text;html=1;align=left;verticalAlign=middle;fontSize=10;fontColor=#F59E0B;" vertex="1" parent="1">
           <mxGeometry x="1480" y="1198" width="340" height="30" as="geometry"/>
         </mxCell>
 
@@ -248,7 +248,7 @@
         <mxCell id="leg-1" value=",  Purple lines: main.py orchestrating boot (steps 1, 3, 12)" style="text;html=1;align=left;verticalAlign=middle;fontSize=11;fontColor=#8B5CF6;" vertex="1" parent="1">
           <mxGeometry x="100" y="1310" width="800" height="24" as="geometry"/>
         </mxCell>
-        <mxCell id="leg-2" value=",  Orange (thick) &amp; cyan (thick) lines: subprocess.Popen spawns (steps 6a, 6b) + TCP broadcasts (steps 13, 14)" style="text;html=1;align=left;verticalAlign=middle;fontSize=11;fontColor=#F59E0B;" vertex="1" parent="1">
+        <mxCell id="leg-2" value=",  Orange (thick) &amp; cyan (thick) lines: subprocess.Popen spawns (step 6a) + TCP broadcast (step 13); the second window and its tick (6b, 14) are in-process" style="text;html=1;align=left;verticalAlign=middle;fontSize=11;fontColor=#F59E0B;" vertex="1" parent="1">
           <mxGeometry x="100" y="1338" width="1200" height="24" as="geometry"/>
         </mxCell>
         <mxCell id="leg-3" value=",  Green lines: SimConnector thread work, pipeline execution + state writes (steps 4, 5, 10, 11)" style="text;html=1;align=left;verticalAlign=middle;fontSize=11;fontColor=#4ADE80;" vertex="1" parent="1">

--- a/documents/dev_docs/diagrams/system_architecture.drawio
+++ b/documents/dev_docs/diagrams/system_architecture.drawio
@@ -39,16 +39,16 @@
         <mxCell id="arc-box" value="Surface 2, Arcade (MAIN FOCUS)&#10;python -m src.arcade.main --viewer --strategy" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1A2138;strokeColor=#8B5CF6;fontColor=#E6E8EF;fontStyle=1;fontSize=13;verticalAlign=top;spacingTop=10;strokeWidth=3;" vertex="1" parent="1">
           <mxGeometry x="660" y="230" width="600" height="280" as="geometry"/>
         </mxCell>
-        <mxCell id="arc-desc" value="3-window live race replay, Phase 3.5 MVP&#10;local strategy pipeline, no FastAPI dependency&#10;pyglet Arcade + PySide6 dashboard + telemetry windows" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#2B1A3C;strokeColor=#8B5CF6;fontColor=#E6E8EF;fontSize=11;" vertex="1" parent="1">
+        <mxCell id="arc-desc" value="3-window live race replay&#10;local strategy pipeline, no FastAPI dependency&#10;pyglet Arcade + the two PITWALL webview windows" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#2B1A3C;strokeColor=#8B5CF6;fontColor=#E6E8EF;fontSize=11;" vertex="1" parent="1">
           <mxGeometry x="690" y="280" width="540" height="70" as="geometry"/>
         </mxCell>
         <mxCell id="arc-win1" value="Window 1&#10;Arcade Replay (pyglet)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#243049;strokeColor=#8B5CF6;fontColor=#D3B8E8;fontSize=10;" vertex="1" parent="1">
           <mxGeometry x="690" y="360" width="170" height="60" as="geometry"/>
         </mxCell>
-        <mxCell id="arc-win2" value="Window 2&#10;Dashboard (Qt)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#243049;strokeColor=#F59E0B;fontColor=#F0D49C;fontSize=10;" vertex="1" parent="1">
+        <mxCell id="arc-win2" value="Window 2&#10;PITWALL &#183; AGENTS (webview)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#243049;strokeColor=#F59E0B;fontColor=#F0D49C;fontSize=10;" vertex="1" parent="1">
           <mxGeometry x="875" y="360" width="170" height="60" as="geometry"/>
         </mxCell>
-        <mxCell id="arc-win3" value="Window 3&#10;Telemetry (Qt)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#243049;strokeColor=#06B6D4;fontColor=#A6E0EC;fontSize=10;" vertex="1" parent="1">
+        <mxCell id="arc-win3" value="Window 3&#10;PITWALL &#183; DATA (same process)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#243049;strokeColor=#06B6D4;fontColor=#A6E0EC;fontSize=10;" vertex="1" parent="1">
           <mxGeometry x="1060" y="360" width="170" height="60" as="geometry"/>
         </mxCell>
         <mxCell id="arc-tcp" value="TCP localhost:9998 broadcast, newline JSON @ 10 Hz" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1D3F2A;strokeColor=#4ADE80;fontColor=#BDEBCC;fontSize=10;fontStyle=1;" vertex="1" parent="1">

--- a/documents/dev_docs/diagrams/tcp_broadcast_dataflow.drawio
+++ b/documents/dev_docs/diagrams/tcp_broadcast_dataflow.drawio
@@ -87,7 +87,7 @@
           <mxGeometry x="80" y="640" width="40" height="40" as="geometry"/>
         </mxCell>
 
-        <mxCell id="dash-subs" value="Strategy Dashboard, MainWindow (QMainWindow)&#10;TelemetryStreamClient (QThread)&#10;socket.recv() &#8594; split by \n &#8594; pyqtSignal(dict)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1A2138;strokeColor=#F59E0B;fontColor=#E6E8EF;fontSize=11;fontStyle=1;strokeWidth=2;" vertex="1" parent="1">
+        <mxCell id="dash-subs" value="PITWALL, one pywebview process for BOTH windows&#10;ArcadeStreamClient, one socket for both&#10;socket.recv() &#8594; split by \n &#8594; PitwallHost keeps the latest tick by seq" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1A2138;strokeColor=#F59E0B;fontColor=#E6E8EF;fontSize=11;fontStyle=1;strokeWidth=2;" vertex="1" parent="1">
           <mxGeometry x="140" y="640" width="560" height="100" as="geometry"/>
         </mxCell>
         <mxCell id="tel-subs" value="RETIRED (7ea6a7a6), Qt TelemetryWindow (QMainWindow)&#10;TelemetryStreamClient (QThread), separate socket connection&#10;consumed arcade.telemetry.{main, rival}, the shape schema v2 replaced&#10;with a span per driver under arcade.telemetry.drivers" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1A2138;strokeColor=#06B6D4;fontColor=#E6E8EF;fontSize=11;fontStyle=1;strokeWidth=2;" vertex="1" parent="1">
@@ -95,7 +95,7 @@
         </mxCell>
 
         <!-- Dashboard widgets -->
-        <mxCell id="dash-wid" value="Orchestrator Card &#183; MC Bars &#183; 6 Sub-Agent Cards &#183; Reasoning Tabs" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#243049;strokeColor=#F59E0B;fontColor=#F0D49C;fontSize=10;" vertex="1" parent="1">
+        <mxCell id="dash-wid" value="Decision band (CALL &#183; WHY &#183; MC bars &#183; PLAN) &#183; 6 sub-agent consoles" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#243049;strokeColor=#F59E0B;fontColor=#F0D49C;fontSize=10;" vertex="1" parent="1">
           <mxGeometry x="140" y="760" width="560" height="40" as="geometry"/>
         </mxCell>
         <mxCell id="tel-wid" value="Delta &#183; Speed &#183; Brake &#183; Throttle, 2&#215;2 ECharts grid" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#243049;strokeColor=#06B6D4;fontColor=#A6E0EC;fontSize=10;" vertex="1" parent="1">
@@ -143,7 +143,7 @@
         </mxCell>
 
         <!-- Footer note -->
-        <mxCell id="footer" value="Single producer (F1ArcadeView), multi-consumer (dashboard + telemetry windows). No FastAPI, no SSE. Localhost-only TCP socket." style="text;html=1;align=center;verticalAlign=middle;fontSize=12;fontColor=#A0A5B8;fontStyle=2;" vertex="1" parent="1">
+        <mxCell id="footer" value="Single producer (F1ArcadeView), ONE subscriber process serving two windows off one socket. No FastAPI, no SSE. Localhost-only TCP socket." style="text;html=1;align=center;verticalAlign=middle;fontSize=12;fontColor=#A0A5B8;fontStyle=2;" vertex="1" parent="1">
           <mxGeometry x="360" y="850" width="1200" height="30" as="geometry"/>
         </mxCell>
 

--- a/src/agents/_shared_defaults.py
+++ b/src/agents/_shared_defaults.py
@@ -43,10 +43,15 @@ def reading_or_default(source: Mapping[str, Any], key: str, default: float) -> f
     identical reads in ``tire_agent`` and ``race_situation_agent`` had not. Hence one
     named function rather than a fourth inline copy.
 
-    ``default`` stays a per-caller argument on purpose: the agents disagree on the
-    fallback temperatures (pace uses 25/35, tire and race_situation use 28/38) and
-    reconciling those numbers is a modelling decision tracked in #789, not something to
-    smuggle in behind a crash fix.
+    ``default`` stayed a per-caller argument because the agents disagreed on the
+    fallback temperatures when this was written (pace 25/35, tire and race_situation
+    28/38), and reconciling those numbers was a modelling decision rather than something
+    to smuggle in behind a crash fix. #789 then reconciled them, so every TEMPERATURE call
+    site now passes the two constants below. The parameter stays because the signature is
+    the general one and because the other quantities never went through that
+    consolidation: humidity is 50.0 at every caller, and rainfall is ``0`` at
+    ``pace_agent.py:974`` and ``0.0`` at ``tire_agent.py:1647``. Those two are
+    per-caller numbers still, not evidence that the temperature disagreement survives.
     """
     value = source.get(key)
     if value is None:

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -1614,7 +1614,11 @@ class RaceSituationAgent:
             "circuit_sc_rate": self.cfg.sc_rate_for(event_name),
             "total_laps": int(session.total_laps),
             "fastest_lap_s": _clean["LapTime"].min().total_seconds(),
-            "AirTemp": float(_wx["AirTemp"].mean()) if "AirTemp" in _wx else 28.0,
+            # The last bare temperature literal #789 left behind, two lines from
+            # siblings it did migrate. It was invisible to that sprint's guard,
+            # which matches a literal in the DEFAULT POSITION of a call and
+            # cannot see a ternary `else`.
+            "AirTemp": float(_wx["AirTemp"].mean()) if "AirTemp" in _wx else DEFAULT_AIR_TEMP_C,
             "TrackTemp": float(_wx["TrackTemp"].mean())
             if "TrackTemp" in _wx
             else DEFAULT_TRACK_TEMP_C,

--- a/src/agents/race_state_builder.py
+++ b/src/agents/race_state_builder.py
@@ -14,7 +14,8 @@ data. All 71 race directories carry a readable weather.parquet with zero NaN
 AirTemp/TrackTemp rows, so the keys are always present and always non-None, and
 40.0-vs-35.0 never actually reached a model there. The value below is chosen on
 the measured-median argument alone, not on a live-divergence one. What IS live is
-the present-but-None case this builder now handles: see DEFAULT_TRACK_TEMP_C.
+the present-but-None case this builder now handles: see
+RACE_STATE_DEFAULT_TRACK_TEMP_C.
 
 The drift that actually bit this codebase was LOGIC drift, not just
 literals: the #750 pace-delta axis, the #465 dead position default, the #633 gap
@@ -80,10 +81,24 @@ _MISSING_COMPOUND_MARKERS = frozenset({"", "nan", "none"})
 # also legitimately find.
 UNKNOWN_TYRE_LIFE = 0
 
-# Dataset medians (2023+2024 weather columns; the 2025 featured parquet carries
-# none): air median 24.1 C, track median exactly 35.0 C. The CLI's old 40.0 track
-# default corresponded to nothing measured, which is the whole reason to pick a
-# canonical value here.
+# **A SECOND pair, deliberately not `_shared_defaults`'s, and the prefix is the
+# whole point.** `_shared_defaults` carries 24.6 / 34.7 under the unprefixed
+# names and the sub-agents read those. This pair held 25.0 / 35.0 under the SAME
+# two names, which is how the divergence survived #789's consolidation: a
+# duplicate with a different name is visible at a glance, a duplicate with the
+# same name reads as the import three lines up (#1088). Renaming moves no served
+# number. Unifying them would, because whichever value wins reaches a prompt, so
+# that is a measurement with its own before and after and is tracked separately.
+#
+# These are #784's F10 decision values, chosen on 2026-08-02 against the dataset
+# as it stood then, when the medians read 24.1 / 35.0 and the 2025 featured
+# parquet carried no weather columns. Neither of those is true today: the 2025
+# parquet carries them natively, and after the 2023 Spanish GP duplicate was
+# removed the medians read 24.7 / 35.5 over 2023+2024 and 24.6 / 34.7 over
+# 2023-2025. Do NOT read the pair below as a present-tense measurement; the
+# per-field record is in documents/audits/DESIGN_race_state_single_contract.md
+# (F10). What the choice was made AGAINST still stands: the CLI's old 40.0 track
+# default corresponded to nothing measured at all.
 #
 # Where these actually fire, measured rather than assumed: NOT on the replay path
 # (all 71 race dirs ship a readable weather.parquet with zero NaN temperature
@@ -92,8 +107,8 @@ UNKNOWN_TYRE_LIFE = 0
 # at all and the producer honours that as an explicit None per key. That case
 # used to reach `float(None)` and raise TypeError; treating present-but-None as
 # missing is what makes these constants load-bearing.
-DEFAULT_AIR_TEMP_C = 25.0
-DEFAULT_TRACK_TEMP_C = 35.0
+RACE_STATE_DEFAULT_AIR_TEMP_C = 25.0
+RACE_STATE_DEFAULT_TRACK_TEMP_C = 35.0
 
 
 def _targeting_against_rival(
@@ -364,8 +379,8 @@ def build_race_state(
         tyre_life=tyre_life if tyre_life is not None else UNKNOWN_TYRE_LIFE,
         gap_ahead_s=float(gap_ahead_s) if gap_ahead_s is not None else None,
         pace_delta_s=float(pace_delta_s),
-        air_temp=_weather_reading(weather, "air_temp", DEFAULT_AIR_TEMP_C),
-        track_temp=_weather_reading(weather, "track_temp", DEFAULT_TRACK_TEMP_C),
+        air_temp=_weather_reading(weather, "air_temp", RACE_STATE_DEFAULT_AIR_TEMP_C),
+        track_temp=_weather_reading(weather, "track_temp", RACE_STATE_DEFAULT_TRACK_TEMP_C),
         rainfall=bool(weather.get("rainfall", False)),
         radio_msgs=radio_msgs if radio_msgs is not None else [],
         rcm_events=rcm_events if rcm_events is not None else [],

--- a/src/arcade/app.py
+++ b/src/arcade/app.py
@@ -1038,9 +1038,10 @@ class F1ArcadeView(arcade.View):
             # Real per-lap FastF1 weather (#616), built once at session load
             # by SessionLoader._extract_weather_by_lap and cached on
             # SessionData.weather_by_lap. An older cache or a session with no
-            # weather data resolves to {}; WeatherPanel.draw already falls
-            # back to its own constants per missing key, so this degrades to
-            # exactly the old hardcoded display instead of raising.
+            # weather data resolves to {}, and WeatherPanel then renders "N/A"
+            # per field. A single NaN sample degrades the same way, because the
+            # loader stores it as None under the key and overlays._reading
+            # coalesces it there (#1087) rather than formatting it and raising.
             "weather": self._session.weather_by_lap.get(lap, {}),
         }
 

--- a/src/arcade/config.py
+++ b/src/arcade/config.py
@@ -173,7 +173,10 @@ ARCADE_CACHE_DIR: Final[Path] = get_data_root() / "cache" / "arcade"
 # not written because rebuilding a session costs 254 s. Until it is, the obligation lives
 # here: if the bytes a rebuild would produce differ from the bytes on disk, this string moves
 # in the SAME commit, or the fix reaches nobody who already has a pickle.
-CACHE_VERSION: Final[str] = "v14"  # + the shared lap-boundary sample sorts stably (#1069)
+# v15: a NaN Rainfall sample now pickles as None instead of "WET" (#1087). The bytes differ only
+# for a session that HAS a NaN weather row, which is exactly the session the fix exists for, so
+# leaving the version at v14 would have delivered the fix to everyone except the affected.
+CACHE_VERSION: Final[str] = "v15"  # + the shared lap-boundary sample sorts stably (#1069)
 
 # --- Multiprocessing pool -------------------------------------------------
 # Serial by default: Windows spawn + pickling a loaded session across 8

--- a/src/arcade/data.py
+++ b/src/arcade/data.py
@@ -131,9 +131,9 @@ class SessionData:
     # and then thrown away; the arcade UI showed a hardcoded 45 C / 18 C / DRY
     # constant on every lap of every race while the strategy pipeline used the
     # real values from a different path. Empty dict means the loader could not
-    # extract weather (older cache, or the session genuinely has none); the
-    # panel's own ``.get(key, default)`` calls keep the old constants as the
-    # last-resort display instead of raising.
+    # extract weather (older cache, or the session genuinely has none), and the
+    # panel then renders "N/A" per field rather than a display constant, so a
+    # session with no weather reads as one with no weather (#1087).
     weather_by_lap: dict[int, dict[str, Any]] = field(default_factory=dict)
     # Whether each driver's telemetry actually places the car. False when the
     # distance never advances: on Melbourne 2025 that is HAD, whose position
@@ -274,9 +274,21 @@ def _nearest_sample(t: np.ndarray, timeline: np.ndarray) -> np.ndarray:
     return np.where(closer_to_left, right - 1, right)
 
 
-# The eight forward gears plus neutral. 0 is a REAL reading - 1,400 raw samples
-# on Melbourne 2025, and the PITWALL GEAR lane's [0, 9] range renders it - so the
-# validity test is one-sided.
+# The eight forward gears plus neutral, and the validity test is ONE-SIDED because
+# 0 is a real reading rather than a sentinel: `session.car_data` for Melbourne 2025
+# carries 202,509 of them across the 20 drivers, and the PITWALL GEAR lane's [0, 9]
+# range renders it.
+#
+# **None of them reaches a replay, and that is a property of the DATA, not a filter
+# here.** Every one of those 202,509 samples falls OUTSIDE every lap window: the
+# cars are stationary in the garage and on the grid, before lap 1 starts at 00:56:06
+# session time, while the laps run to 02:19:37. `_process_driver_data` reads
+# `lap.get_telemetry()`, so it only ever sees samples inside a lap, and across all
+# 1,059 laps of this race not one carries gear 0. Measured 2026-08-26 (#1094).
+#
+# So a replay of this race legitimately serves no neutral frame. Do NOT widen the
+# predicate below to `< 1` on the strength of that: the reading is real, other
+# sessions can put a stationary car inside a lap window, and one-sided is the rule.
 def _concat_sorted_by_time(arrays: dict[str, list[np.ndarray]]) -> dict[str, np.ndarray]:
     """Flatten the per-lap arrays into one time-ordered block per channel.
 
@@ -848,10 +860,23 @@ class SessionLoader:
     def _weather_row_to_dict(self, row: "pd.Series") -> dict[str, Any]:
         """Map one merged weather+lap row to the ``WeatherPanel``-facing shape.
 
-        Key names match ``WeatherPanel.draw``'s ``weather.get(key, default)``
-        calls exactly, so a row missing a single reading (rare, but possible
-        on an incomplete weather sample) only loses that one field to the
-        panel's own default instead of dropping the whole lap."""
+        Key names match the panel's lookups exactly, so a row missing a single
+        reading (rare, but possible on an incomplete weather sample) loses only
+        that one field instead of dropping the whole lap.
+
+        **A missing reading is an explicit ``None`` under the key, never an
+        absent key**, which is why the panel cannot lean on a ``dict.get``
+        default: the default fires on a missing KEY and this stores a missing
+        VALUE. ``overlays._reading`` is the consumer that coalesces it, and
+        before #1087 it did not exist, so a single NaN sample raised inside
+        ``on_draw`` and took the render loop with it.
+
+        **``Rainfall`` needs the same ``pd.notna`` guard as the five numbers,
+        and for a worse reason.** It is the one field where a dropped sample
+        did not raise: ``bool(float("nan"))`` is ``True``, so a NaN read as
+        "WET" and the panel announced rain on a dry race. A crash is loud and a
+        wrong affirmative is not, which is why this line survived the fix that
+        was written to close exactly this class."""
         return {
             "air_temp": float(row["AirTemp"]) if pd.notna(row.get("AirTemp")) else None,
             "track_temp": float(row["TrackTemp"]) if pd.notna(row.get("TrackTemp")) else None,
@@ -860,7 +885,11 @@ class SessionLoader:
             "wind_direction": (
                 float(row["WindDirection"]) if pd.notna(row.get("WindDirection")) else None
             ),
-            "rain_state": "WET" if bool(row.get("Rainfall")) else "DRY",
+            "rain_state": (
+                ("WET" if bool(row["Rainfall"]) else "DRY")
+                if pd.notna(row.get("Rainfall"))
+                else None
+            ),
         }
 
     def _extract_official_status(self, session: Any, driver_codes: dict) -> dict[str, str]:

--- a/src/arcade/overlays.py
+++ b/src/arcade/overlays.py
@@ -87,6 +87,68 @@ def _wind_dir(deg: float | None) -> str:
     return _COMPASS[int(((deg % 360) / 22.5) + 0.5) % 16]
 
 
+def _reading(value: float | None, spec: str, unit: str = "") -> str:
+    """Format one weather reading with its unit, or ``"N/A"`` when there is none.
+
+    **The unit belongs to the number, so an absent reading carries neither.**
+    Rendering "N/A C" puts a unit on a quantity that was never measured, and on
+    the wind row, where two fields share one line, it produced "N/A km/h N/A".
+    Every string assertion passed on that: it took looking at the drawn panel.
+
+    ``SessionLoader._weather_row_to_dict`` writes an explicit ``None`` UNDER
+    THE KEY when FastF1's reading is NaN, so ``dict.get(key, default)`` returns
+    that ``None`` and the default never fires. This is the ``Series.get`` lesson
+    of CLAUDE.md section 11 reproduced in a plain dict: the default covers a
+    missing KEY, never a missing VALUE.
+
+    ``"N/A"`` rather than the old display constant, and that is the point of the
+    fix rather than an aesthetic choice. 18.0 C shown for an unknown air
+    temperature is a number the reader cannot tell apart from a measurement,
+    which is the sentinel-collision shape this repo keeps paying for. Absent
+    data has to look absent.
+    """
+    if value is None:
+        return "N/A"
+    return f"{format(value, spec)}{unit}"
+
+
+def _weather_rows(weather: dict) -> list[tuple[str, str]]:
+    """The panel's five label/value pairs, as finished strings.
+
+    Split out of ``WeatherPanel.draw`` so the rendered TEXT can be asserted
+    without a GL context. The crash this closes lived in these five
+    expressions and nowhere else in the draw call, and a check that needed a
+    window to run is a check that does not run.
+
+    Every field degrades the same way, which is what was missing: ``_wind_dir``
+    already returned ``"N/A"`` on a missing direction while its five siblings
+    formatted whatever they were handed, so one field of six carried the fix.
+    """
+    speed = weather.get("wind_speed")
+    direction = weather.get("wind_direction")
+    # One row, two readings, so it collapses to a single "N/A" only when BOTH
+    # are missing. A known speed with an unknown bearing is a real state and
+    # keeps saying so.
+    if speed is None and direction is None:
+        wind = "N/A"
+    else:
+        wind = f"{_reading(speed, '.1f', ' km/h')} {_wind_dir(direction)}"
+
+    return [
+        ("Track", _reading(weather.get("track_temp"), ".1f", " C")),
+        ("Air", _reading(weather.get("air_temp"), ".1f", " C")),
+        ("Humidity", _reading(weather.get("humidity"), ".0f", "%")),
+        ("Wind", wind),
+        # A string, so it takes the `or` rather than ``_reading``, but it is
+        # nullable for the same reason as the five numbers: the loader stores
+        # ``None`` when the ``Rainfall`` sample is missing. It did not always.
+        # `bool(float("nan"))` is ``True``, so a dropped sample used to render
+        # "WET" on a dry race, and that is worse than the crash the other five
+        # fields took, because a wrong affirmative reading is silent.
+        ("Rain", f"{weather.get('rain_state') or 'N/A'}"),
+    ]
+
+
 class WeatherPanel:
     """Top-left weather readout: track/air temp, humidity, wind, rain.
 
@@ -143,17 +205,7 @@ class WeatherPanel:
     def draw(self, frame: dict | None, window_height: int) -> None:
         weather = (frame or {}).get("weather") or {}
         top_y = window_height - self.top_offset
-        rows: list[tuple[str, str]] = [
-            ("Track", f"{weather.get('track_temp', 45.0):.1f} C"),
-            ("Air", f"{weather.get('air_temp', 18.0):.1f} C"),
-            ("Humidity", f"{weather.get('humidity', 55.0):.0f}%"),
-            (
-                "Wind",
-                f"{weather.get('wind_speed', 0.0):.1f} km/h "
-                f"{_wind_dir(weather.get('wind_direction'))}",
-            ),
-            ("Rain", f"{weather.get('rain_state', 'DRY')}"),
-        ]
+        rows = _weather_rows(weather)
         panel_h = 26 + len(rows) * WEATHER_ROW_GAP + self.PANEL_PADDING
         self._draw_card(top_y, panel_h)
 

--- a/src/pitwall/__main__.py
+++ b/src/pitwall/__main__.py
@@ -1,9 +1,9 @@
 """Entry point: two windows, one host, one stream client.
 
-Spawned by the arcade as `python -m src.pitwall`, exactly the way the Qt
-dashboard is today. This is the ONLY module that imports pywebview, so a
-machine without a system webview still runs the tests and every other
-surface.
+Spawned by the arcade as `python -m src.pitwall` (`src/arcade/app.py:501`), the
+way the Qt dashboard used to be before this replaced it in sprint 7. This is the
+ONLY module that imports pywebview, so a machine without a system webview still
+runs the tests and every other surface.
 
 Run it directly to develop against a running arcade:
 

--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -1665,6 +1665,123 @@ const CTY_VIEW = {
 }
 
 
+// --- ⭐ the hover affordance, asserted as the RENDERED cursor and border ------
+//
+// Both rules were gated on `.agent-card:has(.agent-tooltip)` and neither ever
+// fired: the popup is portaled to `<body>`, so it is not a descendant of the
+// card and `:has()` could not reach it (#1089). Ten lines of comment above them
+// described the trade-off that produced them, so a reader checking whether the
+// affordance existed read that and stopped.
+//
+// **The signal this sweeps on is the tooltip actually appearing, never the
+// class.** Asserting `.has-tooltip` against the component that sets it is the
+// mechanism checking itself, and the mechanism is what was wrong last time. So
+// each card is hovered, and what it DID (a popup, or none) is compared against
+// what it LOOKS like (the computed cursor, the border that lifted).
+//
+// It also asserts the sweep reached both outcomes. The fixture gives RAG
+// `tooltip: null`, so one card must come out on each arm; without that line a
+// build where no card had the affordance, or where every card did, would pass
+// whichever arm it happened to satisfy.
+{
+  const hoverCtx = await browser.newContext({ viewport: CLIENT });
+  const hoverPage = await hoverCtx.newPage();
+  watchPage(hoverPage, failures, "hover affordance");
+  await hoverPage.addInitScript((view) => {
+    window.pywebview = {
+      api: {
+        get_agents_view: async (since) => (since >= view.seq ? null : view),
+        get_connection: async () => ({ label: "Connected", colour: "#10b981" }),
+      },
+    };
+  }, VIEW);
+  await hoverPage.goto(`http://127.0.0.1:${server.address().port}/agents.html`, {
+    waitUntil: "domcontentloaded",
+  });
+  await hoverPage.waitForSelector(".agent-card", { timeout: 5000 });
+
+  // Read with the pointer parked off every card, so this is the resting border
+  // the hover rule has to change. Taken from a card rather than from a token so
+  // a theme edit cannot silently make "changed" and "unchanged" the same string.
+  await hoverPage.mouse.move(2, 2);
+  await hoverPage.waitForTimeout(150);
+  const resting = await hoverPage.evaluate(
+    () => getComputedStyle(document.querySelector(".agent-card")).borderColor,
+  );
+
+  const withTooltip = [];
+  let hoveredCardBorder = null;
+  for (let index = 0; index < 6; index += 1) {
+    await hoverPage.locator(".agent-card").nth(index).hover();
+    await hoverPage.waitForTimeout(200);
+    const seen = await hoverPage.evaluate((i) => {
+      const card = document.querySelectorAll(".agent-card")[i];
+      const style = getComputedStyle(card);
+      return {
+        popup: document.querySelectorAll(".agent-tooltip").length === 1,
+        cursor: style.cursor,
+        border: style.borderColor,
+      };
+    }, index);
+    withTooltip.push(seen.popup);
+    if (seen.popup) hoveredCardBorder = seen.border;
+    check(
+      seen.popup ? seen.cursor === "help" : seen.cursor !== "help",
+      `agent card ${index}: the help cursor appears exactly where a transcript does ` +
+        `(popup ${seen.popup}, cursor ${seen.cursor})`,
+    );
+    check(
+      seen.popup ? seen.border !== resting : seen.border === resting,
+      `agent card ${index}: the border lifts under the pointer exactly where a ` +
+        `transcript does (popup ${seen.popup}, ${resting} -> ${seen.border})`,
+    );
+    await hoverPage.mouse.move(2, 2);
+    await hoverPage.waitForTimeout(150);
+  }
+  check(
+    withTooltip.some(Boolean) && withTooltip.some((has) => !has),
+    `agent cards: the sweep reached BOTH outcomes, so neither arm passed by never ` +
+      `running (${JSON.stringify(withTooltip)})`,
+  );
+
+  // The WHY module is the third tooltip target and had no affordance at all
+  // until #1092, which the #1089 fix made worse by giving the other two one.
+  // Same class, same rule, so this asserts the SAME pair of effects rather than
+  // a second convention.
+  await hoverPage.mouse.move(2, 2);
+  await hoverPage.waitForTimeout(150);
+  const why = await hoverPage.evaluate(
+    () => getComputedStyle(document.querySelector(".why-panel")).borderColor,
+  );
+  await hoverPage.locator(".why-panel").hover();
+  await hoverPage.waitForTimeout(250);
+  const whyHover = await hoverPage.evaluate(() => {
+    const node = document.querySelector(".why-panel");
+    const style = getComputedStyle(node);
+    return { cursor: style.cursor, border: style.borderColor, popup: document.querySelectorAll(".agent-tooltip").length };
+  });
+  check(
+    whyHover.popup === 1,
+    `why panel: hovering it opens the orchestrator transcript (${whyHover.popup})`,
+  );
+  check(
+    whyHover.cursor === "help",
+    `why panel: it says so with the same help cursor the consoles use (${whyHover.cursor})`,
+  );
+  check(
+    whyHover.border !== why,
+    `why panel: and the same border lift (${why} -> ${whyHover.border})`,
+  );
+  // The same VALUE, not merely some change: one tell has to mean one thing, and
+  // two modules drifting to two different hover colours is how it stops doing so.
+  check(
+    whyHover.border === hoveredCardBorder,
+    `why panel: the lift lands on the same colour the consoles use ` +
+      `(${whyHover.border} vs ${hoveredCardBorder})`,
+  );
+  await hoverCtx.close();
+}
+
 await browser.close();
 server.close();
 

--- a/src/pitwall/ui/src/features/agents/AgentCard.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentCard.tsx
@@ -56,6 +56,14 @@ export function AgentCard({
           "agent-card",
           idle ? "is-idle" : "",
           slot ? `slot-${slot}` : "",
+          // The hover affordance is gated on THIS, not on
+          // `:has(.agent-tooltip)`. The popup is portaled to `document.body`,
+          // so it is never a descendant of the card and that selector matched
+          // nothing for as long as it existed (#1089). `ContingenciesCard`
+          // already did it this way and the reason was written down in the
+          // stylesheet beside it; it was never carried back to the six
+          // consoles.
+          card.tooltip ? "has-tooltip" : "",
         ]
           .filter(Boolean)
           .join(" ")

--- a/src/pitwall/ui/src/features/agents/ContingenciesCard.tsx
+++ b/src/pitwall/ui/src/features/agents/ContingenciesCard.tsx
@@ -143,9 +143,10 @@ export function ContingenciesCard({ view }: { view: ContingenciesView }) {
  * One branch.
  *
  * The hover affordance is gated on a class this component sets, NOT on
- * `:has(.agent-tooltip)`. That selector is what the six consoles use and it has
- * never matched anything: the popup is portaled to `document.body`, so it is
- * not a descendant of the card whose hover it was meant to drive.
+ * `:has(.agent-tooltip)`: the popup is portaled to `document.body`, so it is
+ * not a descendant of the card whose hover it was meant to drive, and that
+ * selector matched nothing. The six consoles carried it until #1089 and now
+ * set their own class the same way.
  *
  * Hover changes the BACKGROUND only. This card sits in a flex column above
  * nothing and below PIT, so anything that changes its box moves a neighbour.

--- a/src/pitwall/ui/src/features/agents/WhyPanel.tsx
+++ b/src/pitwall/ui/src/features/agents/WhyPanel.tsx
@@ -27,7 +27,16 @@ export function WhyPanel({ view }: { view: OrchestratorView }) {
   const { anchor, props, hold } = useTooltipTarget(TOOLTIP_ID, view.why_detail !== null);
 
   return (
-    <section className="card why-panel" {...props}>
+    // `has-tooltip` is the same class the agent consoles set and the same rule
+    // paints it, because this module is a card carrying a transcript exactly as
+    // they are. It had no affordance at all until #1092: the narrative is
+    // clamped to three lines and the rest, including the DecisionMemory block,
+    // is only reachable through the popup, so a reader with no tell has no way
+    // to know the rest exists.
+    <section
+      className={`card why-panel${view.why_detail ? " has-tooltip" : ""}`}
+      {...props}
+    >
       <h2 className="band-title">WHY THIS CALL</h2>
 
       {view.why_detail && anchor ? (

--- a/src/pitwall/ui/src/styles/agents.css
+++ b/src/pitwall/ui/src/styles/agents.css
@@ -463,8 +463,19 @@
  * anywhere over it opens the transcript and nothing extra is drawn. An
  * earlier version added a visible "i" glyph and made only those 14 px
  * hoverable: a new element with no counterpart in the window being
- * ported. */
-.agent-card:has(.agent-tooltip) {
+ * ported.
+ *
+ * **Gated on a class `AgentCard` sets, never on `:has(.agent-tooltip)`.** That
+ * selector was here first and matched nothing for as long as it existed: the
+ * popup is portaled to `<body>` (`Tooltip.tsx:105`), so it is not a descendant
+ * of the card whose hover it was meant to drive, and neither of the two rules
+ * below ever fired (#1089).
+ *
+ * **Keyed on `.card`, not on `.agent-card`, so one tell means one thing.** The
+ * WHY module is a card carrying a tooltip exactly as the six consoles are, and
+ * it had no affordance at all until #1092. Giving it a third bespoke treatment
+ * would say "there is something here" in three different ways on one window. */
+.card.has-tooltip {
   cursor: help;
 }
 
@@ -477,12 +488,13 @@
  *
  * Border colour only: no size, no shadow, nothing that moves a neighbour. The
  * six cards sit in a grid and a card that grows on hover would shift the five
- * beside it. */
-.agent-card {
+ * beside it, and the WHY module sits in the band beside three siblings with the
+ * same constraint. */
+.card.has-tooltip {
   transition: border-color var(--motion-fast) var(--motion-ease);
 }
 
-.agent-card:has(.agent-tooltip):hover {
+.card.has-tooltip:hover {
   border-color: var(--qt-fg-3);
 }
 
@@ -928,10 +940,10 @@
   border-radius: 4px;
 }
 
-/* **Gated on a class the component sets, never on `:has(.agent-tooltip)`.** That
- * selector drives the six consoles' hover and has never matched anything: the
- * popup is portaled to `<body>`, so it is not a descendant of the card it was
- * meant to describe.
+/* **Gated on a class the component sets**, for the reason spelled out beside
+ * `.agent-card.has-tooltip` above: a portaled popup is not a descendant of its
+ * own anchor, so `:has()` cannot reach it. This card had the right shape first
+ * and the six consoles were brought to it in #1089.
  *
  * Background only. This card sits in a flex column under PIT, so anything that
  * changes its box moves a neighbour - the same reason the consoles' own hover is

--- a/tests/agents/test_no_shadowed_shared_defaults.py
+++ b/tests/agents/test_no_shadowed_shared_defaults.py
@@ -1,0 +1,134 @@
+"""No agent module may redefine a name ``_shared_defaults`` already exports (#1088).
+
+``race_state_builder`` defined ``DEFAULT_AIR_TEMP_C = 25.0`` and
+``DEFAULT_TRACK_TEMP_C = 35.0`` three lines below an import that pulled
+``DEFAULT_TOTAL_LAPS`` out of ``_shared_defaults``, where the same two names
+hold 24.6 and 34.7. Both pairs were live on the same path.
+
+**The name collision is the defect, not the two values.** #789 existed to
+collapse five fallback pairs into one and walked past this one, because a
+duplicate under a DIFFERENT name is visible at a glance while a duplicate under
+the SAME name reads as the import above it. So this asserts the shape that hid
+it rather than the numbers that differed: whether the two pairs should hold one
+value is a measurement question with its own before and after, and a test that
+demanded equality would have forced that decision as a drive-by.
+
+Parsed with ``ast``, never grepped. A grep for the constant names finds every
+import, every call site and every mention in a comment, and finds no
+assignment it was not already told to look for.
+
+Companion to ``test_weather_defaults_single_source.py``, which covers the other
+half: a module inventing a numeric fallback under no name at all.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_AGENTS = ROOT / "src" / "agents"
+_SHARED = _AGENTS / "_shared_defaults.py"
+
+
+def _module_level_assignments(path: Path) -> dict[str, ast.expr]:
+    """Every ``NAME = ...`` and ``NAME: T = ...`` bound at module scope.
+
+    Module scope only. A name bound inside a function or a class is scoped by
+    construction and cannot be mistaken for the import at the top of the file,
+    which is the confusion this guards.
+
+    **It descends into ``if`` and ``try`` bodies, which is not a detail.** A
+    name bound in a ``try/except ImportError`` fallback or under
+    ``if TYPE_CHECKING:`` still binds at module scope and still shadows the
+    import, and those are precisely where a value someone did not want reviewed
+    ends up. Reading only ``tree.body`` misses them, and the first version of
+    this guard did.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    bound: dict[str, ast.expr] = {}
+
+    def visit(body: list[ast.stmt]) -> None:
+        for node in body:
+            if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                if node.value is not None:
+                    bound[node.target.id] = node.value
+            elif isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        bound[target.id] = node.value
+            # Not FunctionDef or ClassDef: those open a new scope. These do not.
+            elif isinstance(node, ast.If):
+                visit(node.body)
+                visit(node.orelse)
+            elif isinstance(node, ast.Try):
+                visit(node.body)
+                visit(node.orelse)
+                visit(node.finalbody)
+                for handler in node.handlers:
+                    visit(handler.body)
+
+    visit(tree.body)
+    return bound
+
+
+def _shared_constant_names() -> set[str]:
+    """The public constants ``_shared_defaults`` exports, by their real names."""
+    names = {n for n in _module_level_assignments(_SHARED) if n.isupper()}
+    assert "DEFAULT_AIR_TEMP_C" in names, "the module this guard is about stopped exporting it"
+    return names
+
+
+_AGENT_MODULES = sorted(
+    p for p in _AGENTS.glob("*.py") if p.name not in {"_shared_defaults.py", "__init__.py"}
+)
+
+
+def test_the_shared_module_exports_the_names_this_guard_reads() -> None:
+    """Anchors the guard to something real, so it cannot pass on an empty set.
+
+    A guard whose comparison set is empty is green about nothing, which is the
+    failure mode this repo has a written lesson about.
+    """
+    assert len(_shared_constant_names()) >= 3
+
+
+@pytest.mark.parametrize("module", _AGENT_MODULES, ids=lambda p: p.name)
+def test_no_agent_module_shadows_a_shared_default(module: Path) -> None:
+    """A module-level name that also lives in ``_shared_defaults`` is a shadow.
+
+    Against the pre-#1088 tree this fails on ``race_state_builder.py`` naming
+    ``DEFAULT_AIR_TEMP_C`` and ``DEFAULT_TRACK_TEMP_C``. It stays green on the
+    fix because those became ``RACE_STATE_DEFAULT_*``: a second pair is allowed
+    to exist and to hold different numbers, it is just not allowed to wear the
+    shared module's name while doing it.
+    """
+    shared = _shared_constant_names()
+    shadowed = sorted(name for name in _module_level_assignments(module) if name in shared)
+    assert shadowed == [], (
+        f"{module.name} redefines {shadowed} at module level, and _shared_defaults already "
+        f"exports those names with different values. Import them, or give this module's own "
+        f"constants a distinct prefix so the divergence is visible at the definition."
+    )
+
+
+def test_the_second_pair_still_exists_under_its_own_name() -> None:
+    """The rename kept a real second pair; it did not quietly unify the values.
+
+    Which of 24.6/25.0 and 34.7/35.0 is right reaches a served prompt, so it is
+    a measurement, and #1088 deliberately did not decide it. This fails if a
+    later edit collapses the pair by importing the shared one instead, which
+    would be that decision made silently.
+    """
+    from src.agents._shared_defaults import DEFAULT_AIR_TEMP_C, DEFAULT_TRACK_TEMP_C
+    from src.agents.race_state_builder import (
+        RACE_STATE_DEFAULT_AIR_TEMP_C,
+        RACE_STATE_DEFAULT_TRACK_TEMP_C,
+    )
+
+    assert (RACE_STATE_DEFAULT_AIR_TEMP_C, RACE_STATE_DEFAULT_TRACK_TEMP_C) != (
+        DEFAULT_AIR_TEMP_C,
+        DEFAULT_TRACK_TEMP_C,
+    ), "the two pairs were unified without the before/after that decision owes"

--- a/tests/agents/test_race_state_builder.py
+++ b/tests/agents/test_race_state_builder.py
@@ -24,8 +24,8 @@ import pytest
 from src.agents._shared_defaults import DEFAULT_TOTAL_LAPS
 from src.agents.position_projection import GAP_UNKNOWN_FALLBACK_S
 from src.agents.race_state_builder import (
-    DEFAULT_AIR_TEMP_C,
-    DEFAULT_TRACK_TEMP_C,
+    RACE_STATE_DEFAULT_AIR_TEMP_C,
+    RACE_STATE_DEFAULT_TRACK_TEMP_C,
     UNKNOWN_COMPOUND,
     UNKNOWN_TYRE_LIFE,
     build_race_state,
@@ -140,8 +140,8 @@ def test_canonical_defaults_fire_when_keys_are_absent(caplog):
     assert rs.total_laps == DEFAULT_TOTAL_LAPS
     assert rs.compound == UNKNOWN_COMPOUND
     assert rs.tyre_life == UNKNOWN_TYRE_LIFE
-    assert rs.air_temp == DEFAULT_AIR_TEMP_C
-    assert rs.track_temp == DEFAULT_TRACK_TEMP_C
+    assert rs.air_temp == RACE_STATE_DEFAULT_AIR_TEMP_C
+    assert rs.track_temp == RACE_STATE_DEFAULT_TRACK_TEMP_C
     assert rs.rainfall is False
     assert rs.radio_msgs == []
     assert rs.rcm_events == []
@@ -188,8 +188,8 @@ def test_present_but_none_weather_lands_on_defaults_without_crashing():
     """
     state = _lap_state(weather={"air_temp": None, "track_temp": None, "rainfall": None})
     rs = build_race_state(state)
-    assert rs.air_temp == DEFAULT_AIR_TEMP_C
-    assert rs.track_temp == DEFAULT_TRACK_TEMP_C
+    assert rs.air_temp == RACE_STATE_DEFAULT_AIR_TEMP_C
+    assert rs.track_temp == RACE_STATE_DEFAULT_TRACK_TEMP_C
     assert rs.rainfall is False
 
 

--- a/tests/agents/test_weather_defaults_single_source.py
+++ b/tests/agents/test_weather_defaults_single_source.py
@@ -11,6 +11,7 @@ while a fourth literal grew back two files away, which is how this started.
 
 from __future__ import annotations
 
+import ast
 import re
 from pathlib import Path
 
@@ -34,6 +35,53 @@ _LITERAL_DEFAULT = re.compile(
     r"""(air_temp|track_temp|AirTemp|TrackTemp)["']?\s*,\s*(\d+\.?\d*)\s*\)""",
 )
 
+# The quantity names, for the AST check below.
+_QUANTITIES = ("air_temp", "track_temp", "AirTemp", "TrackTemp")
+
+
+def _ternary_literal_defaults(source: str) -> list[str]:
+    """Temperature values whose fallback is a bare number in a ternary `else`.
+
+    The shape the regex above cannot see, and the one that survived #789 in
+    `race_situation_agent`: `"AirTemp": float(...) if "AirTemp" in _wx else 28.0`.
+    A ternary `else` is not a call argument, so there is no closing paren after
+    the number and the pattern walks straight past it. The literal sat two lines
+    from a sibling that HAD been migrated, which is why nobody reading the block
+    noticed either (#1088).
+
+    **Parsed, not matched.** A regex for this needs the quantity name and the
+    `else` on one line, and it therefore misses both an integer literal
+    (`else 28`) and the multiline form that the very sibling line at
+    `race_situation_agent.py:1621-1624` is written in today. The tree does not
+    care where the newlines fall.
+
+    Keyed on the dict KEY or the assignment target naming a temperature, since
+    that is what says which quantity the fallback is for.
+    """
+    offenders: list[str] = []
+
+    def literal(node: ast.expr) -> str | None:
+        if isinstance(node, ast.IfExp) and isinstance(node.orelse, ast.Constant):
+            value = node.orelse.value
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                return str(value)
+        return None
+
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Dict):
+            for key, value in zip(node.keys, node.values):
+                named = isinstance(key, ast.Constant) and key.value in _QUANTITIES
+                found = literal(value) if named else None
+                if found is not None:
+                    offenders.append(f"{key.value}: ... else {found}")
+        elif isinstance(node, ast.Assign):
+            names = [t.id for t in node.targets if isinstance(t, ast.Name)]
+            found = literal(node.value)
+            for name in names:
+                if found is not None and any(q.lower() in name.lower() for q in _QUANTITIES):
+                    offenders.append(f"{name} = ... else {found}")
+    return offenders
+
 
 @pytest.mark.parametrize("module", _MODEL_FACING)
 def test_no_model_facing_agent_states_its_own_temperature_fallback(module):
@@ -43,6 +91,7 @@ def test_no_model_facing_agent_states_its_own_temperature_fallback(module):
     code = "\n".join(line.split("#", 1)[0] for line in source.splitlines())
 
     offenders = [m.group(0).strip() for m in _LITERAL_DEFAULT.finditer(code)]
+    offenders += _ternary_literal_defaults(source)
     assert offenders == [], (
         f"{module} states a numeric temperature fallback: {offenders}. Import "
         f"DEFAULT_AIR_TEMP_C / DEFAULT_TRACK_TEMP_C from _shared_defaults instead."

--- a/tests/surfaces/test_arcade_telemetry_span.py
+++ b/tests/surfaces/test_arcade_telemetry_span.py
@@ -693,16 +693,45 @@ def test_no_served_frame_carries_a_gear_the_car_cannot_select():
     128 and 1,840 above gear 8**. PITWALL's GEAR lane is locked to [0, 9], so each
     is a full-height spike.
 
-    Gear 0 is asserted PRESENT in the same breath. It is a real reading, and a
-    validity predicate written `g < 1 or g > 8` would erase 4,773 frames of a
-    stationary car while making the first assertion pass.
+    That the predicate stays ONE-SIDED is the other half, and it is asserted on
+    the function rather than on this race's frames. It used to be asserted here
+    as `neutral > 1000` served frames, which passed only against a cached pickle
+    that carried about 19 minutes of pre-race garage time. Melbourne 2025 puts
+    all 202,509 of its gear-0 samples OUTSIDE every lap window, so a correct
+    replay of it serves none, and the old assertion failed the moment the cache
+    was rebuilt (#1094). A test that can only pass against a stale artefact is
+    asserting the artefact, not the code.
     """
     frames = _active_frames(_melbourne_or_skip())
     gears = {frame.gear for frame in frames}
     assert max(gears) <= 8, f"gears above 8 are served: {sorted(g for g in gears if g > 8)}"
     assert min(gears) >= 0
-    neutral = sum(1 for frame in frames if frame.gear == 0)
-    assert neutral > 1000, f"only {neutral} neutral frames: is 0 being filtered as invalid?"
+
+
+def test_neutral_is_repaired_as_a_real_reading_not_as_an_impossible_one():
+    """A one-sided validity test, asserted on the repair itself.
+
+    This is what `neutral > 1000` was reaching for. Stated on the function it
+    guards, it needs no session, runs in CI where the pickle never exists, and
+    fails on the actual mistake: widening the predicate to `g < 1 or g > 8`,
+    which would erase a stationary car's reading while leaving every other
+    assertion in this file green.
+    """
+    import numpy as np
+
+    from src.arcade.data import _drop_impossible_gears
+
+    # 0 alongside a genuinely impossible 128, so the array takes the repair path
+    # rather than the untouched-return shortcut.
+    repaired = _drop_impossible_gears(np.array([0.0, 3.0, 128.0, 0.0, 5.0]))
+    assert list(repaired) == [0.0, 3.0, 3.0, 0.0, 5.0], (
+        f"neutral did not survive the repair: {list(repaired)}"
+    )
+
+    untouched = np.array([0.0, 0.0, 1.0])
+    assert list(_drop_impossible_gears(untouched)) == [0.0, 0.0, 1.0], (
+        "an all-valid array containing neutral was rewritten"
+    )
 
 
 def test_no_served_frame_carries_a_drs_code_the_feed_never_emits():

--- a/tests/surfaces/test_arcade_weather_panel.py
+++ b/tests/surfaces/test_arcade_weather_panel.py
@@ -1,0 +1,174 @@
+"""What the weather panel renders when a reading is missing (#1087).
+
+The panel used to format four fields straight out of ``weather.get(key,
+default)``. ``SessionLoader._weather_row_to_dict`` stores an explicit ``None``
+under the key when FastF1's sample is NaN, so the default never fired and
+``f"{None:.1f}"`` raised inside ``on_draw``, killing the pyglet render loop
+rather than degrading one row.
+
+Two things are asserted here and they are different claims. That no input
+raises is the crash guard. That an absent reading renders ``"N/A"`` rather than
+a plausible number is the sentinel guard, and it is the one that would catch a
+"fix" that swapped the crash for an invented 18.0 C.
+
+The rows are built by ``_weather_rows`` rather than by ``draw`` because
+``draw`` needs a GL context, and a check that needs a window to run is a check
+that does not run in CI. The split is the fix, not a testing convenience: the
+five expressions that crashed are all in the extracted function.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.arcade.overlays import _reading, _weather_rows
+
+# The shape the loader emits on a complete sample, for contrast with the rows
+# below. Every value is a float except the rain state, which is a string here
+# and `None` when its sample was dropped, the same as its five siblings.
+FULL_READING = {
+    "track_temp": 41.3,
+    "air_temp": 23.7,
+    "humidity": 55.0,
+    "wind_speed": 2.4,
+    "wind_direction": 180.0,
+    "rain_state": "DRY",
+}
+
+# The five NUMERIC fields, which are the ones that used to crash. `rain_state`
+# is nullable too and is covered on its own below, because its failure was the
+# opposite kind: it rendered "WET" rather than raising.
+#
+# Melbourne 2025 carries zero NaN across 178 weather rows, which is the whole
+# reason this was latent, so the input is built by hand rather than hunted for
+# in data/raw/.
+NULLABLE_FIELDS = (
+    "track_temp",
+    "air_temp",
+    "humidity",
+    "wind_speed",
+    "wind_direction",
+)
+
+
+def _labelled(rows: list[tuple[str, str]]) -> dict[str, str]:
+    return dict(rows)
+
+
+def test_a_complete_reading_still_renders_its_numbers() -> None:
+    """The fix must not turn a real measurement into a placeholder."""
+    values = _labelled(_weather_rows(FULL_READING))
+    assert values["Track"] == "41.3 C"
+    assert values["Air"] == "23.7 C"
+    assert values["Humidity"] == "55%"
+    assert values["Wind"] == "2.4 km/h S"
+    assert values["Rain"] == "DRY"
+
+
+@pytest.mark.parametrize("field", NULLABLE_FIELDS)
+def test_one_null_reading_does_not_raise(field: str) -> None:
+    """The crash guard, one field at a time.
+
+    Against the pre-#1087 code every case except ``wind_direction`` raises
+    ``TypeError: unsupported format string passed to NoneType.__format__``,
+    and ``wind_direction`` passes because ``_wind_dir`` already handled it.
+    That asymmetry is the defect: one field of six carried the fix.
+    """
+    weather = dict(FULL_READING, **{field: None})
+    _weather_rows(weather)
+
+
+@pytest.mark.parametrize(
+    ("field", "label"),
+    [
+        ("track_temp", "Track"),
+        ("air_temp", "Air"),
+        ("humidity", "Humidity"),
+        ("wind_speed", "Wind"),
+        ("wind_direction", "Wind"),
+    ],
+)
+def test_a_null_reading_renders_as_absent(field: str, label: str) -> None:
+    """The sentinel guard: absent data has to LOOK absent.
+
+    Asserting ``"N/A"`` appears in the row, not merely that nothing raised.
+    A fix that returned the old 18.0 C constant would satisfy the crash guard
+    above and fail here, which is the point: a display constant the reader
+    cannot tell apart from a measurement is the collision shape that produced
+    the bug in the first place.
+    """
+    weather = dict(FULL_READING, **{field: None})
+    assert "N/A" in _labelled(_weather_rows(weather))[label]
+
+
+def test_every_reading_null_at_once() -> None:
+    """A weather channel that dropped out entirely, not just one sample."""
+    weather = dict.fromkeys(NULLABLE_FIELDS)
+    weather["rain_state"] = "WET"
+    values = _labelled(_weather_rows(weather))
+    # No units on a quantity that was never measured, and ONE "N/A" on the wind
+    # row rather than two around a unit. That row reading "N/A km/h N/A" passed
+    # every string assertion here until the panel was actually drawn and looked at.
+    assert values["Track"] == "N/A"
+    assert values["Air"] == "N/A"
+    assert values["Humidity"] == "N/A"
+    assert values["Wind"] == "N/A"
+    assert values["Rain"] == "WET"
+
+
+def test_no_weather_at_all_claims_nothing() -> None:
+    """The empty dict, which is an older cache or a session with no weather.
+
+    Every field including the rain state, because "DRY" on a session whose
+    weather was never loaded is a claim about the track rather than a display
+    default. Before #1087 this rendered 45.0 C / 18.0 C / 55% / DRY.
+    """
+    values = _labelled(_weather_rows({}))
+    assert set(values) == {"Track", "Air", "Humidity", "Wind", "Rain"}
+    assert all("N/A" in value for value in values.values())
+
+
+def test_a_dropped_rainfall_sample_does_not_announce_rain() -> None:
+    """The sixth field, and the only one whose failure was silent.
+
+    ``bool(float("nan"))`` is ``True``, so before the guard a NaN ``Rainfall``
+    read as "WET" and the panel announced rain on a dry race. The five numeric
+    fields crashed on a dropped sample, which is loud; this one asserted the
+    opposite of the truth and kept rendering.
+
+    Driven through the loader rather than the panel, because the panel was
+    never where this lived: ``_weather_row_to_dict`` is what decides, and no
+    test reached it until the opening gate found the row.
+    """
+    import pandas as pd
+
+    from src.arcade.data import SessionLoader
+
+    to_dict = SessionLoader._weather_row_to_dict
+    complete = {
+        "AirTemp": 23.7,
+        "TrackTemp": 41.3,
+        "Humidity": 55.0,
+        "WindSpeed": 2.4,
+        "WindDirection": 180.0,
+    }
+    dropped = to_dict(None, pd.Series(dict(complete, Rainfall=float("nan"))))
+    assert dropped["rain_state"] is None, "a dropped rainfall sample must not assert a state"
+    assert _labelled(_weather_rows(dropped))["Rain"] == "N/A"
+
+    for stored, expected in ((True, "WET"), (False, "DRY")):
+        real = to_dict(None, pd.Series(dict(complete, Rainfall=stored)))
+        assert real["rain_state"] == expected, "a real reading still renders itself"
+
+
+def test_the_helper_keeps_its_format_spec() -> None:
+    """A present value is formatted, not stringified.
+
+    Guards the one way the coalescing could be written and still be wrong:
+    returning ``str(value)`` would render 23.7000000001 for a float that came
+    off a resample, and every assertion above would still be about "N/A".
+    """
+    assert _reading(23.75, ".1f", " C") == "23.8 C"
+    assert _reading(55.4, ".0f", "%") == "55%"
+    # The unit rides with the number, so an absent reading carries neither.
+    assert _reading(None, ".1f", " C") == "N/A"

--- a/tests/surfaces/test_diagrams_no_retired_surface.py
+++ b/tests/surfaces/test_diagrams_no_retired_surface.py
@@ -1,0 +1,133 @@
+"""No diagram outside the two marked legacy names a retired surface (#1090).
+
+Three `.drawio` files still drew the PySide6 pair PITWALL replaced in sprint 7,
+and one of them spawned `src.arcade.telemetry`, a module that does not exist at
+all. They survived a full documentation sweep because a diagram is read as a
+picture: nothing about a stale box looks stale, and the two files that WERE
+retired had been renamed, which made the folder look audited.
+
+**Labels are parsed out of the `value=` attributes, never grepped from the raw
+XML.** The diagrams README already records why, and the rule is the repo's own:
+a grep counts matches inside `style=` attributes and colour names, so it
+over-reports a file whose only hit is a hex code and under-reports a defect
+spelled some other way. This is the parse half; a claim about what a diagram
+MEANS still has to be checked against the code by hand.
+
+The vocabulary below is deliberately narrow. It catches the retired GUI toolkit
+by name, which is the drift that actually happened twice here, and it makes no
+attempt to judge whether a diagram is otherwise current.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_DIAGRAMS = ROOT / "documents" / "dev_docs" / "diagrams"
+
+# Retired with the Qt windows in sprint 7. `Qt` alone is not here: it appears in
+# legitimate prose about the port's history, and a rule that fires on it would
+# be turned off rather than obeyed.
+_RETIRED = (
+    "PySide6",
+    "QApplication",
+    "QMainWindow",
+    "QThread",
+    "pyqtSignal",
+    "src.arcade.telemetry",
+)
+
+# The two files kept ON PURPOSE as a record of surfaces that no longer exist.
+# Their names carry the marker, so the exemption is visible in the folder
+# listing rather than only here.
+_LEGACY_SUFFIX = "_legacy.drawio"
+
+
+def _tab_names(path: Path) -> list[str]:
+    """The `<diagram name=...>` page tabs, which survive a compressed save."""
+    raw = path.read_text(encoding="utf-8")
+    return [html.unescape(n) for n in re.findall(r'<diagram[^>]*name="([^"]*)"', raw)]
+
+
+def _labels(path: Path) -> list[str]:
+    """Every rendered string in one diagram: cell values plus the tab name.
+
+    A box that SAYS it is retired is dropped, because that is the diagram doing
+    the right thing. `tcp_broadcast_dataflow` draws the dead Qt telemetry window
+    beside the live subscriber precisely so the reader can see what was replaced,
+    and its own label opens with the word. Reading that as a defect would push
+    the honest picture out to make the check green.
+    """
+    raw = path.read_text(encoding="utf-8")
+    values = [html.unescape(v) for v in re.findall(r'value="([^"]*)"', raw)]
+    return [text for text in values + _tab_names(path) if "RETIRED" not in text]
+
+
+_ALL = sorted(_DIAGRAMS.rglob("*.drawio"))
+_CURRENT = [p for p in _ALL if not p.name.endswith(_LEGACY_SUFFIX)]
+_LEGACY = [p for p in _ALL if p.name.endswith(_LEGACY_SUFFIX)]
+
+
+def test_the_folder_is_where_this_guard_thinks_it_is() -> None:
+    """A guard over an empty file list is green about nothing."""
+    assert len(_CURRENT) >= 10, f"only found {len(_CURRENT)} current diagrams under {_DIAGRAMS}"
+
+
+@pytest.mark.parametrize("diagram", _CURRENT, ids=lambda p: p.name)
+def test_no_current_diagram_names_the_retired_qt_surface(diagram: Path) -> None:
+    """Against the pre-#1090 tree this fails on three files.
+
+    `subprocess_launch_sequence` (step 7's `QApplication + MainWindow` and a
+    step 6b spawning `src.arcade.telemetry`), `tcp_broadcast_dataflow` (the live
+    subscriber box), and `system_architecture` (`PySide6 dashboard`).
+    """
+    labels = _labels(diagram)
+    # draw.io can save a diagram COMPRESSED, as one base64 blob with no `value=`
+    # attribute in sight. The check would then read nothing and pass, which is
+    # the empty-set green this repo has a written lesson about, and it would do
+    # it silently on a file someone merely re-saved from the app.
+    #
+    # Counted on CELL values, not on `_labels`: a compressed file still exposes
+    # its `<diagram name=...>` tab, so "at least one label" is satisfied by the
+    # page name alone. Asserting the wrong one of the two would have closed this
+    # hole on paper and left it open.
+    cells = [text for text in labels if text not in _tab_names(diagram)]
+    assert cells, (
+        f"{diagram.name} exposes no cell labels, only its tab name. It is probably saved "
+        f"compressed; re-save it as 'Uncompressed' so its text stays readable to a diff and "
+        f"to this check."
+    )
+    text = "\n".join(labels)
+    named = sorted({word for word in _RETIRED if word in text})
+    assert named == [], (
+        f"{diagram.name} still names {named}. Either redraw it against the code, or rename it "
+        f"with the {_LEGACY_SUFFIX} marker if it is being kept as a record of a dead surface."
+    )
+
+
+def test_the_qt_legacy_diagram_still_carries_what_makes_it_legacy() -> None:
+    """The exemption is real, not a spelling nobody checks.
+
+    Without this, renaming a file to `*_legacy.drawio` would exempt it whatever
+    it contains, and the guard above could be satisfied by moving a stale
+    diagram rather than fixing it.
+
+    Only the Qt one, named by its filename. The other legacy file is the
+    Streamlit page tree, which is a different dead surface and names none of
+    the words above; asserting the vocabulary against it would be asserting the
+    wrong thing about the right file.
+    """
+    qt_legacy = [p for p in _LEGACY if "qt" in p.stem.lower()]
+    assert len(qt_legacy) == 1, (
+        f"expected one Qt legacy diagram, found {[p.name for p in qt_legacy]}"
+    )
+    text = "\n".join(_labels(qt_legacy[0]))
+    named = sorted({word for word in _RETIRED if word in text})
+    assert named, (
+        f"{qt_legacy[0].name} carries the legacy marker but names no retired Qt surface; "
+        f"either it was redrawn and should lose the marker, or the marker is wrong"
+    )


### PR DESCRIPTION
## What

Fixes the four behaviour defects a writing sweep found and filed rather than touching, so that PR
could stay a prose change: #1087, #1088, #1089, #1090. Each gets a guard that was watched failing
against the unfixed code before it was trusted.

Auditing those fixes turned up three more defects, filed as #1092, #1093 and #1094, and all three
are fixed here too rather than deferred.

## Why

### #1087, the arcade weather panel raised on a dropped sample

`WeatherPanel.draw` formatted four fields with `weather.get(key, default):.1f`.
`SessionLoader._weather_row_to_dict` stores an explicit `None` UNDER THE KEY when FastF1's reading
is NaN, so the default never fires and `f"{None:.1f}"` raises inside `on_draw`, which kills the
render loop rather than degrading one row. `_wind_dir` already returned "N/A" on `None`, so one
field of six carried the fix.

Latent on the shipped data: Melbourne 2025 has 0 NaN across 178 weather rows.

Absent readings now render "N/A" rather than the old 45.0 C / 18.0 C / 55% constants. A displayed
number the reader cannot tell apart from a measurement is the sentinel-collision shape that
produced the bug.

### #1088, two same-named weather defaults holding different values

`_shared_defaults.py:84-85` holds 24.6 / 34.7. `race_state_builder.py:95-96` held 25.0 / 35.0 under
the same two names, three lines below an import pulling `DEFAULT_TOTAL_LAPS` out of that same
module. Both live on the same path.

#789 existed to collapse five fallback pairs into one and walked past this one, because a duplicate
under a different name is visible at a glance while a duplicate under the same name reads as the
import above it.

**Renamed, not unified.** Which value wins reaches a served prompt, so that is a measurement with
its own before and after, not a cleanup riding along with a rename. The second pair keeps 25.0 /
35.0 as `RACE_STATE_DEFAULT_AIR_TEMP_C` / `RACE_STATE_DEFAULT_TRACK_TEMP_C`.

### #1089, the agent cards' hover affordance was dead CSS

`.agent-card:has(.agent-tooltip)` cannot match: `Tooltip` renders through `createPortal` to
`document.body`, so the popup is never a descendant of the card. Neither the help cursor nor the
border lift ever fired, and ten lines of comment above the two rules described them as the shipped
solution, so a reader checking whether the affordance existed read that and stopped.

`ContingenciesCard` already had the right shape, gated on a class it sets, with the reason written
in the stylesheet beside it. The lesson was learned once and never carried back to the six consoles.

### #1090, three diagrams still drew the retired Qt surface

`subprocess_launch_sequence`, `tcp_broadcast_dataflow` and `system_architecture` were not marked
legacy and still named the PySide6 pair PITWALL replaced.

## How

### #1087

`overlays.py` gains `_reading(value, spec, unit)` and `_weather_rows(weather)`. The split is the fix, not
a testing convenience: the five expressions that crashed all live in the extracted function, and
`draw` needs a GL context, so a check on the rendered text could not otherwise run in CI.

Three comments described the opposite mechanism and moved with the fix: `data.py:134-136`,
`_weather_row_to_dict`'s docstring, and `app.py:1041-1043`. All three claimed the panel's own
`.get(key, default)` calls kept the old constants "instead of raising".

### #1088

`race_state_builder`'s pair renamed, call sites at `:376-377`, the module docstring, and
`tests/agents/test_race_state_builder.py` updated with it. The comment above the constants now says
why two pairs exist and why the rename moves no number.

Also folded in: `race_situation_agent.py:1617`'s bare `else 28.0` AirTemp literal, two lines from
siblings #789 did migrate, now `DEFAULT_AIR_TEMP_C`.

**This one moves a value, 28.0 to 24.6.** It reaches only `run()`, the FastF1-session path, which
is called through `run_race_situation_agent` and then `run_strategy_orchestrator`, and that has no
caller in any `.py` in the repo. Every shipped surface (CLI, arcade, backend, MCP tools, bench)
uses the `_from_state` variants. So it moves a number on a notebook-driven session loaded without
weather, and nowhere else.

Why #789's own test could not see either instance:

- its regex matches a literal in the DEFAULT POSITION of a call, `name, number)`. A ternary `else`
  has no closing paren after the number, so `else 28.0` was invisible to it.
- its module list never included `race_state_builder.py`, and the builder's pair are module-level
  assignments rather than call-site literals, so scanning the file would not have hit them either.

### #1089

`AgentCard` sets `has-tooltip` when it renders a tooltip; both rules gate on the class. The comment
block moved with the fix, and so did two others that described the dead selector in the present
tense as what the six consoles use (`agents.css:931-934`, `ContingenciesCard.tsx:145-148`).

### #1090

Redrawn against the code, not against a sibling diagram, which is how two more stale messages
turned up in `subprocess_launch_sequence` than the issue named:

- step 6b spawned `src.arcade.telemetry`, **a module that does not exist**. `app.py:501` has the
  only `subprocess.Popen` and it spawns `python -m src.pitwall`.
- step 14 sent a second TCP tick to that process. `src/pitwall/__main__.py` builds one
  `ArcadeStreamClient` for both windows; there is one socket and one seq.

Both arrows now start at the PITWALL column. Step 7 became `PitwallHost(ArcadeStreamClient)`, step
15's "tabs" went with the reasoning panel in #1020, and the self-call's `pyqtSignal.emit` became
the pywebview `get_tick`.

One claim in #1090 was already closed on `dev`: the `5.4-mini` "candidate" wording went in
`85cd199a`, one of the prose sweep's own commits, after the issue was filed. `strategy_orchestrator.py`
sets it at `:138`, not `:139`.

### #1092, #1093

`WhyPanel` is a third portaled-tooltip target and `.why-panel` had no cursor and no hover rule at
all, so once #1089 gave the six consoles a tell, the WHY module was the only card carrying a
transcript that did not advertise it. It now sets the same `has-tooltip` class, and both rules moved
from `.agent-card` to `.card`, so one tell means one thing across the window instead of a third
bespoke treatment. The smoke asserts the WHY module lands on the same hovered colour as the
consoles, not merely that something changed.

`src/pitwall/__main__.py`'s docstring said the arcade spawns it "exactly the way the Qt dashboard is
today". That surface was retired in sprint 7 and this module replaced it; `src/arcade/dashboard/`
now holds nothing but a `__pycache__`.

## Found while auditing the fixes, and fixed here

Both came from gates over this branch, and both are cases of a fix's own comment covering something.

1. **A NaN `Rainfall` announced rain on a dry race.** `data.py:869` read
   `"WET" if bool(row.get("Rainfall")) else "DRY"`, and `bool(float("nan"))` is `True`. The five
   numeric fields crashed on a dropped sample, which is loud; this one asserted the opposite of the
   truth and kept rendering. It now takes the same `pd.notna` guard as its siblings.

   The comment #1087 introduced said the loader "cannot emit `None`" for this field. True as
   written, and it papered over the fact that it emitted a wrong value instead.

2. **The rewritten #1088 comment carried two claims measurement refutes.** It said "track median
   exactly 35.0 C" and that the 2025 featured parquet carries no weather columns. Measured today:
   air 24.7 / track 35.5 over 2023+2024, air 24.6 / track 34.7 over 2023-2025, and the 2025 parquet
   does carry them. Both figures come from #784's F10, chosen on 2026-08-02 against a pre-dedup
   dataset; the comment now says that and points at the design doc rather than restating a median
   as a present-tense fact.

Also corrected: `_shared_defaults.py`'s `reading_or_default` docstring, which described the
pre-#789 world in the present tense ("the agents disagree on the fallback temperatures"), and now
also names the two per-caller rainfall numbers it had wrongly said did not exist.

3. **`CACHE_VERSION` was not bumped and had to be.** `config.py:169-175` states the obligation four
   lines above the constant: if the bytes a rebuild would produce differ from the bytes on disk, the
   string moves in the SAME commit, or the fix reaches nobody who already has a pickle. The Rainfall
   change alters the pickled `rain_state` for any session with a NaN weather row, which is precisely
   the session the fix exists for. Bumped to v15.

Three guards shipped here had holes, proven by execution and closed:

- the shadow guard read only `tree.body`, so a name bound in a `try/except ImportError` fallback or
  under `if TYPE_CHECKING:` shadowed the import invisibly. It now walks `if` and `try` bodies, and
  still refuses to descend into function or class scopes.
- the ternary check was a regex needing the quantity name and the `else` on one line, so it missed
  an integer literal (`else 28`) and the multiline form that a sibling line uses today. Replaced
  with an `ast.IfExp` walk.
- the diagram guard passed on a draw.io file saved COMPRESSED, which exposes no `value=` attributes
  at all. It now requires cell labels, counted separately from the page tab, because a compressed
  file still exposes its tab name and asserting on that would have closed the hole on paper only.

## Out of scope

- **Whether the two weather pairs should hold one value.** That is the measurement #1088
  deliberately did not make.

Nothing else. The three defects this branch's own gates turned up are fixed here rather than
deferred: **#1092** gives the WHY module the same hover tell the consoles have, keyed on `.card` so
one tell means one thing across the window; **#1093** stops the entry point's docstring naming the
Qt dashboard in the present tense; **#1094** is covered under Checks.

## Checks

Executed, not assumed.

| suite | before | after |
|---|---:|---:|
| `tests/surfaces` | 295 | 331 |
| `tests/surfaces` + `tests/agents` | | 590 passed, 13 skipped |
| `smoke-agents` | 116 | 133 |
| `smoke-data` | 373 | 373 |

`uvx ruff@0.15.22 check .` and `format --check .` both clean, 189 files.

**Every guard was watched RED against the unfixed code**, with a mutant that compiles:

- #1087: the four pre-fix format expressions restored inside `_weather_rows`. 10 of 14 fail,
  `TypeError` on the crash cases and `AssertionError` on the sentinel cases. `wind_direction` passes
  both ways, which is the asymmetry the defect was.
- Rainfall: the pre-fix line restored. `assert 'WET' is None`.
- #1088: both names reverted. The AST guard reports
  `shadowed = ['DEFAULT_AIR_TEMP_C', 'DEFAULT_TRACK_TEMP_C']`. The guard asserts the SHAPE, not the
  values, because demanding equality would force the measurement decision as a drive-by.
- The `28.0` fold-in: the literal restored. The new ternary pattern catches it where #789's own
  pattern could not.
- #1089: `:has()` restored and the class removed, then rebuilt. Exactly 10 failures, the five
  tooltip-carrying cards times two checks, with the popup on screen, cursor `auto` and the border
  measured unchanged at `rgb(45,45,58)`. RAG, which has no tooltip, passes both ways.
- #1090: `git checkout dev -- documents/dev_docs/diagrams/`. Exactly the three files in the issue.

**The real paths, driven rather than mocked.**

- **The weather loader, on shipped data.** All 178 rows of
  `data/raw/2025/Melbourne/weather.parquet` through `_weather_row_to_dict` and `_weather_rows`: 890
  label/value pairs, no exception. A real row renders
  `Track 19.1 C · Air 15.9 C · Humidity 76% · Wind 1.9 km/h WNW · Rain DRY`. Injecting a NaN into
  each of the six columns in turn degrades that column and leaves the other five reading their real
  values.
- **The panel, in a real arcade window.** `WeatherPanel.draw` called against a live GL context for a
  complete reading, one dropped sample and no weather at all. None raised, `bottom_y` is 120 in all
  three, and the PNGs were looked at.
- **`build_race_state`, for real.** A real reading passes through as 22.0 / 31.5; an absent one and
  a present-but-`None` one both land on 25.0 / 35.0. The rename moves nothing.
- **The line the `28.0` fold-in changed, executed on a real FastF1 session.** Melbourne 2025 loaded,
  `RaceSituationAgent.run()` driven with `_run_core` stubbed so no provider call is made. With the
  AirTemp column present the served value is the real 14.43; with it dropped the served value is
  24.6, where it was 28.0. Both branches observed, not read off the source.
- **The hover affordance, in a real browser on the real bundle.** Border `rgb(45, 45, 58)` at rest
  and `rgb(156, 163, 175)` under the pointer with `cursor: help`; the one card with no transcript
  stays at `rgb(45, 45, 58)`. Screenshotted and looked at.

**Looking at it caught something every assertion passed on.** The drawn panel rendered the wind row
as `N/A km/h N/A` when both wind readings were absent, and put a unit on quantities that had no
value (`N/A C`, `N/A%`). Fifteen tests were green on those exact strings. The unit now rides with
the number, so an absent reading carries neither, and the wind row collapses to a single `N/A` only
when both of its readings are missing. A known speed with an unknown bearing still says so.

Not exercised: the pywebview windows themselves (the smoke and the screenshots use Chromium against
the same built bundle), and the redrawn diagrams have been parsed and their labels checked against
the code, but not opened in draw.io.

**The cache bump exposed a test asserting a stale artefact, and that is #1094, fixed here.**
Rebuilding at v15 gave 2,505,580 frames against the v14 pickle's 3,083,460, and zero gear-0 frames
against 307,249, which reads as catastrophic loss. Measured across all 20 drivers it is the
opposite: of 202,509 gear-0 samples in `session.car_data`, **none falls inside any lap window**, and
none of the 1,059 laps' telemetry carries one. They are pre-race garage and grid samples, mean speed
0.6 km/h. The race lap span is 5,011.1 s, which is 125,278 frames at 25 Hz, and the rebuild produced
125,279. The rebuild is right to within one frame; the v14 pickle carried about 19 minutes that are
not race laps.

`test_no_served_frame_carries_a_gear_the_car_cannot_select` asserted `neutral > 1000`, which could
only pass against such a pickle, and it skips whenever the cached version does not match. So it had
been green for as long as nobody rebuilt. Its intent, that the validity predicate stays one-sided
because gear 0 is a real reading, now sits on `_drop_impossible_gears` itself: no session needed, it
runs in CI where the pickle never exists, and it was watched failing against a deliberately
two-sided predicate. The comment above `_MAX_GEAR` claimed "1,400 raw samples", which matches
neither figure, and now carries the measured 202,509 with the reason none of them reaches a replay.

With a v15 cache present, `tests/surfaces` runs **331 passed, 0 skipped**: the six tests that had
been skipping on the version mismatch now execute.

Closes nothing. Issues on this project close when the work reaches `main` with green CI, and this
lands on `dev`.

Refs #1087, #1088, #1089, #1090.

Also closes #1092, #1093 and #1094, which this branch's own gates opened.
