### PR TITLE
fix(arcade): size the menu's focus band to the form it highlights

### DIFF
--- a/src/arcade/config.py
+++ b/src/arcade/config.py
@@ -225,7 +225,14 @@ STREAM_HISTORY_TAIL: Final[int] = 30
 # --- Menu view ------------------------------------------------------------
 MENU_TITLE: Final[str] = "F1 STRATLAB"
 MENU_ROW_HEIGHT: Final[int] = 40
-MENU_ROW_WIDTH: Final[int] = 540
+# Half the space between the label column's right edge and the value column's
+# left edge. Both columns are anchored off the window's centre axis, so this is
+# what separates them.
+MENU_GUTTER: Final[int] = 20
+# Breathing room the focus fill adds beyond the form's own content. The accent
+# rule under the focused row takes the content extent with no padding, so the
+# fill reads as a band around the text and the rule as an underline of it.
+MENU_FOCUS_PAD: Final[int] = 24
 MENU_LABEL_FONT: Final[int] = 13
 MENU_VALUE_FONT: Final[int] = 15
 MENU_HINT_FONT: Final[int] = 11

--- a/src/arcade/views.py
+++ b/src/arcade/views.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Callable
+from typing import Callable, NamedTuple
 
 import arcade
 from src.arcade.config import (
@@ -23,10 +23,11 @@ from src.arcade.config import (
     DRIVER_TO_TEAM_2025,
     FONT_BODY,
     FONT_TITLE,
+    MENU_FOCUS_PAD,
+    MENU_GUTTER,
     MENU_HINT_FONT,
     MENU_LABEL_FONT,
     MENU_ROW_HEIGHT,
-    MENU_ROW_WIDTH,
     MENU_TITLE,
     MENU_VALUE_FONT,
     STRATEGY_REQUIRED_YEAR,
@@ -65,6 +66,74 @@ class _FormField:
     step_right: Callable[[LaunchConfig], None] | None = None
     visible: Callable[[LaunchConfig], bool] = field(default_factory=lambda: lambda _cfg: True)
     editable: bool = False  # text fields accept on_text
+
+
+def menu_content_extents(
+    label_widths: list[float],
+    value_widths: list[float],
+    *,
+    gutter: int = MENU_GUTTER,
+) -> tuple[float, float]:
+    """How far the form's content reaches left and right of its own axis.
+
+    Labels are right-aligned at `axis - gutter` and values left-aligned at
+    `axis + gutter`, so the two columns are as wide as the widest label and the
+    widest value rather than as anything a single row measures. The band is
+    sized off the whole form for that reason: fitting it to each row instead
+    would move both its edges on every focus change, which reads worse than a
+    band that is a little loose on the short rows.
+
+    The two extents are not equal. At 1280 the widest label is STRATEGY and the
+    widest value is the round's GP name, and those render at 83 and 131 pixels.
+    """
+    widest_label = max(label_widths) if label_widths else 0.0
+    widest_value = max(value_widths) if value_widths else 0.0
+    return gutter + widest_label, gutter + widest_value
+
+
+class MenuFormGeometry(NamedTuple):
+    """Where the menu form sits, in offsets from the window's centre axis.
+
+    `axis_offset` is negative whenever the value column is wider than the label
+    column, which is the normal case: it pulls the label/value boundary left so
+    that the CONTENT ends up centred in the window rather than the boundary.
+    """
+
+    axis_offset: float
+    band_half: float
+    rule_half: float
+
+
+def menu_form_geometry(
+    label_widths: list[float],
+    value_widths: list[float],
+    *,
+    gutter: int = MENU_GUTTER,
+    pad: int = MENU_FOCUS_PAD,
+) -> MenuFormGeometry:
+    """Place the form and size the focused row's band to what is drawn in it.
+
+    **Pure on purpose**, the same reason `legend_mode` is (#1096): this decision
+    is made between GL calls in `on_draw`, so a check on the drawn result needs
+    a window, and a check that needs a window does not run in CI.
+
+    Two things come out of it. The band replaces a fixed 540 px rectangle over a
+    form whose content spans 254, which is what made the accent rule read as a
+    line across the panel rather than an underline of the focused field (#1099).
+    The axis offset is the correction that tightening the band made visible: an
+    over-wide symmetric band had been hiding that the content itself sits right
+    of the window's centre.
+
+    The fill takes the padding and the rule does not, so the fill reads as a
+    band around the text and the rule as an underline of it.
+    """
+    extent_left, extent_right = menu_content_extents(label_widths, value_widths, gutter=gutter)
+    rule_half = (extent_left + extent_right) / 2
+    return MenuFormGeometry(
+        axis_offset=(extent_left - extent_right) / 2,
+        band_half=rule_half + pad,
+        rule_half=rule_half,
+    )
 
 
 class MenuView(arcade.View):
@@ -262,11 +331,32 @@ class MenuView(arcade.View):
         self._hint.y = 60
         self._hint.draw()
 
+    def _set_row_texts(self, visible_rows: list[int]) -> None:
+        """Push every visible row's current strings into its two Text objects.
+
+        Split from the draw loop because the focus band has to know how wide the
+        widest label and the widest value are BEFORE the first row is painted,
+        and a Text reports its rendered width only once it holds the string.
+        """
+        for field_idx in visible_rows:
+            f = self._fields[field_idx]
+            self._label_texts[field_idx].text = f.label.upper()
+            self._value_texts[field_idx].text = f.get_value(self._cfg)
+
     def _draw_fields(self, w: int, h: int) -> None:
         cx = w // 2
         visible_rows: list[int] = [i for i, f in enumerate(self._fields) if f.visible(self._cfg)]
         total_h = len(visible_rows) * MENU_ROW_HEIGHT
         start_y = (h + total_h) // 2 - 40
+
+        self._set_row_texts(visible_rows)
+        geometry = menu_form_geometry(
+            [self._label_texts[i].content_width for i in visible_rows],
+            [self._value_texts[i].content_width for i in visible_rows],
+        )
+        # The form's own axis, left of the window's whenever the value column is
+        # the wider of the two, so the CONTENT is what ends up centred.
+        axis = cx + geometry.axis_offset
 
         for draw_idx, field_idx in enumerate(visible_rows):
             f = self._fields[field_idx]
@@ -275,31 +365,29 @@ class MenuView(arcade.View):
 
             if focused:
                 arcade.draw_rect_filled(
-                    arcade.XYWH(cx, row_y, MENU_ROW_WIDTH, MENU_ROW_HEIGHT - 4),
+                    arcade.XYWH(cx, row_y, geometry.band_half * 2, MENU_ROW_HEIGHT - 4),
                     (*CONTENT_BG, 220),
                 )
                 arcade.draw_line(
-                    cx - MENU_ROW_WIDTH / 2 + 40,
+                    cx - geometry.rule_half,
                     row_y - 16,
-                    cx + MENU_ROW_WIDTH / 2 - 40,
+                    cx + geometry.rule_half,
                     row_y - 16,
                     ACCENT,
                     2,
                 )
 
             label = self._label_texts[field_idx]
-            label.text = f.label.upper()
             label.color = ACCENT if focused else TEXT_TERTIARY
-            label.x = cx - 20
+            label.x = axis - MENU_GUTTER
             label.y = row_y
             label.draw()
 
             val = self._value_texts[field_idx]
-            val.text = f.get_value(self._cfg)
             val.color = TEXT_PRIMARY if focused else TEXT_SECONDARY
             if f.key == "strategy":
                 val.color = SUCCESS if self._cfg.strategy_mode else TEXT_TERTIARY
-            val.x = cx + 20
+            val.x = axis + MENU_GUTTER
             val.y = row_y
             val.draw()
 

--- a/tests/surfaces/test_arcade_menu_layout.py
+++ b/tests/surfaces/test_arcade_menu_layout.py
@@ -1,0 +1,141 @@
+"""Guards on the launch menu's layout arithmetic.
+
+The menu's geometry is decided between GL calls in ``MenuView._draw_fields``, so
+a check on the drawn result needs a window and a check that needs a window does
+not run in CI. Every decision is therefore split into a pure function and
+checked here, the same seam ``legend_mode`` (#1096) and ``_weather_rows``
+(#1087) were cut for.
+
+``ROW_WIDTHS`` is the one piece of data a pure function cannot produce: what the
+font actually renders. It was read off the live ``arcade.Text`` objects at
+1280x720 after ``on_draw`` ran, so it is a measurement, not an estimate.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.arcade.config import MENU_FOCUS_PAD, MENU_GUTTER
+from src.arcade.views import menu_content_extents, menu_form_geometry
+
+# (row, rendered label width, rendered value width), measured 2026-08-27 at
+# 1280x720 with the menu's default LaunchConfig, seven rows visible.
+ROW_WIDTHS: list[tuple[str, float, float]] = [
+    ("Year", 43, 46),
+    ("Round", 62, 131),
+    ("Mode", 51, 99),
+    ("Driver", 61, 44),
+    ("Rival", 48, 33),
+    ("Team", 47, 81),
+    ("Strategy", 83, 36),
+]
+
+
+def _extents_for(rows: list[tuple[str, float, float]]) -> tuple[float, float]:
+    return menu_content_extents([r[1] for r in rows], [r[2] for r in rows])
+
+
+def test_band_contains_every_row_it_can_highlight() -> None:
+    """No row's text may stick out of the band drawn behind it.
+
+    The failure this catches is a band fitted to one row: the focus can land on
+    any of the seven, so a band that only holds the row it was sized on crops
+    the others.
+    """
+    left, right = _extents_for(ROW_WIDTHS)
+    for name, label_w, value_w in ROW_WIDTHS:
+        assert MENU_GUTTER + label_w <= left, f"{name} label overflows the band's left edge"
+        assert MENU_GUTTER + value_w <= right, f"{name} value overflows the band's right edge"
+
+
+def test_band_is_sized_to_the_content_and_not_to_a_constant() -> None:
+    """The band may exceed the widest row by the padding and by nothing else.
+
+    This is the assertion the old code fails. It drew a fixed 540 px rectangle
+    with a 460 px rule under a form whose content spans 254 px, so the excess
+    was 143 px on the right where the padding allows 24 (#1099).
+    """
+    left, right = _extents_for(ROW_WIDTHS)
+    widest_label = max(r[1] for r in ROW_WIDTHS)
+    widest_value = max(r[2] for r in ROW_WIDTHS)
+
+    assert left - (MENU_GUTTER + widest_label) == 0
+    assert right - (MENU_GUTTER + widest_value) == 0
+
+    fill_left, fill_right = left + MENU_FOCUS_PAD, right + MENU_FOCUS_PAD
+    assert fill_left - (MENU_GUTTER + widest_label) <= MENU_FOCUS_PAD
+    assert fill_right - (MENU_GUTTER + widest_value) <= MENU_FOCUS_PAD
+
+
+def test_band_tracks_the_widest_row_when_a_value_grows() -> None:
+    """A longer GP name widens the band, which a constant could not do.
+
+    ``Round`` renders the round number plus the circuit's name, so its width is
+    session data rather than a layout choice. Melbourne is 131 px; the longest
+    name on the 2025 calendar is longer.
+    """
+    before_left, before_right = _extents_for(ROW_WIDTHS)
+    longer = [(n, lw, vw * 2 if n == "Round" else vw) for n, lw, vw in ROW_WIDTHS]
+    after_left, after_right = _extents_for(longer)
+
+    assert after_right > before_right
+    assert after_left == before_left, "a wider value must not move the label column"
+
+
+def test_the_two_halves_are_measured_independently() -> None:
+    """The band is not symmetric, and forcing it to be would waste one side.
+
+    The widest label (STRATEGY) and the widest value (the round's GP name) are
+    on different rows and are not the same width, so a single half-width would
+    have to take the larger of the two and pad the other side with it.
+    """
+    left, right = _extents_for(ROW_WIDTHS)
+    assert left != right
+
+
+def test_no_visible_rows_collapses_to_the_gutter() -> None:
+    """An empty form still has a centre axis, so the extents are the gutter.
+
+    ``max()`` on an empty sequence raises, and the visible-row list is filtered
+    by a predicate, so this is reachable rather than theoretical.
+    """
+    assert menu_content_extents([], []) == (MENU_GUTTER, MENU_GUTTER)
+
+
+@pytest.mark.parametrize("gutter", [0, 20, 60])
+def test_the_gutter_is_added_to_both_sides(gutter: int) -> None:
+    """The columns are anchored off the axis, so the gutter is inside the band."""
+    left, right = menu_content_extents([40.0], [90.0], gutter=gutter)
+    assert (left, right) == (gutter + 40.0, gutter + 90.0)
+
+
+def test_the_band_is_centred_on_the_window_axis() -> None:
+    """The fill and the rule are symmetric about the window's centre.
+
+    A symmetric band over an asymmetric form only works because the form's own
+    axis is shifted to compensate. Before the band was tightened it was 540 px
+    wide and hid the shift; at 302 px the form would read visibly off-centre
+    without it.
+    """
+    geometry = menu_form_geometry([r[1] for r in ROW_WIDTHS], [r[2] for r in ROW_WIDTHS])
+    left, right = _extents_for(ROW_WIDTHS)
+
+    assert geometry.axis_offset == pytest.approx((left - right) / 2)
+    assert geometry.axis_offset < 0, "the value column is the wider one, so the axis moves left"
+    # Content edges measured from the window axis, which is where they are drawn.
+    content_left = geometry.axis_offset - left
+    content_right = geometry.axis_offset + right
+    assert content_left == pytest.approx(-geometry.rule_half)
+    assert content_right == pytest.approx(geometry.rule_half)
+
+
+def test_the_fill_takes_the_padding_and_the_rule_does_not() -> None:
+    """The two are drawn from the same content, one inset from the other."""
+    geometry = menu_form_geometry([r[1] for r in ROW_WIDTHS], [r[2] for r in ROW_WIDTHS])
+    assert geometry.band_half - geometry.rule_half == MENU_FOCUS_PAD
+
+
+def test_a_symmetric_form_needs_no_axis_shift() -> None:
+    """Equal columns leave the boundary on the window axis, where it started."""
+    geometry = menu_form_geometry([60.0], [60.0])
+    assert geometry.axis_offset == 0


### PR DESCRIPTION
## What

The launch menu's focused row drew a fixed 540 px fill with a 460 px accent rule under it, over a form whose content spans 254 px. Both are now sized to what is actually drawn, and the form is centred in the window.

## Why

Measured at 1280x720, centre axis x=640, seven rows visible:

| element | before | after |
|---|---:|---:|
| focus fill | 370..910 (540 px) | 489..791 (302 px) |
| accent rule | 410..870 (460 px) | 513..767 (254 px) |
| widest row content (`Round`) | 558..791 (233 px) | 534..767 (233 px) |
| narrowest row content (`Rival`) | 572..693 (121 px) | 548..669 (121 px) |
| fill centre | 640 | 640 |
| content centre | 664 | 640 |

The rule was the more visible half. It ran 460 px under 155 px of text, which reads as a rule across the panel rather than as an underline of the focused field.

## How

`MENU_ROW_WIDTH` is gone, replaced by two pure functions in `src/arcade/views.py`:

- `menu_content_extents` returns how far the widest label and the widest value reach either side of the form's axis.
- `menu_form_geometry` turns those into the fill's half-width, the rule's half-width and the form's axis offset.

The fill takes `MENU_FOCUS_PAD` (24) and the rule does not, so the fill is a band around the text and the rule an underline of it.

Two decisions worth recording:

- **The band is sized off the whole form, not per row.** Fitting it to each row would move both edges on every focus change, since the labels and the values are both ragged. A band that is loose on `Rival` reads better than one that resizes under the cursor.
- **The form's own axis moves left by 24 px.** The value column is wider than the label column, so the content was sitting right of the window's centre. The over-wide symmetric band had been hiding it; tightening the band made it visible, so the shift ships with the same change rather than as a follow-up.

## Checks

- `tests/surfaces/test_arcade_menu_layout.py`, 11 new guards on the two pure functions. The geometry is decided between GL calls in `on_draw`, so the seam is the same one `legend_mode` (#1096) and `_weather_rows` (#1087) were cut for: a check that needs a window does not run in CI.
- Three mutants watched red before the guards were trusted:
  - the pre-fix constant band (`return 270.0, 270.0`): 7 of 11 fail.
  - a band fitted to the average row instead of the widest: fails containment, which proves that assertion is not vacuous.
  - `axis_offset=0.0`: fails the centring guard only.
- `tests/surfaces` 350 -> 361, executed.
- `ruff check .` and `ruff format --check .` clean, 191 files.
- Rendered the menu offscreen at 1280x720 and 1920x1080 and looked at both.

## Out of scope

The two other menu issues from #1098: the layout not scaling with the window (#1100) and the seven rows carrying equal weight (#1101). Both touch the same draw path and land separately.

Part of #1098.
