### PR TITLE
fix(arcade): collapse the controls legend where it would cover a driver card

### DIFF
--- a/docs/pages/arcade-quick-start.md
+++ b/docs/pages/arcade-quick-start.md
@@ -87,10 +87,17 @@ Hotkeys handled by `F1ArcadeView.on_key_press`:
 | `D` | show / hide the DRS zones on the track |
 | `B` | show / hide the progress bar |
 | `A` | show / hide the eighteen non-featured cars |
+| `C` | show / hide the controls list itself |
 | `Escape` | close the window |
 
 `Escape` quits rather than returning to the menu, and it does so whether or not
 `--viewer` was used at launch.
+
+The controls list collapses to a single `C  Controls` line when the column above
+it has no room, which at the default 1280x720 is any session with a rival: the
+list needs 154 px and the two driver cards leave 146. It used to draw over the
+second card instead. `C` opens it anyway where it does not fit, on the grounds
+that a list you asked for is one you can dismiss with the same key.
 
 ## Known limitations
 

--- a/src/arcade/app.py
+++ b/src/arcade/app.py
@@ -914,11 +914,28 @@ class F1ArcadeView(arcade.View):
 
         if self._show_progress_bar:
             self._progress_bar.draw(self.window.width, frame_idx)
-        self._controls_legend.draw()
+        # The legend decides between the full list and a one-line hint from the
+        # room the cards above it actually left, because at the default 720 with
+        # two drivers the column leaves 146 px and the list needs 154, so it used
+        # to draw straight over the rival card (#1096). Measured from the LOWEST
+        # card rather than from a constant: the stack's depth depends on whether
+        # a rival was chosen.
+        lowest_card = self._driver_info_main.top_y - self._driver_info_main.height
+        if self._driver_info_rival is not None:
+            lowest_card = min(
+                lowest_card,
+                self._driver_info_rival.top_y - self._driver_info_rival.height,
+            )
+        self._controls_legend.draw(space_below=lowest_card - self._controls_legend.bottom)
         self._update_hud(frame)
 
     def on_key_press(self, symbol: int, modifiers: int) -> None:
-        if symbol == arcade.key.ESCAPE:
+        if symbol == arcade.key.C:
+            # Force-open overrides the room check, so a user who asks for the
+            # list gets it even where it overlaps: they summoned it and the same
+            # key dismisses it.
+            self._controls_legend.toggle()
+        elif symbol == arcade.key.ESCAPE:
             self.window.close()
         elif symbol == arcade.key.SPACE:
             self._is_paused = not self._is_paused

--- a/src/arcade/overlays.py
+++ b/src/arcade/overlays.py
@@ -883,12 +883,59 @@ class ProgressBar:
         arcade.draw_rect_filled(arcade.XYWH(sx + w / 2, self.bottom + self.height + 5, w, 5), color)
 
 
+# Row pitch and the header's own band, shared by the span helper and the draw
+# loop so the two cannot disagree about how tall the legend is.
+LEGEND_ROW_PITCH: Final[int] = 14
+LEGEND_HEADER_BAND: Final[int] = 18
+
+
+def legend_span(row_count: int) -> int:
+    """Pixels the legend occupies above its own bottom edge.
+
+    Data, not a drawing side effect, because the decision below has to be made
+    before anything is drawn and has to be checkable without a GL context.
+    """
+    return row_count * LEGEND_ROW_PITCH + LEGEND_HEADER_BAND
+
+
+def legend_mode(space_below: int | None, row_count: int, *, forced_open: bool = False) -> str:
+    """``"full"`` or ``"hint"``, from the room the column actually left.
+
+    **The whole point of this function is that it is pure** (#1096). The
+    geometry it decides on lives between GL calls in ``on_draw``, so a check on
+    the drawn result needs a window, and a check that needs a window does not
+    run in CI. `_weather_rows` was split out for the same reason.
+
+    ``space_below`` is the gap between the legend's bottom edge and the lowest
+    thing already drawn above it, or ``None`` when the caller has nothing above
+    to measure against. The full legend spans 154 px and the column leaves 146
+    at the default 720 with two drivers, so it cannot fit there at ANY anchor,
+    which is why clamping it under the lowest card was not the fix.
+
+    ``forced_open`` wins: a user who pressed the key asked for the panel and can
+    dismiss it again, so an overlap they summoned is theirs to make.
+    """
+    if forced_open:
+        return "full"
+    if space_below is None:
+        return "full"
+    return "full" if space_below >= legend_span(row_count) else "hint"
+
+
 class ControlsLegend:
-    """Static bottom-left cheat sheet for keyboard bindings.
+    """Bottom-left cheat sheet for keyboard bindings, collapsible.
 
     Uses the same ACCENT title / TERTIARY body convention as the other
     panels so the legend reads as part of the UI instead of a debug
