### PR TITLE
refactor(arcade): one driver table instead of two stacked cards

### DIFF
--- a/docs/pages/arcade-quick-start.md
+++ b/docs/pages/arcade-quick-start.md
@@ -94,10 +94,16 @@ Hotkeys handled by `F1ArcadeView.on_key_press`:
 `--viewer` was used at launch.
 
 The controls list collapses to a single `C  Controls` line when the column above
-it has no room, which at the default 1280x720 is any session with a rival: the
-list needs 154 px and the two driver cards leave 146. It used to draw over the
-second card instead. `C` opens it anyway where it does not fit, on the grounds
-that a list you asked for is one you can dismiss with the same key.
+it has no room. The list needs 158 px, and the left column leaves 263 at the
+default 1280x720 whether one driver is followed or two, so the collapse fires
+only on a window dragged below roughly 618 px tall. `C` opens the list anyway
+where it does not fit, on the grounds that a list you asked for is one you can
+dismiss with the same key.
+
+The telemetry under the weather card is one table with a column per driver. It
+used to be a card each, which repeated the same six labels under two headers and
+took 354 px of the column for twelve values; at the default height that left
+146 px against a list needing 158, and the list drew over the second card.
 
 ## Known limitations
 

--- a/src/arcade/app.py
+++ b/src/arcade/app.py
@@ -339,24 +339,19 @@ class F1ArcadeView(arcade.View):
             top_y=h - 220,
             width=LEADERBOARD_WIDTH,
         )
