### PR TITLE
fix(arcade): group the menu's rows and weight the one that runs the agents

### DIFF
--- a/src/arcade/config.py
+++ b/src/arcade/config.py
@@ -253,6 +253,15 @@ MENU_STATUS_FONT: Final[int] = 13
 # void this scaling exists to remove, deliberately traded for a legibility cap.
 MENU_SCALE_MIN: Final[float] = 0.85
 MENU_SCALE_MAX: Final[float] = 2.0
+# Extra pitch inserted where one group of rows ends and the next begins. The
+# seven options are three different kinds of decision (which race, which cars,
+# whether the agent pipeline runs) and used to render as one undifferentiated
+# list.
+MENU_GROUP_GAP: Final[int] = 22
+# How much larger an emphasised row draws than its siblings. One row carries it:
+# the strategy toggle, which decides whether the multi-agent layer runs at all
+# and so is the only choice on the form that changes what the replay IS.
+MENU_EMPHASIS: Final[float] = 1.3
 # Distances from the window's own edges, at scale 1.0.
 MENU_TITLE_TOP: Final[int] = 80
 MENU_SUBTITLE_TOP: Final[int] = 112

--- a/src/arcade/views.py
+++ b/src/arcade/views.py
@@ -11,8 +11,9 @@ inside the window instead of remembering CLI flags.
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Callable, NamedTuple
+from typing import Callable, Final, NamedTuple
 
 import arcade
 from src.arcade.config import (
@@ -23,7 +24,9 @@ from src.arcade.config import (
     DRIVER_TO_TEAM_2025,
     FONT_BODY,
     FONT_TITLE,
+    MENU_EMPHASIS,
     MENU_FOCUS_PAD,
+    MENU_GROUP_GAP,
     MENU_GUTTER,
     MENU_HINT_BOTTOM,
     MENU_HINT_FONT,
@@ -71,11 +74,18 @@ class _FormField:
     key: str
     label: str
     kind: str  # "int", "round", "mode", "text", "bool"
+    # Which of the three decisions this row belongs to: "race" picks the event,
+    # "cars" picks who is followed, "pipeline" decides whether the agents run.
+    # Rows are drawn in group order and a gap separates one group from the next.
+    group: str
     get_value: Callable[[LaunchConfig], str]
     step_left: Callable[[LaunchConfig], None] | None = None
     step_right: Callable[[LaunchConfig], None] | None = None
     visible: Callable[[LaunchConfig], bool] = field(default_factory=lambda: lambda _cfg: True)
     editable: bool = False  # text fields accept on_text
+    # Drawn a step larger than its siblings. Reserved for a choice that
+    # changes what the replay is rather than which race it shows.
+    emphasis: bool = False
 
 
 def menu_content_extents(
@@ -101,27 +111,89 @@ def menu_content_extents(
     return gutter + widest_label, gutter + widest_value
 
 
+# The keyboard contract, as pairs rather than as one string. It used to be a
+# single run-on separated by spaces, so "Type to edit ENTER launch" ran together
+# at the exact place a reader needs the boundary (#1101).
+MENU_HINTS: Final[tuple[tuple[str, str], ...]] = (
+    ("UP/DOWN", "focus"),
+    ("LEFT/RIGHT", "change"),
+    ("Type", "to edit"),
+    ("ENTER", "launch"),
+    ("ESC", "quit"),
+)
+MENU_HINT_SEPARATOR: Final[str] = "  ·  "
+
+
+def menu_hint_line(pairs: tuple[tuple[str, str], ...] = MENU_HINTS) -> str:
+    """The hint line, with a visible boundary between one binding and the next."""
+    return MENU_HINT_SEPARATOR.join(f"{key} {action}" for key, action in pairs)
+
+
+def round_label(year: int, round_: int) -> str:
+    """`3 Melbourne`: which round of the season, and where it was run.
+
+    The number used to be formatted `%2d`, which put a leading space on every
+    single-digit round. The value column is left-aligned, so rounds 1 to 9 were
+    indented one space further than the rest and the pair read as three tokens
+    rather than two (#1101).
+    """
+    return f"{round_} {get_gp_names(year).get(round_, '?')}"
+
+
+def menu_row_offsets(
+    groups: Sequence[str],
+    pitch: float,
+    group_gap: float,
+) -> tuple[float, ...]:
+    """How far below the first row each row's centre sits.
+
+    Pure, like its siblings here, and it is what makes the grouping a property
+    the tests can read: a gap appears wherever consecutive rows belong to
+    different groups, and nowhere else.
+    """
+    offsets: list[float] = []
+    y = 0.0
+    previous: str | None = None
+    for group in groups:
+        if previous is not None and group != previous:
+            y += group_gap
+        offsets.append(y)
+        y += pitch
+        previous = group
+    return tuple(offsets)
+
+
 class MenuBands(NamedTuple):
     """The menu's vertical anchors and its type scale, for one window height.
 
     Every y is where a centre-anchored line of text sits, not the edge of a
-    glyph box, because that is what the draw call is given. `form_top` and
-    `form_bottom` are the centres of the first and last rows.
+    glyph box, because that is what the draw call is given. `row_offsets` holds
+    each row's distance below `form_top`, which is not a constant multiple of
+    the pitch: a gap sits at every group boundary.
     """
 
     scale: float
     title_y: float
     subtitle_y: float
     form_top: float
-    form_bottom: float
     row_pitch: float
+    row_offsets: tuple[float, ...]
     hint_y: float
     status_y: float
+
+    @property
+    def form_bottom(self) -> float:
+        """Centre of the last row."""
+        return self.form_top - (self.row_offsets[-1] if self.row_offsets else 0.0)
 
     @property
     def form_height(self) -> float:
         """Centre to centre of the outermost rows, plus the two half-rows."""
         return self.form_top - self.form_bottom + self.row_pitch
+
+    def row_y(self, index: int) -> float:
+        """Centre of the row drawn at `index`, groups included."""
+        return self.form_top - self.row_offsets[index]
 
 
 def menu_scale(window_height: int) -> float:
@@ -134,7 +206,7 @@ def menu_scale(window_height: int) -> float:
     return max(MENU_SCALE_MIN, min(MENU_SCALE_MAX, window_height / SCREEN_HEIGHT))
 
 
-def menu_bands(window_height: int, row_count: int) -> MenuBands:
+def menu_bands(window_height: int, groups: Sequence[str]) -> MenuBands:
     """Place the title, the form and the hint for a window of this height.
 
     **Pure on purpose**, the same reason `legend_mode` is (#1096): a check on
@@ -147,20 +219,26 @@ def menu_bands(window_height: int, row_count: int) -> MenuBands:
     rather than of the window: it was 0.46 at 720 and 1.10 at 1080, and it is
     now 0.46 at both (#1100).
 
-    The form's block sits half a row below the window's vertical centre, which
-    is where it sat before and where it reads best against a title band that is
-    taller than the hint.
+    `groups` is one entry per VISIBLE row, in draw order, so the form's height
+    depends on how many group boundaries the rows cross as well as on how many
+    rows there are. One-driver mode hides the rival row without removing a
+    boundary, which is why the count alone is not enough.
+
+    The block sits half a row below the window's vertical centre, which is where
+    it sat before either change and where it reads best against a title band
+    that is taller than the hint.
     """
     scale = menu_scale(window_height)
     pitch = MENU_ROW_HEIGHT * scale
-    form_top = window_height / 2 + (row_count - 2) * pitch / 2
+    offsets = menu_row_offsets(groups, pitch, MENU_GROUP_GAP * scale)
+    span = offsets[-1] if offsets else 0.0
     return MenuBands(
         scale=scale,
         title_y=window_height - MENU_TITLE_TOP * scale,
         subtitle_y=window_height - MENU_SUBTITLE_TOP * scale,
-        form_top=form_top,
-        form_bottom=form_top - (row_count - 1) * pitch,
+        form_top=window_height / 2 - pitch / 2 + span / 2,
         row_pitch=pitch,
+        row_offsets=offsets,
         hint_y=MENU_HINT_BOTTOM * scale,
         status_y=MENU_STATUS_BOTTOM * scale,
     )
@@ -211,6 +289,85 @@ def menu_form_geometry(
     )
 
 
+def build_menu_fields(toggle_strategy: Callable[[], None]) -> list[_FormField]:
+    """The seven rows the menu draws, in draw order.
+
+    Module level rather than a method so the table can be read without a window
+    (`arcade.View.__init__` needs one), which is what lets the group assignment,
+    the emphasis flag and every rendered value string be checked in CI. The
+    strategy toggle is passed in because it mutates the view's own config and
+    then forces the year, which is view state rather than table data.
+    """
+    return [
+        _FormField(
+            key="year",
+            label="Year",
+            kind="int",
+            group="race",
+            get_value=lambda c: str(c.year),
+            step_left=lambda c: (
+                setattr(c, "year", max(2023, c.year - 1)) if not c.strategy_mode else None
+            ),
+            step_right=lambda c: (
+                setattr(c, "year", min(2025, c.year + 1)) if not c.strategy_mode else None
+            ),
+        ),
+        _FormField(
+            key="round",
+            label="Round",
+            kind="round",
+            group="race",
+            get_value=lambda c: round_label(c.year, c.round_),
+            step_left=lambda c: setattr(c, "round_", max(1, c.round_ - 1)),
+            step_right=lambda c: setattr(c, "round_", min(23, c.round_ + 1)),
+        ),
+        _FormField(
+            key="mode",
+            label="Mode",
+            kind="mode",
+            group="cars",
+            get_value=lambda c: "2 DRIVERS" if c.mode_two_drivers else "1 DRIVER",
+            step_left=lambda c: setattr(c, "mode_two_drivers", not c.mode_two_drivers),
+            step_right=lambda c: setattr(c, "mode_two_drivers", not c.mode_two_drivers),
+        ),
+        _FormField(
+            key="driver_main",
+            label="Driver",
+            kind="text",
+            group="cars",
+            get_value=lambda c: c.driver_main or "---",
+            editable=True,
+        ),
+        _FormField(
+            key="driver_rival",
+            label="Rival",
+            kind="text",
+            group="cars",
+            get_value=lambda c: c.driver_rival or "---",
+            editable=True,
+            visible=lambda c: c.mode_two_drivers,
+        ),
+        _FormField(
+            key="team",
+            label="Team",
+            kind="text",
+            group="cars",
+            get_value=lambda c: c.team or "---",
+            editable=True,
+        ),
+        _FormField(
+            key="strategy",
+            label="Strategy",
+            kind="bool",
+            group="pipeline",
+            get_value=lambda c: "ON" if c.strategy_mode else "OFF",
+            step_left=lambda c: toggle_strategy(),
+            step_right=lambda c: toggle_strategy(),
+            emphasis=True,
+        ),
+    ]
+
+
 class MenuView(arcade.View):
     """Pre-replay keyboard form. On ENTER it loads the session and swaps
     to `F1ArcadeView`. Any validation error surfaces inline in DANGER red."""
@@ -249,7 +406,7 @@ class MenuView(arcade.View):
             anchor_y="center",
         )
         self._hint = arcade.Text(
-            "UP/DOWN focus   LEFT/RIGHT change   Type to edit   ENTER launch   ESC quit",
+            menu_hint_line(),
             0,
             0,
             TEXT_TERTIARY,
@@ -312,66 +469,7 @@ class MenuView(arcade.View):
     # --- Field definitions ----------------------------------------------
 
     def _build_fields(self) -> list[_FormField]:
-        return [
-            _FormField(
-                key="year",
-                label="Year",
-                kind="int",
-                get_value=lambda c: str(c.year),
-                step_left=lambda c: (
-                    setattr(c, "year", max(2023, c.year - 1)) if not c.strategy_mode else None
-                ),
-                step_right=lambda c: (
-                    setattr(c, "year", min(2025, c.year + 1)) if not c.strategy_mode else None
-                ),
-            ),
-            _FormField(
-                key="round",
-                label="Round",
-                kind="round",
-                get_value=lambda c: f"{c.round_:2d}  {get_gp_names(c.year).get(c.round_, '?')}",
-                step_left=lambda c: setattr(c, "round_", max(1, c.round_ - 1)),
-                step_right=lambda c: setattr(c, "round_", min(23, c.round_ + 1)),
-            ),
-            _FormField(
-                key="mode",
-                label="Mode",
-                kind="mode",
-                get_value=lambda c: "2 DRIVERS" if c.mode_two_drivers else "1 DRIVER",
-                step_left=lambda c: setattr(c, "mode_two_drivers", not c.mode_two_drivers),
-                step_right=lambda c: setattr(c, "mode_two_drivers", not c.mode_two_drivers),
-            ),
-            _FormField(
-                key="driver_main",
-                label="Driver",
-                kind="text",
-                get_value=lambda c: c.driver_main or "---",
-                editable=True,
-            ),
-            _FormField(
-                key="driver_rival",
-                label="Rival",
-                kind="text",
-                get_value=lambda c: c.driver_rival or "---",
-                editable=True,
-                visible=lambda c: c.mode_two_drivers,
-            ),
-            _FormField(
-                key="team",
-                label="Team",
-                kind="text",
-                get_value=lambda c: c.team or "---",
-                editable=True,
-            ),
-            _FormField(
-                key="strategy",
-                label="Strategy",
-                kind="bool",
-                get_value=lambda c: "ON" if c.strategy_mode else "OFF",
-                step_left=lambda c: self._toggle_strategy(),
-                step_right=lambda c: self._toggle_strategy(),
-            ),
-        ]
+        return build_menu_fields(self._toggle_strategy)
 
     def _toggle_strategy(self) -> None:
         self._cfg.strategy_mode = not self._cfg.strategy_mode
@@ -384,7 +482,7 @@ class MenuView(arcade.View):
         self.clear()
         w, h = self.window.width, self.window.height
         visible_rows: list[int] = [i for i, f in enumerate(self._fields) if f.visible(self._cfg)]
-        bands = menu_bands(h, len(visible_rows))
+        bands = menu_bands(h, [self._fields[i].group for i in visible_rows])
         self._apply_scale(bands.scale)
 
         self._title.x = w / 2
@@ -427,10 +525,10 @@ class MenuView(arcade.View):
         self._hint.font_size = MENU_HINT_FONT * scale
         self._error_text.font_size = MENU_STATUS_FONT * scale
         self._loading_text.font_size = MENU_STATUS_FONT * scale
-        for text in self._label_texts:
-            text.font_size = MENU_LABEL_FONT * scale
-        for text in self._value_texts:
-            text.font_size = MENU_VALUE_FONT * scale
+        for f, label, value in zip(self._fields, self._label_texts, self._value_texts, strict=True):
+            step = MENU_EMPHASIS if f.emphasis else 1.0
+            label.font_size = MENU_LABEL_FONT * scale * step
+            value.font_size = MENU_VALUE_FONT * scale * step
 
     def _set_row_texts(self, visible_rows: list[int]) -> None:
         """Push every visible row's current strings into its two Text objects.
@@ -461,19 +559,20 @@ class MenuView(arcade.View):
 
         for draw_idx, field_idx in enumerate(visible_rows):
             f = self._fields[field_idx]
-            row_y = bands.form_top - draw_idx * bands.row_pitch
+            row_y = bands.row_y(draw_idx)
             focused = field_idx == self._focus_idx
 
             if focused:
+                row_height = bands.row_pitch * (MENU_EMPHASIS if f.emphasis else 1.0) - 4
                 arcade.draw_rect_filled(
-                    arcade.XYWH(cx, row_y, geometry.band_half * 2, bands.row_pitch - 4),
+                    arcade.XYWH(cx, row_y, geometry.band_half * 2, row_height),
                     (*CONTENT_BG, 220),
                 )
                 arcade.draw_line(
                     cx - geometry.rule_half,
-                    row_y - bands.row_pitch * 0.4,
+                    row_y - row_height * 0.44,
                     cx + geometry.rule_half,
-                    row_y - bands.row_pitch * 0.4,
+                    row_y - row_height * 0.44,
                     ACCENT,
                     2,
                 )
@@ -487,7 +586,7 @@ class MenuView(arcade.View):
             val = self._value_texts[field_idx]
             val.color = TEXT_PRIMARY if focused else TEXT_SECONDARY
             if f.key == "strategy":
-                val.color = SUCCESS if self._cfg.strategy_mode else TEXT_TERTIARY
+                val.color = SUCCESS if self._cfg.strategy_mode else TEXT_SECONDARY
             val.x = axis + gutter
             val.y = row_y
             val.draw()

--- a/tests/surfaces/test_arcade_menu_layout.py
+++ b/tests/surfaces/test_arcade_menu_layout.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 import pytest
 
 from src.arcade.config import (
+    MENU_EMPHASIS,
     MENU_FOCUS_PAD,
+    MENU_GROUP_GAP,
     MENU_GUTTER,
     MENU_HINT_FONT,
     MENU_ROW_HEIGHT,
@@ -26,10 +28,17 @@ from src.arcade.config import (
     SCREEN_HEIGHT,
 )
 from src.arcade.views import (
+    MENU_HINT_SEPARATOR,
+    MENU_HINTS,
+    LaunchConfig,
+    build_menu_fields,
     menu_bands,
     menu_content_extents,
     menu_form_geometry,
+    menu_hint_line,
+    menu_row_offsets,
     menu_scale,
+    round_label,
 )
 
 # (row, rendered label width, rendered value width), measured 2026-08-27 at
@@ -157,6 +166,13 @@ def test_a_symmetric_form_needs_no_axis_shift() -> None:
 
 # --- The form scales with the window (#1100) -------------------------------
 
+# The real seven rows, read off the table the view draws rather than restated
+# here, so a group reassigned in views.py reaches every assertion below.
+FIELDS = build_menu_fields(lambda: None)
+GROUPS = tuple(f.group for f in FIELDS)
+ROW_COUNT = len(GROUPS)
+GROUP_BREAKS = sum(1 for a, b in zip(GROUPS, GROUPS[1:]) if a != b)
+
 # Heights a user can actually produce. The window is resizable with no minimum,
 # so the small ones are reached by dragging rather than hypothetical, and the
 # large ones are a maximised window on a 1440p and a 4K display.
@@ -165,8 +181,6 @@ HEIGHTS = (480, 600, 720, 800, 900, 1080, 1400, 2160)
 # Above this, a gap between two bands is no longer breathing room. Measured
 # before the fix: 0.46 at 720 and 1.10 at 1080, from a form that never grew.
 MAX_GAP_RATIO = 0.9
-
-ROW_COUNT = len(ROW_WIDTHS)
 
 
 def _unclamped(height: int) -> bool:
@@ -180,21 +194,33 @@ UNCLAMPED_HEIGHTS = tuple(h for h in HEIGHTS if _unclamped(h))
 CLAMPED_HEIGHTS = tuple(h for h in HEIGHTS if not _unclamped(h))
 
 
-def test_the_default_window_is_left_exactly_as_it_was() -> None:
-    """At SCREEN_HEIGHT the scale is 1 and every anchor is its old constant.
+def test_the_default_window_keeps_the_anchors_the_scaling_did_not_move() -> None:
+    """At SCREEN_HEIGHT the scale is 1, so the three edge bands are untouched.
 
-    The point of the fix is what happens AWAY from the default, so the default
-    itself has to come out unchanged. Rendered offscreen at 1280x720 before and
-    after, the two frames differ by zero pixels; these are the four numbers that
-    make that true.
+    The point of #1100 is what happens AWAY from the default, so the default's
+    own title, subtitle, hint and pitch have to come out at their old constants.
+    The form's block is the one thing that did move, and only because #1101 puts
+    a gap at each group boundary, so it is asserted separately below.
     """
-    bands = menu_bands(SCREEN_HEIGHT, ROW_COUNT)
+    bands = menu_bands(SCREEN_HEIGHT, GROUPS)
     assert bands.scale == 1.0
     assert bands.title_y == SCREEN_HEIGHT - 80
     assert bands.subtitle_y == SCREEN_HEIGHT - 112
     assert bands.hint_y == 60
     assert bands.row_pitch == 40
-    assert bands.form_top == 460, "the first row sat at 460 before the fix"
+
+
+def test_the_group_gaps_are_the_only_thing_that_moved_the_form() -> None:
+    """The block is taller by exactly the gaps, and still centred where it was.
+
+    Before either change the first row sat at 460 with a 280 px block. The block
+    grows by one `MENU_GROUP_GAP` per boundary and stays centred half a row below
+    the window's middle, so the first row rises by half of what was added.
+    """
+    bands = menu_bands(SCREEN_HEIGHT, GROUPS)
+    added = GROUP_BREAKS * MENU_GROUP_GAP
+    assert bands.form_height == ROW_COUNT * MENU_ROW_HEIGHT + added
+    assert bands.form_top == 460 + added / 2
 
 
 @pytest.mark.parametrize("height", HEIGHTS)
@@ -204,7 +230,7 @@ def test_no_band_collides_with_another(height: int) -> None:
     Clearance is one full font size, which is twice what separating two
     centre-anchored lines strictly needs, so this fails before anything touches.
     """
-    bands = menu_bands(height, ROW_COUNT)
+    bands = menu_bands(height, GROUPS)
     form_top_edge = bands.form_top + bands.row_pitch / 2
     form_bottom_edge = bands.form_bottom - bands.row_pitch / 2
 
@@ -231,7 +257,7 @@ def test_the_gaps_stay_proportional_to_the_form(height: int) -> None:
     declines to use goes back into the gaps, which
     `test_beyond_the_ceiling_the_void_returns_and_says_so` states outright.
     """
-    bands = menu_bands(height, ROW_COUNT)
+    bands = menu_bands(height, GROUPS)
     gap_above = bands.subtitle_y - (bands.form_top + bands.row_pitch / 2)
     gap_below = (bands.form_bottom - bands.row_pitch / 2) - bands.hint_y
 
@@ -241,7 +267,7 @@ def test_the_gaps_stay_proportional_to_the_form(height: int) -> None:
 
 def test_the_sweep_exercises_both_clamps_and_the_range_between() -> None:
     """The split above is real: every one of the three regimes has a height."""
-    scales = {menu_bands(h, ROW_COUNT).scale for h in HEIGHTS}
+    scales = {menu_bands(h, GROUPS).scale for h in HEIGHTS}
     assert MENU_SCALE_MIN in scales, "no swept height reaches the floor"
     assert MENU_SCALE_MAX in scales, "no swept height reaches the ceiling"
     assert UNCLAMPED_HEIGHTS, "the ratio guard would parametrize over nothing"
@@ -258,14 +284,16 @@ def test_beyond_the_ceiling_the_void_returns_and_says_so(height: int) -> None:
     size. The bands still may not collide, which the collision guard covers at
     the same heights.
     """
-    bands = menu_bands(height, ROW_COUNT)
+    bands = menu_bands(height, GROUPS)
     assert bands.scale in (MENU_SCALE_MIN, MENU_SCALE_MAX)
-    assert bands.form_height == pytest.approx(ROW_COUNT * MENU_ROW_HEIGHT * bands.scale)
+    assert bands.form_height == pytest.approx(
+        (ROW_COUNT * MENU_ROW_HEIGHT + GROUP_BREAKS * MENU_GROUP_GAP) * bands.scale
+    )
 
 
 def test_a_taller_window_gets_a_taller_form() -> None:
     """The plain statement of the defect, which a constant pitch cannot satisfy."""
-    forms = [menu_bands(h, ROW_COUNT).form_height for h in UNCLAMPED_HEIGHTS]
+    forms = [menu_bands(h, GROUPS).form_height for h in UNCLAMPED_HEIGHTS]
     assert forms == sorted(forms)
     assert forms[-1] > forms[0]
 
@@ -284,6 +312,139 @@ def test_the_form_block_keeps_its_place_whatever_the_row_count(rows: int) -> Non
     The block sits half a row below the window's vertical centre at every count,
     which is where it sat before the fix.
     """
-    bands = menu_bands(SCREEN_HEIGHT, rows)
+    bands = menu_bands(SCREEN_HEIGHT, GROUPS[:rows])
     block_centre = (bands.form_top + bands.form_bottom) / 2
     assert block_centre == SCREEN_HEIGHT / 2 - bands.row_pitch / 2
+
+
+# --- The rows are grouped and one of them carries weight (#1101) -----------
+
+
+def test_the_seven_rows_fall_into_the_three_decisions_they_are() -> None:
+    """Which race, which cars, whether the agents run.
+
+    Named here so a row added to the wrong group fails rather than quietly
+    joining the one above it.
+    """
+    by_group = {f.key: f.group for f in FIELDS}
+    assert by_group == {
+        "year": "race",
+        "round": "race",
+        "mode": "cars",
+        "driver_main": "cars",
+        "driver_rival": "cars",
+        "team": "cars",
+        "strategy": "pipeline",
+    }
+
+
+def test_the_groups_are_contiguous_in_draw_order() -> None:
+    """A group split across the form would put a gap inside itself.
+
+    `menu_row_offsets` inserts a gap wherever consecutive rows differ, so a
+    table ordered race, cars, race would draw three bands for two groups.
+    """
+    seen: list[str] = []
+    for group in GROUPS:
+        if not seen or seen[-1] != group:
+            assert group not in seen, f"{group} is split across the form"
+            seen.append(group)
+    assert seen == ["race", "cars", "pipeline"]
+
+
+def test_a_gap_sits_at_every_boundary_and_nowhere_else() -> None:
+    """The pitch between two rows says whether they are the same kind."""
+    offsets = menu_row_offsets(GROUPS, pitch=40, group_gap=22)
+    steps = [b - a for a, b in zip(offsets, offsets[1:])]
+    expected = [40 + (22 if a != b else 0) for a, b in zip(GROUPS, GROUPS[1:])]
+    assert steps == expected
+    assert steps.count(62) == GROUP_BREAKS == 2
+
+
+def test_one_driver_mode_loses_a_row_but_not_a_boundary() -> None:
+    """Hiding the rival row must not merge the cars group into its neighbours.
+
+    The rival row is the only one with a `visible` predicate and it sits inside
+    its own group, so the form gets shorter by one row and keeps both gaps.
+    """
+    one_driver = LaunchConfig(mode_two_drivers=False)
+    visible = tuple(f.group for f in FIELDS if f.visible(one_driver))
+
+    assert len(visible) == ROW_COUNT - 1
+    breaks = sum(1 for a, b in zip(visible, visible[1:]) if a != b)
+    assert breaks == GROUP_BREAKS
+
+    bands = menu_bands(SCREEN_HEIGHT, visible)
+    assert bands.form_height == (ROW_COUNT - 1) * MENU_ROW_HEIGHT + breaks * MENU_GROUP_GAP
+
+
+def test_exactly_one_row_is_emphasised_and_it_is_the_pipeline_switch() -> None:
+    """The switch that decides whether the multi-agent layer runs at all.
+
+    Emphasis is only worth anything while it is scarce, so the count is asserted
+    as well as which row carries it.
+    """
+    emphasised = [f.key for f in FIELDS if f.emphasis]
+    assert emphasised == ["strategy"]
+    assert MENU_EMPHASIS > 1.0
+
+
+def test_the_boundary_between_two_bindings_is_visible() -> None:
+    """Four printed marks for five pairs, read off the line rather than the constant.
+
+    A first draft of this asserted `menu_hint_line().split(MENU_HINT_SEPARATOR)`,
+    which is circular: swapping the separator back to three spaces still splits
+    into five, so the guard passed against the exact run-on it was written for.
+    It counts marks in the rendered string now, and whitespace is not a mark.
+    """
+    line = menu_hint_line()
+    marks = [c for c in line if not (c.isalnum() or c.isspace() or c == "/")]
+    assert len(marks) == len(MENU_HINTS) - 1, f"{line!r} has no visible boundaries"
+    assert MENU_HINT_SEPARATOR.strip(), "a whitespace-only separator is the defect"
+
+
+def test_the_hint_line_holds_every_binding_in_order() -> None:
+    """The separator may change without the contract it separates changing."""
+    parts = menu_hint_line().split(MENU_HINT_SEPARATOR)
+    assert parts == [f"{key} {action}" for key, action in MENU_HINTS]
+    for part in parts:
+        assert "  " not in part, f"{part!r} still runs two tokens together"
+
+
+def test_the_hint_names_the_keys_the_menu_actually_reads() -> None:
+    """A hint documenting a key the view does not bind is worse than none."""
+    keys = {key for key, _ in MENU_HINTS}
+    assert keys == {"UP/DOWN", "LEFT/RIGHT", "Type", "ENTER", "ESC"}
+
+
+@pytest.mark.parametrize("year", [2023, 2024, 2025])
+def test_the_round_value_is_two_tokens_for_every_round_of_every_season(year: int) -> None:
+    """No leading space and no double space, at one digit or two.
+
+    The old `%2d` put a leading space on rounds 1 to 9, and the value column is
+    left-aligned, so those nine indented one space further than the rest. Swept
+    over the real calendars rather than over the default round.
+    """
+    for round_ in range(1, 24):
+        value = round_label(year, round_)
+        assert value == value.lstrip(), f"{year} R{round_}: {value!r} has a leading space"
+        assert "  " not in value, f"{year} R{round_}: {value!r} has a double space"
+        assert value.split(" ", 1)[0] == str(round_)
+
+
+def test_the_round_value_still_names_the_circuit() -> None:
+    """Trimming the spacing must not trim the half a reader actually reads.
+
+    Both digit widths, and two different seasons, because the round-to-circuit
+    map is per year: Melbourne opened 2025 at round 1 and was round 3 in 2024,
+    while 2025 round 3 was Suzuka.
+    """
+    assert round_label(2025, 1) == "1 Melbourne"
+    assert round_label(2024, 3) == "3 Melbourne"
+    assert round_label(2025, 3) == "3 Suzuka"
+    assert round_label(2024, 23) == "23 Lusail"
+
+
+def test_an_unknown_round_says_so_rather_than_inventing_a_circuit() -> None:
+    """Absent data has to look absent, per the weather panel's `N/A` (#1087)."""
+    assert round_label(2025, 99).endswith("?")


### PR DESCRIPTION
## What

The launch menu's seven options now read as the three decisions they are, the row that turns on the agent pipeline carries weight, and the two text defects in the same draw path are gone.

## Why

The seven rows are not one list:

- `Year`, `Round` pick the race.
- `Mode`, `Driver`, `Rival`, `Team` pick the cars.
- `Strategy` decides whether the multi-agent pipeline runs at all, which is what makes the replay more than a replay.

All three rendered at identical weight, and the last one sat at the bottom in the same type as `Team`, with its only distinction being a green value when on.

Two text defects rode along in the same draw call:

| | before | after |
|---|---|---|
| hint | `UP/DOWN focus   LEFT/RIGHT change   Type to edit   ENTER launch   ESC quit` | `UP/DOWN focus  ·  LEFT/RIGHT change  ·  Type to edit  ·  ENTER launch  ·  ESC quit` |
| round value | `" 3  Melbourne"` | `"3 Melbourne"` |

The round value is the worse of the two: the column is left-aligned, so the `%2d` indented rounds 1 to 9 one space further than rounds 10 to 23.

## How

- `_FormField` gains a `group`. `menu_row_offsets` inserts `MENU_GROUP_GAP` (22) wherever consecutive rows belong to different groups and nowhere else, so grouping is a property of the offsets rather than something drawn on top of them. `menu_bands` now takes the visible rows' groups instead of a count, because one-driver mode removes a row without removing a boundary.
- `_FormField` gains an `emphasis` flag. One row carries it. The label, the value and the focus band all draw at `MENU_EMPHASIS` (1.3).
- `OFF` moves from `TEXT_TERTIARY` to `TEXT_SECONDARY`. Tertiary is the same grey the unfocused labels use, so the row read as disabled rather than as a switch that is off.
- The hint becomes `MENU_HINTS`, five key/action pairs, joined by `menu_hint_line`.
- `round_label(year, round_)` replaces the inline lambda.
- **The field table moves out of `MenuView` into `build_menu_fields`.** `arcade.View.__init__` needs a window, so as a method the table could not be read in CI. At module level the group assignment, the emphasis flag and every rendered value string are all assertable.

Grouping is spacing only, no separator rule. The gap was enough on the rendered frame, and a rule would have been a second mark for the same job.

## Checks

- `tests/surfaces/test_arcade_menu_layout.py` 34 -> 48 guards, no skips.
- Five mutants watched red:
  - **E**, no gap at a boundary (the flat list): 6 failures.
  - **F**, the `%2d` round format restored: 4 failures, across all three seasons' calendars.
  - **G**, a whitespace separator (the run-on): 1 failure.
  - **H**, `Strategy` loses its emphasis: 1 failure.
  - **I**, `Strategy` folded back into the cars group: 3 failures.
- **Mutant G passed on the first attempt and the guard was wrong, not the mutant.** It asserted `menu_hint_line().split(MENU_HINT_SEPARATOR)`, which is circular: swap the separator back to three spaces and the line still splits into five. The guard counts printed marks in the rendered string now, and whitespace is not a mark. Recorded in the test's own docstring.
- **The round sweep found a fact I had wrong.** A first assertion said `round_label(2025, 3) == "3 Melbourne"`, from the arcade's cached `Melbourne_2025_race.pkl`. The 2025 calendar opened in Australia at round 1 and round 3 was Suzuka. The assertion was corrected; the code was already right.
- `tests/surfaces` 384 -> 398, executed.
- `ruff check .` and `ruff format --check .` clean, 191 files.
- Rendered offscreen at 1280x720 and 1920x1080, plus a frame with the emphasised row focused and `Strategy = ON`, and looked at all of them.

## Out of scope

The two replay issues from #1098, #1102 and #1103. Nothing here touches `app.py` or `overlays.py`.

Part of #1098.