-    overlay."""
+    overlay.
+
+    **It collapses to one line when the column above it has no room** rather
+    than drawing over the driver card, which is what it used to do at the
+    default window height with two drivers. The hint line names the key that
+    brings it back, so nothing is hidden without saying where it went."""
+
+    HINT_KEY: Final[str] = "C"
+    HINT_TEXT: Final[str] = "Controls"
 
     LINES: Final[tuple[tuple[str, str], ...]] = (
         ("SPACE", "Pause / Resume"),
@@ -899,12 +946,16 @@ class ControlsLegend:
         ("A", "Toggle all 20 cars"),
         ("D", "Toggle DRS zones"),
         ("B", "Toggle progress bar"),
+        ("C", "Toggle this list"),
         ("ESC", "Close"),
     )
 
     def __init__(self, x: int = LEGEND_X, bottom: int = LEGEND_BOTTOM) -> None:
         self.x = x
         self.bottom = bottom
+        # Set by the view's `C` branch. False means "decide from the room",
+        # which is the state the window opens in.
+        self.forced_open = False
         self._header = arcade.Text(
             "CONTROLS",
             x,
@@ -943,17 +994,58 @@ class ControlsLegend:
             )
             for _, desc in self.LINES
         ]
+        # Pre-allocated like every other Text in this module: creating one
+        # inside draw() leaks a glyph texture per frame.
+        self._hint_key = arcade.Text(
+            self.HINT_KEY,
+            0,
+            0,
+            TEXT_PRIMARY,
+            10,
+            bold=True,
+            font_name=FONT_BODY,
+            anchor_x="left",
+            anchor_y="bottom",
+        )
+        self._hint_desc = arcade.Text(
+            self.HINT_TEXT,
+            0,
+            0,
+            TEXT_TERTIARY,
+            10,
+            font_name=FONT_BODY,
+            anchor_x="left",
+            anchor_y="bottom",
+        )
 
-    def draw(self) -> None:
+    def toggle(self) -> None:
+        self.forced_open = not self.forced_open
+
+    def draw(self, space_below: int | None = None) -> None:
+        """Draw the full list, or the one-line hint when there is no room.
+
+        ``space_below`` is how much vertical room the column above left free.
+        ``None`` keeps the old unconditional behaviour, which is what a caller
+        with nothing above the legend wants.
+        """
+        if legend_mode(space_below, len(self.LINES), forced_open=self.forced_open) == "hint":
+            self._hint_key.x = self.x
+            self._hint_key.y = self.bottom
+            self._hint_key.draw()
+            self._hint_desc.x = self.x + 70
+            self._hint_desc.y = self.bottom
+            self._hint_desc.draw()
+            return
+
         y = self.bottom
         rows = list(zip(self._key_texts, self._desc_texts))
         for i, (key, desc) in enumerate(reversed(rows)):
             key.x = self.x
-            key.y = y + i * 14
+            key.y = y + i * LEGEND_ROW_PITCH
             key.draw()
             desc.x = self.x + 70
-            desc.y = y + i * 14
+            desc.y = y + i * LEGEND_ROW_PITCH
             desc.draw()
         self._header.x = self.x
-        self._header.y = self.bottom + len(self.LINES) * 14 + 6
+        self._header.y = self.bottom + len(self.LINES) * LEGEND_ROW_PITCH + 6
         self._header.draw()