-        self._driver_info_main = DriverInfoPanel(
+        # One table with a column per driver rather than a card each. Two cards
+        # repeated the same six labels under two headers and took 354 px of the
+        # left column for twelve values (#1102).
+        followed = [(driver_main, self._color_for(driver_main))]
+        if driver_rival:
+            followed.append((driver_rival, self._color_for(driver_rival)))
+        self._driver_info = DriverInfoPanel(
             x=20,
             top_y=h - 200,
             width=DRIVER_BOX_WIDTH,
             height=DRIVER_BOX_HEIGHT,
-            driver_code=driver_main,
-            color=self._color_for(driver_main),
+            drivers=followed,
         )
-        self._driver_info_rival: DriverInfoPanel | None = None
-        if driver_rival:
-            self._driver_info_rival = DriverInfoPanel(
-                x=20,
-                top_y=h - 200 - DRIVER_BOX_HEIGHT - DRIVER_BOX_GAP,
-                width=DRIVER_BOX_WIDTH,
-                height=DRIVER_BOX_HEIGHT,
-                driver_code=driver_rival,
-                color=self._color_for(driver_rival),
-            )
 
         self._progress_bar = ProgressBar(
             total_frames=session_data.total_frames,
@@ -902,31 +897,25 @@ class F1ArcadeView(arcade.View):
         self._race_events.draw()
         self._weather.draw(frame, self.window.height)
         sorted_progress = self._leaderboard.sorted_progress(frame, self._gaps, frame_idx)
-        # DRIVER_BOX_GAP also controls the weather → main-driver gap for
-        # a consistent rhythm between the three stacked cards.
-        self._driver_info_main.set_top(self._weather.bottom_y - DRIVER_BOX_GAP)
-        self._driver_info_main.draw(frame, sorted_progress, self._gaps, frame_idx)
-        if self._driver_info_rival:
-            self._driver_info_rival.set_top(
-                self._weather.bottom_y - DRIVER_BOX_GAP - DRIVER_BOX_HEIGHT - DRIVER_BOX_GAP
-            )
-            self._driver_info_rival.draw(frame, sorted_progress, self._gaps, frame_idx)
+        # DRIVER_BOX_GAP separates the weather card from the driver table. The
+        # two are 14 px apart on screen rather than 32, because
+        # `WeatherPanel.bottom_y` is computed from the last row's baseline and
+        # sits 18 px above the card's own edge.
+        self._driver_info.set_top(self._weather.bottom_y - DRIVER_BOX_GAP)
+        self._driver_info.draw(frame, sorted_progress, self._gaps, frame_idx)
 
         if self._show_progress_bar:
             self._progress_bar.draw(self.window.width, frame_idx)
         # The legend decides between the full list and a one-line hint from the
-        # room the cards above it actually left, because at the default 720 with
-        # two drivers the column leaves 146 px and the list needs 154, so it used
-        # to draw straight over the rival card (#1096). Measured from the LOWEST
-        # card rather than from a constant: the stack's depth depends on whether
-        # a rival was chosen.
-        lowest_card = self._driver_info_main.top_y - self._driver_info_main.height
-        if self._driver_info_rival is not None:
-            lowest_card = min(
-                lowest_card,
-                self._driver_info_rival.top_y - self._driver_info_rival.height,
-            )
-        self._controls_legend.draw(space_below=lowest_card - self._controls_legend.bottom)
+        # room the column above it actually left. It used to draw over the rival
+        # card at the default 720, where two stacked cards left 146 px against a
+        # list that needs 158 (#1096). One table leaves 263 there, so the full
+        # list fits, and the collapse now fires below about 615 px of window
+        # instead of below 788. Measured from the panel rather than assumed,
+        # because the room still depends on the window's height.
+        self._controls_legend.draw(
+            space_below=self._driver_info.bottom_y - self._controls_legend.bottom
+        )
         self._update_hud(frame)
 
     def on_key_press(self, symbol: int, modifiers: int) -> None:

--- a/src/arcade/config.py
+++ b/src/arcade/config.py
@@ -50,6 +50,14 @@ DRIVER_BOX_HEIGHT: Final[int] = 145
 DRIVER_BOX_GAP: Final[int] = 32
 DRIVER_HEADER_HEIGHT: Final[int] = 28
 DRIVER_ROW_GAP: Final[int] = 19
+DRIVER_PAD_X: Final[int] = 12
+# Narrowest the driver table's label column may get, so the value columns take
+# the rest. Not the width of the longest label: a label only has to clear the
+# value on its OWN row, and the widest label (Compound, 64 px) sits beside a
+# single letter while the widest values (the gaps, 103 px) sit beside 37 and
+# 40 px labels. Measured over 400 frames of a real race, the widest
+# label-plus-value pair on any row is 140 px.
+DRIVER_LABEL_MIN: Final[int] = 40
 
 # --- Leaderboard ----------------------------------------------------------
 LEADERBOARD_WIDTH: Final[int] = 240

--- a/src/arcade/overlays.py
+++ b/src/arcade/overlays.py
@@ -11,6 +11,7 @@ rows, a bug that bit both the reference and earlier attempts here.
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Final
 
 import arcade
@@ -21,6 +22,8 @@ from src.arcade.config import (
     COMPOUND_LETTERS,
     CONTENT_BG,
     DRIVER_HEADER_HEIGHT,
+    DRIVER_LABEL_MIN,
+    DRIVER_PAD_X,
     DRIVER_ROW_GAP,
     DRS_ELIGIBLE_CODE,
     DRS_OPEN_CODES,
@@ -235,15 +238,104 @@ class WeatherPanel:
         arcade.draw_rect_filled(arcade.XYWH(cx, strip_cy, self.width, self.STRIP_H), ACCENT)
 
 
-class DriverInfoPanel:
-    """Telemetry box for one driver: speed, gear, DRS, compound, gaps.
+DRIVER_ROW_LABELS: Final[tuple[str, ...]] = (
+    "Speed",
+    "Gear",
+    "DRS",
+    "Compound",
+    "Ahead",
+    "Behind",
+)
 
-    Redesigned vs f1_replay's filled team-colour header: a neutral
-    CONTENT_BG card with a 3 px team-colour strip on top and the driver
-    code rendered in team colour, instead of a clone of the reference app."""
+
+def driver_rows(
+    data: dict,
+    ahead: str,
+    behind: str,
+) -> list[tuple[str, str, tuple[int, int, int]]]:
+    """One driver's six label/value/colour rows, as finished strings.
+
+    Split out of the panel's draw call for the reason ``_weather_rows`` was
+    (#1087): the rendered TEXT is then assertable without a GL context, and a
+    check that needs a window is a check that does not run in CI.
+    """
+    tyre = int(data.get("tyre", 1))
+    drs = data.get("drs", 0)
+    return [
+        ("Speed", f"{data.get('speed', 0):.0f} km/h", TEXT_PRIMARY),
+        ("Gear", f"{data.get('gear', 0)}", TEXT_PRIMARY),
+        ("DRS", DriverInfoPanel._drs_label(drs), DriverInfoPanel._drs_color(drs)),
+        ("Compound", COMPOUND_LETTERS.get(tyre, "?"), COMPOUND_COLORS.get(tyre, TEXT_PRIMARY)),
+        ("Ahead", ahead, TEXT_SECONDARY),
+        ("Behind", behind, TEXT_SECONDARY),
+    ]
+
+
+def driver_table(
+    per_driver: list[list[tuple[str, str, tuple[int, int, int]]]],
+) -> list[tuple[str, list[tuple[str, tuple[int, int, int]]]]]:
+    """Turn one row list per driver into one row per label, one cell per driver.
+
+    The two drivers used to get a card each, so the same six labels were drawn
+    twice under two headers: 354 px of column for twelve values (#1102). Here
+    the label is written once and each driver contributes a cell to it.
+
+    Raises when the row lists do not agree on their labels, because a table that
+    silently zips mismatched rows is how a value ends up under the wrong name.
+    """
+    if not per_driver:
+        return []
+    labels = [label for label, _, _ in per_driver[0]]
+    for rows in per_driver[1:]:
+        if [label for label, _, _ in rows] != labels:
+            raise ValueError(f"driver row labels disagree: {labels} vs {[r[0] for r in rows]}")
+    return [
+        (label, [(rows[i][1], rows[i][2]) for rows in per_driver]) for i, label in enumerate(labels)
+    ]
+
+
+def driver_column_edges(
+    width: int,
+    column_count: int,
+    *,
+    pad_x: int = DRIVER_PAD_X,
+    label_min: int = DRIVER_LABEL_MIN,
+) -> tuple[float, ...]:
+    """Right edge of each value column, as an offset from the card's left edge.
+
+    Columns are equal and share whatever the label column does not need. The
+    minimum is 40 px rather than the width of the longest label, because a label
+    only has to clear the value on its OWN row: "Compound" is the widest at 64 px
+    and its value is a single letter, while "Ahead" is 37 px against a 103 px
+    value. Measured over 400 frames of a real race, the widest label-plus-value
+    pair on any row is 140 px, which one column of 118 plus a 40 px label
+    column clears by 18.
+
+    With one column this returns the card's own right padding, so a single
+    driver draws exactly where it did before the table existed.
+    """
+    inner = width - 2 * pad_x
+    column = (inner - label_min) / column_count
+    return tuple(pad_x + label_min + column * (i + 1) for i in range(column_count))
+
+
+class DriverInfoPanel:
+    """Telemetry table for one or two drivers: speed, gear, DRS, compound, gaps.
+
+    One card with a value column per driver rather than a card each. Two cards
+    carried the same six labels under two headers and 354 px of the left column
+    for twelve values, which is what left the controls legend nowhere to draw at
+    the default window height (#1096, #1102).
+
+    Visual identity, unchanged: a neutral CONTENT_BG card with a 3 px
+    team-colour strip on top and the driver code in team colour. With two
+    drivers the strip is split at the boundary between their columns, so which
+    colour belongs to which column is legible from the strip as well as from
+    the code above it.
+    """
 
     STRIP_H: int = 3
-    PAD_X: int = 12
+    PAD_X: int = DRIVER_PAD_X
 
     def __init__(
         self,
@@ -251,35 +343,40 @@ class DriverInfoPanel:
         top_y: int,
         width: int,
         height: int,
-        driver_code: str,
-        color: tuple[int, int, int],
+        drivers: Sequence[tuple[str, tuple[int, int, int]]],
     ) -> None:
+        if not drivers:
+            raise ValueError("a driver panel needs at least one driver")
         self.x = x
         self.top_y = top_y
         self.width = width
         self.height = height
-        self.code = driver_code
-        self.color = color
-        self._header = arcade.Text(
-            driver_code,
-            0,
-            0,
-            color,
-            15,
-            bold=True,
-            font_name=FONT_TITLE,
-            anchor_x="left",
-            anchor_y="center",
-        )
-        self._subheader = arcade.Text(
-            "DRIVER",
+        self.drivers = tuple(drivers)
+        self.codes = tuple(code for code, _ in self.drivers)
+        self._column_edges = driver_column_edges(width, len(self.drivers), pad_x=self.PAD_X)
+        self._headers = [
+            arcade.Text(
+                code,
+                0,
+                0,
+                color,
+                15,
+                bold=True,
+                font_name=FONT_TITLE,
+                anchor_x="right",
+                anchor_y="center",
+            )
+            for code, color in self.drivers
+        ]
+        self._caption = arcade.Text(
+            "DRIVERS" if len(self.drivers) > 1 else "DRIVER",
             0,
             0,
             TEXT_TERTIARY,
             9,
             bold=True,
             font_name=FONT_TITLE,
-            anchor_x="right",
+            anchor_x="left",
             anchor_y="center",
         )
         self._label = arcade.Text(
@@ -304,6 +401,11 @@ class DriverInfoPanel:
             anchor_y="center",
         )
 
+    @property
+    def bottom_y(self) -> int:
+        """Bottom edge of the card, which is what the legend measures against."""
+        return self.top_y - self.height
+
     def set_top(self, top_y: int) -> None:
         self.top_y = top_y
 
@@ -314,49 +416,59 @@ class DriverInfoPanel:
         gaps: RaceGapCalculator,
         frame_idx: int,
     ) -> None:
-        data = (frame.get("drivers") or {}).get(self.code)
-        if not data:
-            return
-        cx = self.x + self.width / 2
-        cy = self.top_y - self.height / 2
+        drivers_in_frame = frame.get("drivers") or {}
+        per_driver: list[list[tuple[str, str, tuple[int, int, int]]]] = []
+        for code in self.codes:
+            data = drivers_in_frame.get(code)
+            if not data:
+                return
+            ahead, behind = self._neighbor_gaps(code, all_drivers_sorted, gaps, frame, frame_idx)
+            per_driver.append(driver_rows(data, ahead, behind))
 
-        arcade.draw_rect_filled(arcade.XYWH(cx, cy, self.width, self.height), (*CONTENT_BG, 230))
-        arcade.draw_rect_outline(arcade.XYWH(cx, cy, self.width, self.height), BORDER_COLOR, 1)
-        strip_cy = self.top_y - self.STRIP_H / 2
-        arcade.draw_rect_filled(arcade.XYWH(cx, strip_cy, self.width, self.STRIP_H), self.color)
-        header_cy = self.top_y - DRIVER_HEADER_HEIGHT / 2
-        self._header.x = self.x + self.PAD_X
-        self._header.y = header_cy
-        self._header.draw()
-        self._subheader.x = self.x + self.width - self.PAD_X
-        self._subheader.y = header_cy
-        self._subheader.draw()
-
-        ahead, behind = self._neighbor_gaps(all_drivers_sorted, gaps, frame, frame_idx)
-        rows: list[tuple[str, str, tuple[int, int, int]]] = [
-            ("Speed", f"{data.get('speed', 0):.0f} km/h", TEXT_PRIMARY),
-            ("Gear", f"{data.get('gear', 0)}", TEXT_PRIMARY),
-            ("DRS", self._drs_label(data.get("drs", 0)), self._drs_color(data.get("drs", 0))),
-            (
-                "Compound",
-                COMPOUND_LETTERS.get(int(data.get("tyre", 1)), "?"),
-                COMPOUND_COLORS.get(int(data.get("tyre", 1)), TEXT_PRIMARY),
-            ),
-            ("Ahead", ahead, TEXT_SECONDARY),
-            ("Behind", behind, TEXT_SECONDARY),
-        ]
+        self._draw_card()
+        self._draw_header()
         y = self.top_y - DRIVER_HEADER_HEIGHT - 14
-        for label, value, color in rows:
+        for label, cells in driver_table(per_driver):
             self._label.text = label
             self._label.x = self.x + self.PAD_X
             self._label.y = y
             self._label.draw()
-            self._value.text = value
-            self._value.color = color
-            self._value.x = self.x + self.width - self.PAD_X
-            self._value.y = y
-            self._value.draw()
+            for edge, (value, color) in zip(self._column_edges, cells, strict=True):
+                self._value.text = value
+                self._value.color = color
+                self._value.x = self.x + edge
+                self._value.y = y
+                self._value.draw()
             y -= DRIVER_ROW_GAP
+
+    def _draw_card(self) -> None:
+        """The card body, its outline, and one strip segment per driver."""
+        cx = self.x + self.width / 2
+        cy = self.top_y - self.height / 2
+        arcade.draw_rect_filled(arcade.XYWH(cx, cy, self.width, self.height), (*CONTENT_BG, 230))
+        arcade.draw_rect_outline(arcade.XYWH(cx, cy, self.width, self.height), BORDER_COLOR, 1)
+
+        strip_cy = self.top_y - self.STRIP_H / 2
+        left = float(self.x)
+        for i, (_, color) in enumerate(self.drivers):
+            last = i == len(self.drivers) - 1
+            right = self.x + self.width if last else self.x + self._column_edges[i]
+            arcade.draw_rect_filled(
+                arcade.XYWH((left + right) / 2, strip_cy, right - left, self.STRIP_H),
+                color,
+            )
+            left = right
+
+    def _draw_header(self) -> None:
+        """The caption on the left, each driver's code over its own column."""
+        header_cy = self.top_y - DRIVER_HEADER_HEIGHT / 2
+        self._caption.x = self.x + self.PAD_X
+        self._caption.y = header_cy
+        self._caption.draw()
+        for header, edge in zip(self._headers, self._column_edges, strict=True):
+            header.x = self.x + edge
+            header.y = header_cy
+            header.draw()
 
     @staticmethod
     def _drs_label(drs: int) -> str:
@@ -385,15 +497,21 @@ class DriverInfoPanel:
 
     def _neighbor_gaps(
         self,
+        code: str,
         sorted_drivers: list[tuple[str, float | None]] | None,
         gaps: RaceGapCalculator,
         frame: dict,
         frame_idx: int,
     ) -> tuple[str, str]:
+        """The intervals either side of `code`, as the timing screen shows them.
+
+        Takes the code rather than reading one off the panel, because the panel
+        now holds a column per driver instead of belonging to one.
+        """
         if not sorted_drivers:
             return "N/A", "N/A"
-        codes = [code for code, _ in sorted_drivers]
-        if self.code not in codes:
+        codes = [c for c, _ in sorted_drivers]
+        if code not in codes:
             return "N/A", "N/A"
         # Inactive is not retired. A finisher's telemetry ends the moment he
         # takes the flag, so reading `active` alone put "NOR OUT" on the
@@ -404,7 +522,7 @@ class DriverInfoPanel:
             for code, data in (frame.get("drivers") or {}).items()
             if not (data or {}).get("active", True) and not gaps.has_finished(code)
         }
-        idx = codes.index(self.code)
+        idx = codes.index(code)
         me = sorted_drivers[idx]
         ahead = (
             "LEADER"

--- a/tests/surfaces/test_arcade_driver_table.py
+++ b/tests/surfaces/test_arcade_driver_table.py
@@ -1,0 +1,205 @@
+"""The driver table carries every value the two cards did (#1102).
+
+Two stacked cards repeated the same six labels under two headers and took 354 px
+of the left column for twelve values, which is what left the controls legend
+nowhere to draw at the default window height (#1096). One table with a column
+per driver carries the same twelve in 177.
+
+**Asserted on pure functions, not on a rendered card.** The strings are built
+between GL calls in ``DriverInfoPanel.draw``, so a check on the drawn result
+needs a display and a check that needs a display does not run in CI.
+``_weather_rows`` was split out for exactly this reason and this file follows it.
+
+The column arithmetic is checked against widths MEASURED off the live
+``arcade.Text`` objects over 400 frames of a real race, listed in ``WIDEST``,
+because what the font renders is the one thing a pure function cannot produce.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.arcade.config import (
+    COMPOUND_COLORS,
+    COMPOUND_LETTERS,
+    DRIVER_BOX_WIDTH,
+    DRIVER_LABEL_MIN,
+    DRIVER_PAD_X,
+    TEXT_PRIMARY,
+    TEXT_SECONDARY,
+)
+from src.arcade.overlays import (
+    DRIVER_ROW_LABELS,
+    driver_column_edges,
+    driver_rows,
+    driver_table,
+)
+
+# Rendered widths of the label and the widest value each row produced, measured
+# 2026-08-27 over 400 frames of Melbourne 2025 with NOR and VER, read off the
+# panel's own Text objects. The gap rows are the wide ones: they carry the
+# neighbour's code, a signed interval and the "(L)" suffix.
+WIDEST: dict[str, tuple[float, float]] = {
+    "Speed": (36, 63),
+    "Gear": (27, 8),
+    "DRS": (24, 39),
+    "Compound": (64, 6),
+    "Ahead": (37, 103),
+    "Behind": (40, 100),
+}
+
+# A gap can be wider than anything that race produced: three digits of seconds
+# and a four-character code. At the ~7 px per character the measurements imply,
+# that is about this.
+WORST_CASE_VALUE = 115.0
+
+
+def _frame(speed: float = 232.0, gear: int = 6, drs: int = 0, tyre: int = 1) -> dict:
+    return {"speed": speed, "gear": gear, "drs": drs, "tyre": tyre}
+
+
+def test_a_driver_produces_the_six_rows_in_order() -> None:
+    """The labels are the contract the table zips on, so their order is data."""
+    rows = driver_rows(_frame(), "VER +2.36s (L)", "PIA -1.80s (L)")
+    assert [label for label, _, _ in rows] == list(DRIVER_ROW_LABELS)
+
+
+def test_every_value_the_two_cards_showed_is_still_shown() -> None:
+    """The scope constraint, asserted rather than assumed.
+
+    #1098 is explicit that nothing is added and nothing is removed: the same
+    numbers are arranged once instead of twice.
+    """
+    rows = driver_rows(_frame(speed=269.4, gear=7, drs=12, tyre=2), "AHEAD", "BEHIND")
+    values = {label: value for label, value, _ in rows}
+    assert values == {
+        "Speed": "269 km/h",
+        "Gear": "7",
+        "DRS": "ON",
+        "Compound": COMPOUND_LETTERS[2],
+        "Ahead": "AHEAD",
+        "Behind": "BEHIND",
+    }
+
+
+def test_the_compound_keeps_its_own_colour() -> None:
+    """Colour is the compound's identity on a timing screen, not decoration."""
+    rows = driver_rows(_frame(tyre=2), "a", "b")
+    colours = {label: colour for label, _, colour in rows}
+    assert colours["Compound"] == COMPOUND_COLORS[2]
+    assert colours["Speed"] == TEXT_PRIMARY
+    assert colours["Ahead"] == TEXT_SECONDARY
+
+
+def test_two_drivers_make_one_row_per_label_with_a_cell_each() -> None:
+    """The shape of the whole change: twelve values under six labels, not two sets."""
+    main = driver_rows(_frame(speed=232, gear=6), "VER +2.36s (L)", "PIA -1.80s (L)")
+    rival = driver_rows(_frame(speed=269, gear=7), "HAM +3.80s (L)", "NOR -2.36s (L)")
+    table = driver_table([main, rival])
+
+    assert [label for label, _ in table] == list(DRIVER_ROW_LABELS)
+    assert all(len(cells) == 2 for _, cells in table)
+    by_label = {label: [value for value, _ in cells] for label, cells in table}
+    assert by_label["Speed"] == ["232 km/h", "269 km/h"]
+    assert by_label["Ahead"] == ["VER +2.36s (L)", "HAM +3.80s (L)"]
+
+    flattened = [value for _, cells in table for value, _ in cells]
+    assert len(flattened) == 12, "twelve values went in and twelve must come out"
+
+
+def test_one_driver_still_makes_a_table() -> None:
+    """One column is the same code path, which is why there is only one panel."""
+    table = driver_table([driver_rows(_frame(), "a", "b")])
+    assert [label for label, _ in table] == list(DRIVER_ROW_LABELS)
+    assert all(len(cells) == 1 for _, cells in table)
+
+
+def test_mismatched_rows_raise_instead_of_zipping_quietly() -> None:
+    """A cell under the wrong label is the failure a silent zip would produce."""
+    good = driver_rows(_frame(), "a", "b")
+    shuffled = [good[1], good[0], *good[2:]]
+    with pytest.raises(ValueError, match="labels disagree"):
+        driver_table([good, shuffled])
+
+
+def test_no_drivers_makes_an_empty_table_rather_than_raising() -> None:
+    """`driver_table` is arithmetic; refusing a driver is the panel's job."""
+    assert driver_table([]) == []
+
+
+# --- The columns fit what the font actually renders ------------------------
+
+
+def test_one_column_ends_where_the_single_card_used_to() -> None:
+    """A single driver must draw exactly where it did before the table existed.
+
+    The old card right-aligned its value at `x + width - PAD_X`, so a one-column
+    table has to land on the same edge or the change is not the no-op it claims
+    to be for that case.
+    """
+    (edge,) = driver_column_edges(DRIVER_BOX_WIDTH, 1)
+    assert edge == DRIVER_BOX_WIDTH - DRIVER_PAD_X
+
+
+def test_two_columns_are_equal_and_fill_the_card() -> None:
+    """Equal columns, and the last one ends on the card's own padding."""
+    first, second = driver_column_edges(DRIVER_BOX_WIDTH, 2)
+    assert second == DRIVER_BOX_WIDTH - DRIVER_PAD_X
+    assert second - first == first - (DRIVER_PAD_X + DRIVER_LABEL_MIN)
+
+
+@pytest.mark.parametrize("columns", [1, 2])
+def test_no_label_can_reach_the_value_beside_it(columns: int) -> None:
+    """Checked per row, because a label only competes with its OWN row's value.
+
+    This is why the label column is 40 px and not 64: `Compound` is the widest
+    label at 64 and sits beside a single letter, while the 103 px gap values sit
+    beside labels of 37 and 40. Reserving the widest label for every row would
+    have cost 24 px the wide rows needed.
+    """
+    edges = driver_column_edges(DRIVER_BOX_WIDTH, columns)
+    label_left = DRIVER_PAD_X
+    for label, (label_width, value_width) in WIDEST.items():
+        value_left = edges[0] - value_width
+        assert label_left + label_width < value_left, (
+            f"{label}: a {label_width} px label reaches a value starting at {value_left}"
+        )
+
+
+@pytest.mark.parametrize("columns", [1, 2])
+def test_no_column_can_reach_the_one_before_it(columns: int) -> None:
+    """A value is right-aligned, so it grows leftward into its neighbour."""
+    edges = driver_column_edges(DRIVER_BOX_WIDTH, columns)
+    previous_edge = DRIVER_PAD_X + DRIVER_LABEL_MIN
+    for edge in edges:
+        assert edge - WORST_CASE_VALUE > previous_edge, (
+            f"a {WORST_CASE_VALUE} px value in the column ending at {edge} "
+            f"overruns the one ending at {previous_edge}"
+        )
+        previous_edge = edge
+
+
+def test_the_widest_measured_row_clears_by_a_readable_margin() -> None:
+    """Not merely non-overlapping: the numbers stay separable at a glance.
+
+    The binding row is either gap row, at 140 px of label plus value against a
+    118 px column plus a 40 px label column.
+    """
+    first, _ = driver_column_edges(DRIVER_BOX_WIDTH, 2)
+    widest_pair = max(label + value for label, value in WIDEST.values())
+    assert widest_pair == 140
+    assert first - DRIVER_PAD_X - widest_pair >= 12
+
+
+def test_a_third_column_would_not_fit_and_the_test_says_so() -> None:
+    """Bounding the generalisation rather than leaving it implied.
+
+    The panel takes a sequence, so three drivers is expressible. It does not fit
+    at this card width, and a future rival-comparison feature has to widen the
+    card rather than assume the columns will divide.
+    """
+    edges = driver_column_edges(DRIVER_BOX_WIDTH, 3)
+    column = edges[1] - edges[0]
+    assert column < WORST_CASE_VALUE, (
+        "three columns now fit, so this bound is stale rather than the panel wrong"
+    )

--- a/tests/surfaces/test_arcade_leaderboard_gaps.py
+++ b/tests/surfaces/test_arcade_leaderboard_gaps.py
@@ -144,15 +144,19 @@ def _order(session: SessionData, idx: int) -> list[str]:
 
 
 def _panel(code: str):
-    """A stand-in for DriverInfoPanel: `_neighbor_gaps` reads only `self.code`.
+    """A stand-in for DriverInfoPanel: `_neighbor_gaps` reads no panel state.
 
     Constructing the real panel allocates `arcade.Text`, which wants a GL
-    context CI does not have. Duck-typing also keeps the test honest the
-    other way: a method that starts reading another attribute raises here
-    instead of passing.
+    context CI does not have. Duck-typing also keeps the test honest the other
+    way: a method that starts reading an attribute raises here instead of
+    passing.
+
+    Since #1102 the panel holds a column per driver rather than belonging to
+    one, so the code is an argument. It is bound here so the callers below read
+    the same as they did.
     """
-    stand_in = SimpleNamespace(code=code, _gap_label=DriverInfoPanel._gap_label)
-    stand_in._neighbor_gaps = lambda *a: DriverInfoPanel._neighbor_gaps(stand_in, *a)
+    stand_in = SimpleNamespace(_gap_label=DriverInfoPanel._gap_label)
+    stand_in._neighbor_gaps = lambda *a: DriverInfoPanel._neighbor_gaps(stand_in, code, *a)
     return stand_in
 
 

--- a/tests/surfaces/test_arcade_legend_fit.py
+++ b/tests/surfaces/test_arcade_legend_fit.py
@@ -1,9 +1,16 @@
-"""The controls legend never draws over the driver cards (#1096).
+"""The controls legend never draws over the driver table (#1096, #1102).
 
-At the default 1280x720 with two drivers the left column leaves 146 px below
-the lowest card and the full legend spans 154, so it drew straight over the
-rival card's DRS, Compound and Ahead rows. Two drivers is what the menu opens
-with, so this was the out-of-the-box first frame.
+At the default 1280x720 with two drivers the left column used to leave 146 px
+below the lowest of two stacked cards while the full legend spans 158, so it
+drew straight over the rival card's DRS, Compound and Ahead rows. Two drivers is
+what the menu opens with, so this was the out-of-the-box first frame.
+
+#1102 replaced the two cards with one table carrying a column per driver, which
+removes the constraint rather than managing it: the column is 177 px deep at any
+driver count instead of 354, so 720 leaves 263 px and the full list fits. The
+collapse is NOT dead code, and this file is where that is checked. It now fires
+below about 618 px of window height rather than below 788, and the sweep keeps
+600 in it for exactly that reason.
 
 **Asserted on a pure function, not on a rendered window.** The geometry lives
 between GL calls in ``on_draw``, so a check on the drawn result needs a display,
@@ -53,15 +60,17 @@ def _weather_bottom(window_height: int) -> int:
 
 
 def _lowest_card_bottom(window_height: int, *, has_rival: bool) -> int:
-    """Bottom edge of the last card in the left column, mirroring ``on_draw``.
+    """Bottom edge of the driver table, mirroring ``on_draw``.
 
-    The cards chain off the weather panel's bottom, so the whole column
-    translates 1:1 with the window height and only the card COUNT changes.
+    The table chains off the weather panel's bottom, so the column translates
+    1:1 with the window height. Since #1102 the driver COUNT no longer changes
+    the depth: one and two drivers are the same table with one or two value
+    columns, so `has_rival` is accepted and deliberately unused. The parameter
+    stays because the assertions below sweep both modes and a silently
+    driver-count-independent column is itself worth asserting.
     """
-    main_bottom = _weather_bottom(window_height) - DRIVER_BOX_GAP - DRIVER_BOX_HEIGHT
-    if not has_rival:
-        return main_bottom
-    return main_bottom - DRIVER_BOX_GAP - DRIVER_BOX_HEIGHT
+    del has_rival
+    return _weather_bottom(window_height) - DRIVER_BOX_GAP - DRIVER_BOX_HEIGHT
 
 
 def test_the_model_matches_the_geometry_measured_on_a_real_window() -> None:
@@ -75,7 +84,7 @@ def test_the_model_matches_the_geometry_measured_on_a_real_window() -> None:
     """
     assert _weather_bottom(720) == 500
     assert _weather_bottom(800) == 580
-    assert _lowest_card_bottom(720, has_rival=True) == 146
+    assert _lowest_card_bottom(720, has_rival=True) == 323
     assert _lowest_card_bottom(720, has_rival=False) == 323
 
 
@@ -114,22 +123,50 @@ def test_the_sweep_reaches_both_modes() -> None:
     assert modes == {"full", "hint"}, f"the sweep only ever produced {modes}"
 
 
-def test_the_default_window_with_two_drivers_collapses() -> None:
-    """The exact case the defect was, named so a regression is legible.
+def test_the_default_window_with_two_drivers_now_fits_the_full_list() -> None:
+    """The exact case the defect was, inverted by #1102.
 
-    1280x720 is `SCREEN_HEIGHT`, and the menu opens on two drivers, so this is
-    the first frame of a default launch rather than an edge case.
+    1280x720 is `SCREEN_HEIGHT` and the menu opens on two drivers, so this is
+    the first frame of a default launch. It used to leave 146 px against a list
+    that needs 158 and collapse to a hint; one table leaves 263 and the list
+    fits, which is the measurable win #1102 was asked for.
     """
     space = _space_below(720, has_rival=True)
+    assert space == 263
+    assert space >= legend_span(len(ControlsLegend.LINES))
+    assert legend_mode(space, len(ControlsLegend.LINES)) == "full"
+
+
+def test_the_collapse_still_fires_on_a_window_a_user_can_produce() -> None:
+    """#1102 must not turn #1096's fix into a branch nobody can reach.
+
+    The window is resizable with no minimum, so the heights below the crossover
+    are reached by dragging. If this ever fails the collapse has become dead
+    code and the branch should be reconsidered rather than kept unreachable.
+    """
+    space = _space_below(600, has_rival=True)
     assert space < legend_span(len(ControlsLegend.LINES))
     assert legend_mode(space, len(ControlsLegend.LINES)) == "hint"
+
+
+def test_the_driver_count_no_longer_changes_the_column_depth() -> None:
+    """One table, one depth, which is what freed the room (#1102).
+
+    Two stacked cards cost 354 px and a table costs 177 whether it carries one
+    column or two, so the geometry that produced the overlap is gone rather
+    than merely accommodated.
+    """
+    for height in HEIGHTS:
+        assert _lowest_card_bottom(height, has_rival=True) == _lowest_card_bottom(
+            height, has_rival=False
+        )
 
 
 def test_one_driver_at_the_default_height_still_gets_the_full_list() -> None:
     """The fix must not collapse a legend that fits.
 
-    A single driver leaves a whole card's worth of room at 720, so collapsing
-    there would be the fix over-reaching.
+    This held before #1102 because a single card left a whole card's worth of
+    room, and holds after it because the table is that same depth.
     """
     space = _space_below(720, has_rival=False)
     assert space >= legend_span(len(ControlsLegend.LINES))


### PR DESCRIPTION
## What

The replay's two stacked driver cards become one table with a value column per driver. Same twelve values, one header instead of two.

## Why

Each card was `DRIVER_BOX_HEIGHT = 145` with its own team strip, its own driver header and the rows `Speed`, `Gear`, `DRS`, `Compound`, `Ahead`, `Behind`. Two of them plus `DRIVER_BOX_GAP` twice is 354 px of the left column for twelve values, and that is what left the controls legend nowhere to draw at the default window height (#1096).

Measured on a hidden window with the real Melbourne 2025 session, 1280x720, two drivers:

| | before | after |
|---|---:|---:|
| column depth below the weather card | 354 px | 177 px |
| lowest card bottom | 146 | 323 |
| space above the legend's anchor | 86 px | 263 px |
| legend needs | 158 px | 158 px |
| `legend_mode` | `hint` | **`full`** |
| height where the collapse starts | below 788 | below ~618 |

That last row is the acceptance test #1102 was given, and it passes: the full list fits at the default height with two drivers, so the constraint is removed rather than managed.

**#1096's collapse is not dead code.** The window is resizable with no minimum, so heights below 618 are reached by dragging, and `test_arcade_legend_fit` keeps 600 in its sweep for exactly that. A new test asserts the collapse still fires there, so if it ever stops the branch gets reconsidered rather than kept unreachable.

## How

`DriverInfoPanel` takes a sequence of `(code, colour)` instead of one driver. Three pure functions come out of the draw call:

- `driver_rows(data, ahead, behind)` builds one driver's six label/value/colour rows, the `_weather_rows` (#1087) precedent.
- `driver_table(per_driver)` turns one row list per driver into one row per label with a cell each. It **raises** when the row lists disagree on their labels, because a table that silently zips mismatched rows is how a value ends up under the wrong name.
- `driver_column_edges(width, column_count)` divides the card.

**The label column is 40 px, not the 64 the widest label needs.** A label only competes with the value on its own row: `Compound` is the widest label at 64 px and sits beside a single letter, while the 103 px gap values sit beside labels of 37 and 40. Reserving the widest label for every row would have cost 24 px that the wide rows needed, and would have forced the card wider than `MARGIN_LEFT` allows. With 40 the two columns are 118 px each and the widest measured label-plus-value pair, 140 px, clears by 18. **No constant changed size and the card is still 300x145.**

Two smaller decisions:

- The team strip splits at the boundary between the two columns rather than at the card's midpoint, so which colour belongs to which column reads from the strip as well as from the code above it. With one driver it is the full-width single colour it always was.
- The header caption moves to the left and the codes to the right over their own columns, which is what the six rows below already did. The single-driver card had them the other way round, so that one case does change.

`docs/pages/arcade-quick-start.md` described the old geometry by the numbers (`154 px`, `two driver cards leave 146`) and is updated in the same change, per the standing rule that the page describing a contract is part of the fix.

## Checks

- New `tests/surfaces/test_arcade_driver_table.py`, 15 guards, all pure. Includes an explicit "twelve values went in and twelve must come out" assertion, since #1098's scope is that nothing is added or removed.
- `tests/surfaces/test_arcade_legend_fit.py` gains 2 and has its card arithmetic and its default-height assertion rewritten. The old `test_the_default_window_with_two_drivers_collapses` said the default collapses; it now says the default fits, which is the inversion this PR is for.
- Four mutants watched red:
  - **J**, reserve the widest label (64) for the label column: 4 failures, including the worst-case column overrun.
  - **K**, `driver_table` zips without checking labels: 1 failure.
  - **L**, the `Behind` row dropped: 4 failures.
  - **M**, the two-card arithmetic restored in the legend guard: 3 failures, which is what makes the win a measurement rather than an assertion.
- `tests/surfaces/test_arcade_leaderboard_gaps.py` needed its `DriverInfoPanel` stand-in updated, because `_neighbor_gaps` takes the driver code now that the panel does not belong to one. Its 34 tests pass unchanged otherwise.
- `tests/surfaces` 384 -> 401 and `tests/agents` 259 passed / 13 skipped, both executed.
- `ruff check .` and `ruff format --check .` clean, 192 files.
- Rendered offscreen with real telemetry at 1280x720 (one driver and two) and 1920x1080 and looked at all three. The full controls list draws at the default height with two drivers, which it could not before.

## Out of scope

#1103, laying the replay out around the circuit, which depends on this one because this changes how much space is free.

Part of #1098.
