### PR TITLE
fix(arcade): scale the launch menu with the window it is given

### DIFF
--- a/src/arcade/config.py
+++ b/src/arcade/config.py
@@ -236,6 +236,28 @@ MENU_FOCUS_PAD: Final[int] = 24
 MENU_LABEL_FONT: Final[int] = 13
 MENU_VALUE_FONT: Final[int] = 15
 MENU_HINT_FONT: Final[int] = 11
+MENU_TITLE_FONT: Final[int] = 32
+MENU_SUBTITLE_FONT: Final[int] = 13
+MENU_STATUS_FONT: Final[int] = 13
+# Every length above is what the menu draws at SCREEN_HEIGHT, and the view
+# multiplies all of them by the window's height over that. Without it a taller
+# window bought nothing but two larger empty gaps: at 1920x1080 the form was the
+# same 280 px it is at 720, stranded between a title alone at the top and a hint
+# alone at the bottom.
+#
+# The bounds are what keeps the scaling useful at both ends. Below the floor the
+# type stops being readable, which is the opposite of the point; above the
+# ceiling the type would keep growing past any useful size. The ceiling sits at
+# 2.0 so that a maximised window on a 1440p display is still inside the range;
+# above it the window keeps growing and the form does not, which is the same
+# void this scaling exists to remove, deliberately traded for a legibility cap.
+MENU_SCALE_MIN: Final[float] = 0.85
+MENU_SCALE_MAX: Final[float] = 2.0
+# Distances from the window's own edges, at scale 1.0.
+MENU_TITLE_TOP: Final[int] = 80
+MENU_SUBTITLE_TOP: Final[int] = 112
+MENU_HINT_BOTTOM: Final[int] = 60
+MENU_STATUS_BOTTOM: Final[int] = 120
 STRATEGY_REQUIRED_YEAR: Final[int] = 2025
 
 # --- 2025 grid: driver code -> team --------------------------------------