--- a/tests/surfaces/test_arcade_legend_fit.py
+++ b/tests/surfaces/test_arcade_legend_fit.py
@@ -1,0 +1,164 @@
+"""The controls legend never draws over the driver cards (#1096).
+
+At the default 1280x720 with two drivers the left column leaves 146 px below
+the lowest card and the full legend spans 154, so it drew straight over the
+rival card's DRS, Compound and Ahead rows. Two drivers is what the menu opens
+with, so this was the out-of-the-box first frame.
+
+**Asserted on a pure function, not on a rendered window.** The geometry lives
+between GL calls in ``on_draw``, so a check on the drawn result needs a display,
+and a check that needs a display does not run in CI. ``_weather_rows`` was split
+out for exactly this reason and this file follows it. The one thing a window
+could add, that the pixels really differ, was measured once by hand when the
+defect was found; what has to hold from here is the decision.
+
+The heights below bracket the crossover rather than sampling near it: 600 and
+660 are smaller than the default, 720 is the default, and 788 upward is where
+the full legend genuinely fits.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.arcade.config import (
+    DRIVER_BOX_GAP,
+    DRIVER_BOX_HEIGHT,
+    LEGEND_BOTTOM,
+    WEATHER_ROW_GAP,
+    WEATHER_TOP_OFFSET,
+)
+from src.arcade.overlays import ControlsLegend, legend_mode, legend_span
+
+# The window heights a user can actually produce. The window is resizable with
+# no minimum, so the small ones are reachable by dragging, not hypothetical.
+HEIGHTS = (600, 660, 720, 800, 900, 1080)
+
+_WEATHER_ROWS = 5
+
+
+def _weather_bottom(window_height: int) -> int:
+    """What ``WeatherPanel.draw`` leaves in ``bottom_y``.
+
+    Mirrors its last three lines (``overlays.py``: ``y = top_y - 32``, then one
+    ``y -= WEATHER_ROW_GAP`` per row, then ``bottom_y = y + WEATHER_ROW_GAP -
+    10``) rather than the panel's outer box, which sits 18 px lower. A first
+    draft of this file used the box height and was 18 px pessimistic at every
+    height, which would have collapsed the legend at 800 where it fits by 12.
+    The runtime never had that bug: ``on_draw`` reads the real attribute.
+    """
+    top_y = window_height - WEATHER_TOP_OFFSET
+    y = top_y - 32 - _WEATHER_ROWS * WEATHER_ROW_GAP
+    return y + WEATHER_ROW_GAP - 10
+
+
+def _lowest_card_bottom(window_height: int, *, has_rival: bool) -> int:
+    """Bottom edge of the last card in the left column, mirroring ``on_draw``.
+
+    The cards chain off the weather panel's bottom, so the whole column
+    translates 1:1 with the window height and only the card COUNT changes.
+    """
+    main_bottom = _weather_bottom(window_height) - DRIVER_BOX_GAP - DRIVER_BOX_HEIGHT
+    if not has_rival:
+        return main_bottom
+    return main_bottom - DRIVER_BOX_GAP - DRIVER_BOX_HEIGHT
+
+
+def test_the_model_matches_the_geometry_measured_on_a_real_window() -> None:
+    """Pins this file's arithmetic to numbers read off the drawn panels.
+
+    A pure test of a duplicated formula is the shape where the test and the
+    code agree with each other and neither agrees with the window. These four
+    were read back from ``F1ArcadeView`` after ``on_draw`` on a real (hidden)
+    window, so if the panels move, this fails here rather than silently
+    changing what every assertion below is about.
+    """
+    assert _weather_bottom(720) == 500
+    assert _weather_bottom(800) == 580
+    assert _lowest_card_bottom(720, has_rival=True) == 146
+    assert _lowest_card_bottom(720, has_rival=False) == 323
+
+
+def _space_below(window_height: int, *, has_rival: bool) -> int:
+    return _lowest_card_bottom(window_height, has_rival=has_rival) - LEGEND_BOTTOM
+
+
+@pytest.mark.parametrize("height", HEIGHTS)
+@pytest.mark.parametrize("has_rival", [True, False], ids=["two-drivers", "one-driver"])
+def test_the_legend_never_draws_over_the_cards(height: int, has_rival: bool) -> None:
+    """Full list only where it fits; a hint line everywhere else.
+
+    This is the assertion that is RED against the pre-#1096 code, which drew
+    the full list unconditionally: at 720 with two drivers it needed 154 px
+    into 146.
+    """
+    space = _space_below(height, has_rival=has_rival)
+    mode = legend_mode(space, len(ControlsLegend.LINES))
+    if mode == "full":
+        assert space >= legend_span(len(ControlsLegend.LINES)), (
+            f"h={height} rival={has_rival}: drew the full legend into {space} px"
+        )
+
+
+def test_the_sweep_reaches_both_modes() -> None:
+    """Neither arm passes by never running.
+
+    Without this the test above is satisfied by a legend that is always a hint,
+    which would close the overlap by deleting the panel.
+    """
+    modes = {
+        legend_mode(_space_below(h, has_rival=r), len(ControlsLegend.LINES))
+        for h in HEIGHTS
+        for r in (True, False)
+    }
+    assert modes == {"full", "hint"}, f"the sweep only ever produced {modes}"
+
+
+def test_the_default_window_with_two_drivers_collapses() -> None:
+    """The exact case the defect was, named so a regression is legible.
+
+    1280x720 is `SCREEN_HEIGHT`, and the menu opens on two drivers, so this is
+    the first frame of a default launch rather than an edge case.
+    """
+    space = _space_below(720, has_rival=True)
+    assert space < legend_span(len(ControlsLegend.LINES))
+    assert legend_mode(space, len(ControlsLegend.LINES)) == "hint"
+
+
+def test_one_driver_at_the_default_height_still_gets_the_full_list() -> None:
+    """The fix must not collapse a legend that fits.
+
+    A single driver leaves a whole card's worth of room at 720, so collapsing
+    there would be the fix over-reaching.
+    """
+    space = _space_below(720, has_rival=False)
+    assert space >= legend_span(len(ControlsLegend.LINES))
+    assert legend_mode(space, len(ControlsLegend.LINES)) == "full"
+
+
+def test_the_key_forces_it_open_where_it_does_not_fit() -> None:
+    """`C` overrides the room check, deliberately.
+
+    A user who presses it asked for the panel and the same key dismisses it, so
+    an overlap they summoned is theirs to make. Without this the key would do
+    nothing at exactly the height where someone would reach for it.
+    """
+    space = _space_below(720, has_rival=True)
+    assert legend_mode(space, len(ControlsLegend.LINES), forced_open=True) == "full"
+
+
+def test_no_measurement_means_the_full_list() -> None:
+    """A caller with nothing above the legend keeps the old behaviour."""
+    assert legend_mode(None, len(ControlsLegend.LINES)) == "full"
+
+
+def test_the_hint_names_a_key_the_list_documents() -> None:
+    """The collapsed state has to say how to get back, and say it correctly.
+
+    A hint naming a key the view does not bind, or one the list does not
+    mention, is worse than no hint.
+    """
+    keys = {key for key, _ in ControlsLegend.LINES}
+    assert ControlsLegend.HINT_KEY in keys, (
+        f"the hint offers {ControlsLegend.HINT_KEY}, which the list does not document"
+    )


### PR DESCRIPTION
## What

The controls legend no longer draws over the second driver card. It collapses to a single
`C  Controls` line when the column above it has no room, and `C` opens it anyway.

## Why

`ControlsLegend` anchored to a fixed `LEGEND_BOTTOM = 60` and grew upward; the driver cards stacked
downward from `WeatherPanel.bottom_y`. Neither knew the other existed and nothing clamped them, so
the left column could overflow its own height.

Measured on a hidden window with the real Melbourne 2025 session, reading the boxes back off the
live objects after `on_draw`:

| height | drivers | lowest card bottom | legend | overlap |
|---:|---:|---:|---|---:|
| 720 | 2 | 146 | 60-214 | **68** |
| 720 | 1 | 323 | 60-214 | 0 |
| 800 | 2 | 226 | 60-214 | 0 |
| 900 | 2 | 326 | 60-214 | 0 |
| 1080 | 2 | 506 | 60-214 | 0 |

**This is the out-of-the-box first frame, not an edge case.** `SCREEN_HEIGHT` is 720 and the menu
opens on two drivers (`views.py:45-51`), so a default `f1-arcade` launch collides immediately. The
window is resizable with no minimum, so smaller heights are worse: 128 px of overlap at 660, 188 at
600. One driver never collides above ~611.

## How

A gate priced eight candidates before anything was written. The governing measurement kills the
obvious one: **clamping the legend under the lowest card cannot work**, because at 720 the column
leaves 146 px and the list spans 154, so no anchor fits it. Two columns would be 416 px wide and
intrude 96 px into the track viewport. Shrinking the cards deletes live data. Raising the default
height is a dodge, since the window resizes.

What landed is a toggle with a room check:

- `legend_span(row_count)` and `legend_mode(space_below, row_count, forced_open=...)` are **pure
  functions**. The geometry lives between GL calls in `on_draw`, so a check on the drawn result
  needs a display and would not run in CI. `_weather_rows` was split out for the same reason last
  sprint and this follows it.
- `on_draw` measures from the LOWEST card rather than a constant, because the stack's depth depends
  on whether a rival was chosen.
- `C` was unbound and now forces the full list open even where it overlaps. The user summoned it and
  the same key dismisses it.
- The list documents its own key, and a test asserts the hint names a key the list carries.

## Out of scope

The layout around it. The circuit sits off-centre with dead space either side, and the panels and
the track carry the same visual weight. That is a design pass, not a defect, and it is not this
change.

## Checks

- `tests/surfaces` **331 -> 350**, 0 skipped. `tests/agents` 259 passed, 13 skipped (the usual
  data-absence set). `uvx ruff@0.15.22 check .` and `format --check .` clean.
- **The guard was watched failing** against the previous always-full behaviour: 7 of 19 red,
  including 600/660/720/800 with two drivers and 600 with one.
- **A bug in the guard itself was caught by that run.** Its first draft modelled the weather panel
  from its outer box, 18 px below where `bottom_y` actually lands, which would have collapsed the
  legend at 800 where it fits by 12 px. The runtime never had it, since `on_draw` reads the real
  attribute. The model is now pinned to four numbers measured on a real window, so the panels moving
  fails there rather than silently changing what every other assertion is about.
- **Looked at, not just measured**: rendered at 720 with two drivers before and after. The VER
  card's DRS, Compound, Ahead and Behind rows are legible now, and forcing the list open with `C`
  shows it overlapping deliberately.

Closes #1096