--- a/src/arcade/views.py
+++ b/src/arcade/views.py
@@ -25,11 +25,21 @@ from src.arcade.config import (
     FONT_TITLE,
     MENU_FOCUS_PAD,
     MENU_GUTTER,
+    MENU_HINT_BOTTOM,
     MENU_HINT_FONT,
     MENU_LABEL_FONT,
     MENU_ROW_HEIGHT,
+    MENU_SCALE_MAX,
+    MENU_SCALE_MIN,
+    MENU_STATUS_BOTTOM,
+    MENU_STATUS_FONT,
+    MENU_SUBTITLE_FONT,
+    MENU_SUBTITLE_TOP,
     MENU_TITLE,
+    MENU_TITLE_FONT,
+    MENU_TITLE_TOP,
     MENU_VALUE_FONT,
+    SCREEN_HEIGHT,
     STRATEGY_REQUIRED_YEAR,
     SUCCESS,
     TEXT_PRIMARY,
@@ -91,6 +101,71 @@ def menu_content_extents(
     return gutter + widest_label, gutter + widest_value
 
 
+class MenuBands(NamedTuple):
+    """The menu's vertical anchors and its type scale, for one window height.
+
+    Every y is where a centre-anchored line of text sits, not the edge of a
+    glyph box, because that is what the draw call is given. `form_top` and
+    `form_bottom` are the centres of the first and last rows.
+    """
+
+    scale: float
+    title_y: float
+    subtitle_y: float
+    form_top: float
+    form_bottom: float
+    row_pitch: float
+    hint_y: float
+    status_y: float
+
+    @property
+    def form_height(self) -> float:
+        """Centre to centre of the outermost rows, plus the two half-rows."""
+        return self.form_top - self.form_bottom + self.row_pitch
+
+
+def menu_scale(window_height: int) -> float:
+    """How much larger than the default the menu draws in this window.
+
+    Clamped at both ends: below the floor the type stops being readable, which
+    is the opposite of what scaling is for, and above the ceiling a 4K window
+    would render the labels at 40 pt.
+    """
+    return max(MENU_SCALE_MIN, min(MENU_SCALE_MAX, window_height / SCREEN_HEIGHT))
+
+
+def menu_bands(window_height: int, row_count: int) -> MenuBands:
+    """Place the title, the form and the hint for a window of this height.
+
+    **Pure on purpose**, the same reason `legend_mode` is (#1096): a check on
+    the drawn result needs a window and a check that needs a window does not run
+    in CI.
+
+    The three bands used to be pinned to constants, so a taller window only ever
+    grew the two gaps between them. Here every distance is a multiple of
+    `menu_scale`, which makes the gap-to-form ratio a property of the layout
+    rather than of the window: it was 0.46 at 720 and 1.10 at 1080, and it is
+    now 0.46 at both (#1100).
+
+    The form's block sits half a row below the window's vertical centre, which
+    is where it sat before and where it reads best against a title band that is
+    taller than the hint.
+    """
+    scale = menu_scale(window_height)
+    pitch = MENU_ROW_HEIGHT * scale
+    form_top = window_height / 2 + (row_count - 2) * pitch / 2
+    return MenuBands(
+        scale=scale,
+        title_y=window_height - MENU_TITLE_TOP * scale,
+        subtitle_y=window_height - MENU_SUBTITLE_TOP * scale,
+        form_top=form_top,
+        form_bottom=form_top - (row_count - 1) * pitch,
+        row_pitch=pitch,
+        hint_y=MENU_HINT_BOTTOM * scale,
+        status_y=MENU_STATUS_BOTTOM * scale,
+    )
+
+
 class MenuFormGeometry(NamedTuple):
     """Where the menu form sits, in offsets from the window's centre axis.
 
@@ -147,6 +222,8 @@ class MenuView(arcade.View):
         self._error: str = ""
         self._loading: bool = False
         self._focus_idx: int = 0
+        # Last scale pushed into the Text objects; see `_apply_scale`.
+        self._scale: float = 1.0
 
         self._fields: list[_FormField] = self._build_fields()
 
@@ -155,7 +232,7 @@ class MenuView(arcade.View):
             0,
             0,
             ACCENT,
-            32,
+            MENU_TITLE_FONT,
             bold=True,
             font_name=FONT_TITLE,
             anchor_x="center",
@@ -166,7 +243,7 @@ class MenuView(arcade.View):
             0,
             0,
             TEXT_TERTIARY,
-            13,
+            MENU_SUBTITLE_FONT,
             font_name=FONT_BODY,
             anchor_x="center",
             anchor_y="center",
@@ -186,7 +263,7 @@ class MenuView(arcade.View):
             0,
             0,
             DANGER,
-            12,
+            MENU_STATUS_FONT,
             bold=True,
             font_name=FONT_BODY,
             anchor_x="center",
@@ -197,7 +274,7 @@ class MenuView(arcade.View):
             0,
             0,
             ACCENT,
-            14,
+            MENU_STATUS_FONT,
             bold=True,
             font_name=FONT_BODY,
             anchor_x="center",
@@ -306,30 +383,54 @@ class MenuView(arcade.View):
     def on_draw(self) -> None:
         self.clear()
         w, h = self.window.width, self.window.height
+        visible_rows: list[int] = [i for i, f in enumerate(self._fields) if f.visible(self._cfg)]
+        bands = menu_bands(h, len(visible_rows))
+        self._apply_scale(bands.scale)
+
         self._title.x = w / 2
-        self._title.y = h - 80
+        self._title.y = bands.title_y
         self._title.draw()
         self._subtitle.x = w / 2
-        self._subtitle.y = h - 112
+        self._subtitle.y = bands.subtitle_y
         self._subtitle.draw()
 
-        self._draw_fields(w, h)
+        self._draw_fields(w, visible_rows, bands)
 
         if self._error:
             self._error_text.text = self._error
             self._error_text.x = w / 2
-            self._error_text.y = 120
+            self._error_text.y = bands.status_y
             self._error_text.draw()
 
         if self._loading:
             self._loading_text.text = "Loading session..."
             self._loading_text.x = w / 2
-            self._loading_text.y = 120
+            self._loading_text.y = bands.status_y
             self._loading_text.draw()
 
         self._hint.x = w / 2
-        self._hint.y = 60
+        self._hint.y = bands.hint_y
         self._hint.draw()
+
+    def _apply_scale(self, scale: float) -> None:
+        """Resize every string to the window, once per change rather than per frame.
+
+        Assigning `font_size` re-lays the glyph run out, and there are sixteen
+        Text objects here, so the guard is what keeps a resize from costing that
+        on every one of sixty frames a second.
+        """
+        if scale == self._scale:
+            return
+        self._scale = scale
+        self._title.font_size = MENU_TITLE_FONT * scale
+        self._subtitle.font_size = MENU_SUBTITLE_FONT * scale
+        self._hint.font_size = MENU_HINT_FONT * scale
+        self._error_text.font_size = MENU_STATUS_FONT * scale
+        self._loading_text.font_size = MENU_STATUS_FONT * scale
+        for text in self._label_texts:
+            text.font_size = MENU_LABEL_FONT * scale
+        for text in self._value_texts:
+            text.font_size = MENU_VALUE_FONT * scale
 
     def _set_row_texts(self, visible_rows: list[int]) -> None:
         """Push every visible row's current strings into its two Text objects.
@@ -343,16 +444,16 @@ class MenuView(arcade.View):
             self._label_texts[field_idx].text = f.label.upper()
             self._value_texts[field_idx].text = f.get_value(self._cfg)
 
-    def _draw_fields(self, w: int, h: int) -> None:
+    def _draw_fields(self, w: int, visible_rows: list[int], bands: MenuBands) -> None:
         cx = w // 2
-        visible_rows: list[int] = [i for i, f in enumerate(self._fields) if f.visible(self._cfg)]
-        total_h = len(visible_rows) * MENU_ROW_HEIGHT
-        start_y = (h + total_h) // 2 - 40
+        gutter = round(MENU_GUTTER * bands.scale)
 
         self._set_row_texts(visible_rows)
         geometry = menu_form_geometry(
             [self._label_texts[i].content_width for i in visible_rows],
             [self._value_texts[i].content_width for i in visible_rows],
+            gutter=gutter,
+            pad=round(MENU_FOCUS_PAD * bands.scale),
         )
         # The form's own axis, left of the window's whenever the value column is
         # the wider of the two, so the CONTENT is what ends up centred.
@@ -360,26 +461,26 @@ class MenuView(arcade.View):
 
         for draw_idx, field_idx in enumerate(visible_rows):
             f = self._fields[field_idx]
-            row_y = start_y - draw_idx * MENU_ROW_HEIGHT
+            row_y = bands.form_top - draw_idx * bands.row_pitch
             focused = field_idx == self._focus_idx
 
             if focused:
                 arcade.draw_rect_filled(
-                    arcade.XYWH(cx, row_y, geometry.band_half * 2, MENU_ROW_HEIGHT - 4),
+                    arcade.XYWH(cx, row_y, geometry.band_half * 2, bands.row_pitch - 4),
                     (*CONTENT_BG, 220),
                 )
                 arcade.draw_line(
                     cx - geometry.rule_half,
-                    row_y - 16,
+                    row_y - bands.row_pitch * 0.4,
                     cx + geometry.rule_half,
-                    row_y - 16,
+                    row_y - bands.row_pitch * 0.4,
                     ACCENT,
                     2,
                 )
 
             label = self._label_texts[field_idx]
             label.color = ACCENT if focused else TEXT_TERTIARY
-            label.x = axis - MENU_GUTTER
+            label.x = axis - gutter
             label.y = row_y
             label.draw()
 
@@ -387,7 +488,7 @@ class MenuView(arcade.View):
             val.color = TEXT_PRIMARY if focused else TEXT_SECONDARY
             if f.key == "strategy":
                 val.color = SUCCESS if self._cfg.strategy_mode else TEXT_TERTIARY
-            val.x = axis + MENU_GUTTER
+            val.x = axis + gutter
             val.y = row_y
             val.draw()
 

--- a/tests/surfaces/test_arcade_menu_layout.py
+++ b/tests/surfaces/test_arcade_menu_layout.py
@@ -15,8 +15,22 @@ from __future__ import annotations
 
 import pytest
 
-from src.arcade.config import MENU_FOCUS_PAD, MENU_GUTTER
-from src.arcade.views import menu_content_extents, menu_form_geometry
+from src.arcade.config import (
+    MENU_FOCUS_PAD,
+    MENU_GUTTER,
+    MENU_HINT_FONT,
+    MENU_ROW_HEIGHT,
+    MENU_SCALE_MAX,
+    MENU_SCALE_MIN,
+    MENU_SUBTITLE_FONT,
+    SCREEN_HEIGHT,
+)
+from src.arcade.views import (
+    menu_bands,
+    menu_content_extents,
+    menu_form_geometry,
+    menu_scale,
+)
 
 # (row, rendered label width, rendered value width), measured 2026-08-27 at
 # 1280x720 with the menu's default LaunchConfig, seven rows visible.
@@ -139,3 +153,137 @@ def test_a_symmetric_form_needs_no_axis_shift() -> None:
     """Equal columns leave the boundary on the window axis, where it started."""
     geometry = menu_form_geometry([60.0], [60.0])
     assert geometry.axis_offset == 0
+
+
+# --- The form scales with the window (#1100) -------------------------------
+
+# Heights a user can actually produce. The window is resizable with no minimum,
+# so the small ones are reached by dragging rather than hypothetical, and the
+# large ones are a maximised window on a 1440p and a 4K display.
+HEIGHTS = (480, 600, 720, 800, 900, 1080, 1400, 2160)
+
+# Above this, a gap between two bands is no longer breathing room. Measured
+# before the fix: 0.46 at 720 and 1.10 at 1080, from a form that never grew.
+MAX_GAP_RATIO = 0.9
+
+ROW_COUNT = len(ROW_WIDTHS)
+
+
+def _unclamped(height: int) -> bool:
+    """Whether the scale at this height is the raw ratio, neither clamp hit."""
+    return MENU_SCALE_MIN < height / SCREEN_HEIGHT < MENU_SCALE_MAX
+
+
+# Split rather than skipped inside the test. A skip reports as coverage while
+# running nothing, and this file would have carried three of them.
+UNCLAMPED_HEIGHTS = tuple(h for h in HEIGHTS if _unclamped(h))
+CLAMPED_HEIGHTS = tuple(h for h in HEIGHTS if not _unclamped(h))
+
+
+def test_the_default_window_is_left_exactly_as_it_was() -> None:
+    """At SCREEN_HEIGHT the scale is 1 and every anchor is its old constant.
+
+    The point of the fix is what happens AWAY from the default, so the default
+    itself has to come out unchanged. Rendered offscreen at 1280x720 before and
+    after, the two frames differ by zero pixels; these are the four numbers that
+    make that true.
+    """
+    bands = menu_bands(SCREEN_HEIGHT, ROW_COUNT)
+    assert bands.scale == 1.0
+    assert bands.title_y == SCREEN_HEIGHT - 80
+    assert bands.subtitle_y == SCREEN_HEIGHT - 112
+    assert bands.hint_y == 60
+    assert bands.row_pitch == 40
+    assert bands.form_top == 460, "the first row sat at 460 before the fix"
+
+
+@pytest.mark.parametrize("height", HEIGHTS)
+def test_no_band_collides_with_another(height: int) -> None:
+    """Title above subtitle above form above hint, at every reachable height.
+
+    Clearance is one full font size, which is twice what separating two
+    centre-anchored lines strictly needs, so this fails before anything touches.
+    """
+    bands = menu_bands(height, ROW_COUNT)
+    form_top_edge = bands.form_top + bands.row_pitch / 2
+    form_bottom_edge = bands.form_bottom - bands.row_pitch / 2
+
+    assert bands.title_y > bands.subtitle_y
+    assert bands.subtitle_y - form_top_edge >= MENU_SUBTITLE_FONT * bands.scale, (
+        f"h={height}: the subtitle sits on the form"
+    )
+    assert form_bottom_edge - bands.hint_y >= MENU_HINT_FONT * bands.scale, (
+        f"h={height}: the form sits on the hint"
+    )
+    assert bands.hint_y > 0
+
+
+@pytest.mark.parametrize("height", UNCLAMPED_HEIGHTS)
+def test_the_gaps_stay_proportional_to_the_form(height: int) -> None:
+    """Extra window height goes into the form, not only into the two gaps.
+
+    This is the assertion that is RED against the pre-#1100 layout, which pinned
+    the title, the hint and a 40 px row pitch to constants: at 1920x1080 the
+    form was still 280 px and the gap above it was 308, a ratio of 1.10.
+
+    Only over the heights where the scale is the raw ratio. Outside that range a
+    clamp holds the type at a readable size on purpose, and the height it
+    declines to use goes back into the gaps, which
+    `test_beyond_the_ceiling_the_void_returns_and_says_so` states outright.
+    """
+    bands = menu_bands(height, ROW_COUNT)
+    gap_above = bands.subtitle_y - (bands.form_top + bands.row_pitch / 2)
+    gap_below = (bands.form_bottom - bands.row_pitch / 2) - bands.hint_y
+
+    assert gap_above / bands.form_height <= MAX_GAP_RATIO
+    assert gap_below / bands.form_height <= MAX_GAP_RATIO
+
+
+def test_the_sweep_exercises_both_clamps_and_the_range_between() -> None:
+    """The split above is real: every one of the three regimes has a height."""
+    scales = {menu_bands(h, ROW_COUNT).scale for h in HEIGHTS}
+    assert MENU_SCALE_MIN in scales, "no swept height reaches the floor"
+    assert MENU_SCALE_MAX in scales, "no swept height reaches the ceiling"
+    assert UNCLAMPED_HEIGHTS, "the ratio guard would parametrize over nothing"
+    assert CLAMPED_HEIGHTS, "the clamps would never be exercised"
+
+
+@pytest.mark.parametrize("height", CLAMPED_HEIGHTS)
+def test_beyond_the_ceiling_the_void_returns_and_says_so(height: int) -> None:
+    """Naming the cost of the legibility cap rather than leaving it unmeasured.
+
+    A 4K window is past the ceiling, so the form stops growing while the window
+    does not, and the height goes back into the gaps. That is the same void the
+    scaling exists to remove, kept deliberately so the type stays a readable
+    size. The bands still may not collide, which the collision guard covers at
+    the same heights.
+    """
+    bands = menu_bands(height, ROW_COUNT)
+    assert bands.scale in (MENU_SCALE_MIN, MENU_SCALE_MAX)
+    assert bands.form_height == pytest.approx(ROW_COUNT * MENU_ROW_HEIGHT * bands.scale)
+
+
+def test_a_taller_window_gets_a_taller_form() -> None:
+    """The plain statement of the defect, which a constant pitch cannot satisfy."""
+    forms = [menu_bands(h, ROW_COUNT).form_height for h in UNCLAMPED_HEIGHTS]
+    assert forms == sorted(forms)
+    assert forms[-1] > forms[0]
+
+
+def test_the_scale_is_clamped_at_both_ends() -> None:
+    """A dragged-down window stops shrinking the type; a 4K one stops growing it."""
+    assert menu_scale(SCREEN_HEIGHT) == 1.0
+    assert menu_scale(100) == MENU_SCALE_MIN
+    assert menu_scale(10_000) == MENU_SCALE_MAX
+
+
+@pytest.mark.parametrize("rows", [1, 6, 7])
+def test_the_form_block_keeps_its_place_whatever_the_row_count(rows: int) -> None:
+    """One-driver mode hides the Rival row, so the count is not a constant.
+
+    The block sits half a row below the window's vertical centre at every count,
+    which is where it sat before the fix.
+    """
+    bands = menu_bands(SCREEN_HEIGHT, rows)
+    block_centre = (bands.form_top + bands.form_bottom) / 2
+    assert block_centre == SCREEN_HEIGHT / 2 - bands.row_pitch / 2


### PR DESCRIPTION
## What

The launch menu now scales with the window instead of centring a fixed-size block in it.

## Why

`_draw_fields` centred rows of a constant `MENU_ROW_HEIGHT = 40`, the title was pinned at `h - 80`, the subtitle at `h - 112` and the hint at a literal `y = 60`. Nothing between them grew, so a taller window only ever produced two larger empty gaps.

Measured, seven rows visible, gap above the form expressed as a multiple of the form's own height:

| window | form height | gap above | ratio | gap below | ratio |
|---|---:|---:|---:|---:|---:|
| 1280x600 before | 280 | 68 | 0.24 | 80 | 0.29 |
| 1280x600 after | 238 | 103 | 0.43 | 113 | 0.47 |
| 1280x720 before | 280 | 128 | 0.46 | 140 | 0.50 |
| 1280x720 after | 280 | 128 | 0.46 | 140 | 0.50 |
| 1920x1080 before | 280 | 308 | 1.10 | 320 | 1.14 |
| 1920x1080 after | 420 | 192 | 0.46 | 210 | 0.50 |
| 2560x1440 before | 280 | 488 | 1.74 | 500 | 1.79 |
| 2560x1440 after | 560 | 256 | 0.46 | 280 | 0.50 |

The old layout also collided at 480 px tall, which a resizable window with no minimum can reach by dragging: the subtitle sat 8 px off the form's top row against a 13 pt line. It clears by 43 px now.

## How

Two pure functions in `src/arcade/views.py`:

- `menu_scale(window_height)` returns `window_height / SCREEN_HEIGHT`, clamped to `[MENU_SCALE_MIN, MENU_SCALE_MAX]` = `[0.85, 2.0]`.
- `menu_bands(window_height, row_count)` returns the title, subtitle, form and hint anchors plus the row pitch, every one of them a multiple of that scale.

`_apply_scale` pushes the scale into the font sizes. It is guarded on the scale having changed, because assigning `font_size` re-lays out the glyph run and there are sixteen `Text` objects on this view.

`config.py` gains the four font literals that were inline (`32`, `13`, `12`, `14`) and the four edge offsets, so every distance the menu draws has a name.

**The default is unchanged on purpose.** At 720 the scale is 1.0 and every anchor comes out at its old constant. Rendered offscreen at 1280x720 before and after, the two frames differ by **zero pixels**.

**The ceiling costs something and the tests say so.** Above 1440 px tall the scale clamps, the form stops growing and the height goes back into the gaps, which is the same void this change removes. That is traded deliberately for keeping the type at a readable size, and `test_beyond_the_ceiling_the_void_returns_and_says_so` asserts the clamped behaviour rather than leaving it unmeasured.

## Checks

- `tests/surfaces/test_arcade_menu_layout.py` grows from 11 guards to 34, all on pure functions, **no skips**. The clamped heights are a separate parametrized case rather than a `pytest.skip` inside the ratio test, because a skip reports as coverage while running nothing.
- Mutant D, the pre-fix pinned layout restored inside `menu_bands`, watched red: 8 failures, including the collision at 480 and the ratio at 1080 and 1400. `test_the_default_window_is_left_exactly_as_it_was` passes under both, which is what pins the zero-pixel claim.
- `tests/surfaces` 361 -> 384, executed.
- `ruff check .` and `ruff format --check .` clean, 191 files.
- Rendered offscreen and looked at 1280x480, 1280x720, 1920x1080 and 2560x1440.

## Out of scope

The last menu issue from #1098, the seven rows carrying equal weight (#1101). It touches the same draw path and lands next.

Part of #1098.
