### PR TITLE
refactor(arcade): lay the replay out around the circuit

### DIFF
--- a/src/arcade/app.py
+++ b/src/arcade/app.py
@@ -36,11 +36,11 @@ from src.arcade.config import (
     FPS,
     LEADERBOARD_RIGHT_MARGIN,
     LEADERBOARD_WIDTH,
-    MARGIN_BOTTOM,
+    LEFT_PANEL_X,
     MARGIN_LEFT,
     MARGIN_RIGHT,
-    MARGIN_TOP,
     PLAYBACK_SPEEDS,
+    PLAYBACK_STATE_Y,
     SEEK_RATE_MULTIPLIER,
     STREAM_BROADCAST_EVERY_N_FRAMES,
     STREAM_HISTORY_TAIL,
@@ -63,7 +63,7 @@ from src.arcade.overlays import (
     WeatherPanel,
     track_status_label,
 )
-from src.arcade.track import Track
+from src.arcade.track import Track, track_viewport
 
 logger = logging.getLogger(__name__)
 
@@ -283,14 +283,7 @@ class F1ArcadeView(arcade.View):
             self._selected_drivers.add(driver_rival)
 
         w, h = window.width, window.height
-        self._track.update_scaling(
-            w,
-            h,
-            margin_left=MARGIN_LEFT,
-            margin_right=MARGIN_RIGHT,
-            margin_bottom=MARGIN_BOTTOM,
-            margin_top=MARGIN_TOP,
-        )
+        self._track.update_scaling(track_viewport(w, h))
 
         self._lap_label = arcade.Text(
             "LAP",
@@ -346,13 +339,24 @@ class F1ArcadeView(arcade.View):
         if driver_rival:
             followed.append((driver_rival, self._color_for(driver_rival)))
         self._driver_info = DriverInfoPanel(
-            x=20,
+            x=LEFT_PANEL_X,
             top_y=h - 200,
             width=DRIVER_BOX_WIDTH,
             height=DRIVER_BOX_HEIGHT,
             drivers=followed,
         )
 
+        self._playback_text = arcade.Text(
+            "",
+            0,
+            0,
+            TEXT_TERTIARY,
+            11,
+            bold=True,
+            font_name=FONT_BODY,
+            anchor_x="left",
+            anchor_y="center",
+        )
         self._progress_bar = ProgressBar(
             total_frames=session_data.total_frames,
             total_laps=session_data.max_lap_number,
@@ -981,14 +985,7 @@ class F1ArcadeView(arcade.View):
             self._selected_drivers = {code}
 
     def on_resize(self, width: float, height: float) -> None:
-        self._track.update_scaling(
-            int(width),
-            int(height),
-            margin_left=MARGIN_LEFT,
-            margin_right=MARGIN_RIGHT,
-            margin_bottom=MARGIN_BOTTOM,
-            margin_top=MARGIN_TOP,
-        )
+        self._track.update_scaling(track_viewport(int(width), int(height)))
         self._leaderboard.x = int(width) - LEADERBOARD_RIGHT_MARGIN
         self._leaderboard.set_top(int(height) - 20)
         # The race-events pill rides the leaderboard's right edge; on_draw
@@ -1107,8 +1104,16 @@ class F1ArcadeView(arcade.View):
         hh = int(t // 3600)
         mm = int((t % 3600) // 60)
         ss = int(t % 60)
-        paused = "  PAUSED" if self._is_paused else ""
-        self._time_text.text = f"{hh:02d}:{mm:02d}:{ss:02d}  x{self.playback_speed}{paused}"
+        self._time_text.text = f"{hh:02d}:{mm:02d}:{ss:02d}"
         self._lap_label.draw()
         self._lap_text.draw()
         self._time_text.draw()
+        # Playback state sits with the playback control rather than under the
+        # lap counter. The speed multiplier and PAUSED describe the replay, the
+        # lap and the clock describe the race, and the band above the progress
+        # bar was empty while these two rode in the top-left corner (#1103).
+        paused = "  PAUSED" if self._is_paused else ""
+        self._playback_text.text = f"x{self.playback_speed}{paused}"
+        self._playback_text.x = MARGIN_LEFT
+        self._playback_text.y = PLAYBACK_STATE_Y
+        self._playback_text.draw()

--- a/src/arcade/config.py
+++ b/src/arcade/config.py
@@ -31,14 +31,37 @@ SCREEN_HEIGHT: Final[int] = 720
 WINDOW_TITLE: Final[str] = "F1 StratLab - Race Replay"
 
 # --- Viewport margins (reserve UI space before fitting track) -------------
-MARGIN_LEFT: Final[int] = 340
+# The circuit's viewport, as insets from the window's edges. Each one is what a
+# panel actually occupies plus a small gap, not a round number: the left column
+# is LEFT_PANEL_X + DRIVER_BOX_WIDTH wide and the leaderboard reserves
+# LEADERBOARD_RIGHT_MARGIN, so anything more is space the circuit is denied for
+# nothing. `track_viewport` in `track.py` is where they are combined, and
+# `tests/surfaces/test_arcade_track_viewport.py` is what keeps them honest.
+MARGIN_LEFT: Final[int] = 330
 MARGIN_RIGHT: Final[int] = 260
 MARGIN_BOTTOM: Final[int] = 90
 MARGIN_TOP: Final[int] = 20
-TRACK_PADDING: Final[float] = 0.05
+# Fraction of the viewport left empty on each side, so the trace is not flush
+# against the panels. At 0.05 it cost 68 px of a 680 px viewport at 1280x720,
+# which is width the circuit is short of: the trace is limited by the viewport's
+# WIDTH at every window size, and every pixel of padding comes straight off it.
+TRACK_PADDING: Final[float] = 0.02
+# Floor under that fraction, in pixels. A car is drawn ON the trace with its
+# three-letter code centred above or below the dot, so the trace has to stop
+# short of the panels by more than the trace itself: the widest three-letter
+# label renders 42 px, which is 21 either side of the car. At 0.02 the fraction
+# alone gives 14 px in a 1280-wide window, so the floor is what stops a label
+# reaching the leaderboard there. The old 0.05 cleared it by accident.
+TRACK_MIN_CLEARANCE: Final[int] = 22
+# Half the widest three-letter driver label, measured on the real font at
+# CAR_LABEL_FONT_SIZE. Read by the guard that keeps the clearance above honest.
+CAR_LABEL_MAX_HALF_WIDTH: Final[int] = 21
 
 # --- Weather panel --------------------------------------------------------
-WEATHER_LEFT: Final[int] = 20
+# Left edge of every panel in the left column, weather card and driver table
+# alike. Named because the track's viewport is derived from it.
+LEFT_PANEL_X: Final[int] = 20
+WEATHER_LEFT: Final[int] = LEFT_PANEL_X
 WEATHER_TOP_OFFSET: Final[int] = 90
 WEATHER_WIDTH: Final[int] = 280
 WEATHER_ROW_GAP: Final[int] = 22
@@ -68,6 +91,10 @@ LEADERBOARD_N_SLOTS: Final[int] = 22
 # --- Progress bar ---------------------------------------------------------
 PROGRESS_BAR_BOTTOM: Final[int] = 30
 PROGRESS_BAR_HEIGHT: Final[int] = 24
+# Centre line of the playback readout, in the band between the progress bar's
+# top edge and MARGIN_BOTTOM. That band was empty while the speed multiplier and
+# PAUSED rode in the top-left corner under the lap counter (#1103).
+PLAYBACK_STATE_Y: Final[int] = 72
 
 # --- Controls legend ------------------------------------------------------
 LEGEND_X: Final[int] = 20
@@ -82,6 +109,10 @@ LEGEND_BOTTOM: Final[int] = 60
 # dependency-free from the backend package.
 BG_COLOR: Final[tuple[int, int, int]] = (18, 17, 39)  # #121127 PRIMARY_BG
 CONTENT_BG: Final[tuple[int, int, int]] = (24, 22, 51)  # #181633 CONTENT_BG (panels)
+# How opaque a panel's card is drawn over the background. Below full so the
+# panels read as surfaces laid on the scene rather than as holes cut in it, and
+# so the circuit is what the eye reaches first.
+PANEL_FILL_ALPHA: Final[int] = 205
 SECONDARY_BG: Final[tuple[int, int, int]] = (30, 27, 75)  # #1e1b4b SECONDARY_BG
 BORDER_COLOR: Final[tuple[int, int, int]] = (45, 45, 58)  # #2d2d3a BORDER
 TEXT_PRIMARY: Final[tuple[int, int, int]] = (255, 255, 255)  # #ffffff
@@ -98,8 +129,11 @@ FONT_BODY: Final[tuple[str, ...]] = ("Inter", "Segoe UI", "Arial")
 FONT_TITLE: Final[tuple[str, ...]] = ("Exo 2", "Inter", "Segoe UI", "Arial")
 
 # --- Track rendering ------------------------------------------------------
-TRACK_EDGE_COLOR: Final[tuple[int, int, int]] = (150, 150, 150)
-TRACK_EDGE_WIDTH: Final[int] = 4
+# The circuit is the reason the window exists, so it is the brightest thing
+# drawn on the background rather than the dimmest. It used to sit at 150 grey
+# against panels whose borders and team-colour strips were louder than it.
+TRACK_EDGE_COLOR: Final[tuple[int, int, int]] = (188, 188, 196)
+TRACK_EDGE_WIDTH: Final[int] = 5
 TRACK_FILL_COLOR: Final[tuple[int, int, int]] = (40, 40, 44)
 DRS_COLOR: Final[tuple[int, int, int]] = (0, 220, 0)
 DRS_WIDTH: Final[int] = 5

--- a/src/arcade/overlays.py
+++ b/src/arcade/overlays.py
@@ -35,6 +35,7 @@ from src.arcade.config import (
     LEADERBOARD_WIDTH,
     LEGEND_BOTTOM,
     LEGEND_X,
+    PANEL_FILL_ALPHA,
     PROGRESS_BAR_BOTTOM,
     PROGRESS_BAR_HEIGHT,
     TEXT_PRIMARY,
@@ -232,7 +233,9 @@ class WeatherPanel:
     def _draw_card(self, top_y: int, panel_h: int) -> None:
         cx = self.x + self.width / 2
         cy = top_y - panel_h / 2
-        arcade.draw_rect_filled(arcade.XYWH(cx, cy, self.width, panel_h), (*CONTENT_BG, 230))
+        arcade.draw_rect_filled(
+            arcade.XYWH(cx, cy, self.width, panel_h), (*CONTENT_BG, PANEL_FILL_ALPHA)
+        )
         arcade.draw_rect_outline(arcade.XYWH(cx, cy, self.width, panel_h), BORDER_COLOR, 1)
         strip_cy = top_y - self.STRIP_H / 2
         arcade.draw_rect_filled(arcade.XYWH(cx, strip_cy, self.width, self.STRIP_H), ACCENT)
@@ -445,7 +448,9 @@ class DriverInfoPanel:
         """The card body, its outline, and one strip segment per driver."""
         cx = self.x + self.width / 2
         cy = self.top_y - self.height / 2
-        arcade.draw_rect_filled(arcade.XYWH(cx, cy, self.width, self.height), (*CONTENT_BG, 230))
+        arcade.draw_rect_filled(
+            arcade.XYWH(cx, cy, self.width, self.height), (*CONTENT_BG, PANEL_FILL_ALPHA)
+        )
         arcade.draw_rect_outline(arcade.XYWH(cx, cy, self.width, self.height), BORDER_COLOR, 1)
 
         strip_cy = self.top_y - self.STRIP_H / 2
@@ -737,7 +742,9 @@ class LeaderboardPanel:
     def _draw_card(self, panel_h: int) -> None:
         cx = self.x + self.width / 2
         cy = self.top_y - panel_h / 2
-        arcade.draw_rect_filled(arcade.XYWH(cx, cy, self.width, panel_h), (*CONTENT_BG, 230))
+        arcade.draw_rect_filled(
+            arcade.XYWH(cx, cy, self.width, panel_h), (*CONTENT_BG, PANEL_FILL_ALPHA)
+        )
         arcade.draw_rect_outline(arcade.XYWH(cx, cy, self.width, panel_h), BORDER_COLOR, 1)
         strip_cy = self.top_y - self.STRIP_H / 2
         arcade.draw_rect_filled(arcade.XYWH(cx, strip_cy, self.width, self.STRIP_H), ACCENT)

--- a/src/arcade/track.py
+++ b/src/arcade/track.py
@@ -12,7 +12,7 @@ here and in the loader, which collapsed the outline into a pseudo-circle.
 from __future__ import annotations
 
 import logging
-from typing import Final
+from typing import Final, NamedTuple
 
 import numpy as np
 
@@ -23,10 +23,15 @@ from src.arcade.config import (
     DRS_WIDTH,
     FINISH_CHEQUER_SEGMENTS,
     FINISH_CHEQUER_WIDTH,
+    MARGIN_BOTTOM,
+    MARGIN_LEFT,
+    MARGIN_RIGHT,
+    MARGIN_TOP,
     TRACK_EDGE_COLOR,
     TRACK_EDGE_WIDTH,
     TRACK_INTERP_EDGE,
     TRACK_INTERP_REF,
+    TRACK_MIN_CLEARANCE,
     TRACK_PADDING,
     TRACK_WIDTH_WORLD,
 )
@@ -37,6 +42,81 @@ logger = logging.getLogger(__name__)
 # `drs_open` for PITWALL's DRS lane, so two subsystems read this fact and a second
 # copy of it is the twin this repo pays for most often.
 _DRS_OUTWARD_OFFSET: Final[float] = 0.9  # fraction of track_width beyond the outer edge
+
+
+class TrackViewport(NamedTuple):
+    """The rectangle the circuit is allowed to draw in, in scene coordinates."""
+
+    left: int
+    right: int
+    bottom: int
+    top: int
+
+    @property
+    def width(self) -> float:
+        return max(1.0, float(self.right - self.left))
+
+    @property
+    def height(self) -> float:
+        return max(1.0, float(self.top - self.bottom))
+
+    @property
+    def centre_x(self) -> float:
+        return (self.left + self.right) / 2.0
+
+    @property
+    def centre_y(self) -> float:
+        return (self.bottom + self.top) / 2.0
+
+
+def track_viewport(window_width: int, window_height: int) -> TrackViewport:
+    """What is left for the circuit once the panels have taken what they use.
+
+    **Pure on purpose**, the same reason `legend_mode` is (#1096): a check on
+    the drawn result needs a window and a check that needs a window does not run
+    in CI.
+
+    Each inset is derived from the panel that sits there rather than chosen, so
+    a panel that grows moves the circuit and one that shrinks gives space back:
+
+    - left, the driver table and the weather card, which start at
+      `LEFT_PANEL_X` and are at most `DRIVER_BOX_WIDTH` wide,
+    - right, the leaderboard, which reserves `LEADERBOARD_RIGHT_MARGIN`,
+    - bottom, the progress bar and the controls legend's hint line,
+    - top, a plain gap, since the lap readout sits over the left column.
+
+    The trace is limited by the viewport's WIDTH at every window size Melbourne
+    was measured at, so the left inset is the one that matters: it reserved 340
+    px for a column 320 px wide, and those 20 px came off the circuit for
+    nothing.
+    """
+    return TrackViewport(
+        left=MARGIN_LEFT,
+        right=window_width - MARGIN_RIGHT,
+        bottom=MARGIN_BOTTOM,
+        top=window_height - MARGIN_TOP,
+    )
+
+
+def track_inset(
+    viewport: TrackViewport,
+    *,
+    padding: float = TRACK_PADDING,
+    min_clearance: int = TRACK_MIN_CLEARANCE,
+) -> tuple[float, float]:
+    """Empty margin the trace keeps inside `viewport`, per axis.
+
+    A fraction alone is wrong at small window sizes. Cars are drawn ON the trace
+    with a three-letter code centred above or below the dot, so what has to
+    clear the panels is the label, not the polyline: at 0.02 the fraction gives
+    14 px in a 1280-wide window against a label that reaches 21 either side.
+    The floor is what makes the clearance a property of the label rather than of
+    the window (#1103).
+    """
+    return (
+        max(viewport.width * padding, float(min_clearance)),
+        max(viewport.height * padding, float(min_clearance)),
+    )
 
 
 class Track:
@@ -119,32 +199,29 @@ class Track:
 
     def update_scaling(
         self,
-        width: int,
-        height: int,
+        viewport: TrackViewport,
         *,
-        margin_left: int,
-        margin_right: int,
-        margin_bottom: int,
-        margin_top: int,
         padding: float = TRACK_PADDING,
     ) -> None:
-        """Fit the rotated track into the reserved viewport and rebuild screen polylines."""
+        """Fit the rotated track into `viewport` and rebuild the screen polylines.
+
+        Takes the rectangle rather than four margins so that where the circuit is
+        allowed to draw is decided once, by `track_viewport`, and can be checked
+        without a window (#1103).
+        """
         if not self._has_geometry:
             return
 
-        inner_w = max(1.0, width - margin_left - margin_right)
-        inner_h = max(1.0, height - margin_bottom - margin_top)
-        usable_w = inner_w * (1.0 - 2.0 * padding)
-        usable_h = inner_h * (1.0 - 2.0 * padding)
+        inset_x, inset_y = track_inset(viewport, padding=padding)
+        usable_w = viewport.width - 2.0 * inset_x
+        usable_h = viewport.height - 2.0 * inset_y
 
         scale_x = usable_w / max(1e-6, self._world_w)
         scale_y = usable_h / max(1e-6, self._world_h)
         self._scale = float(min(scale_x, scale_y))
 
-        screen_cx = margin_left + inner_w / 2.0
-        screen_cy = margin_bottom + inner_h / 2.0
-        self._tx = float(screen_cx - self._scale * self._world_cx)
-        self._ty = float(screen_cy - self._scale * self._world_cy)
+        self._tx = float(viewport.centre_x - self._scale * self._world_cx)
+        self._ty = float(viewport.centre_y - self._scale * self._world_cy)
 
         self._screen_inner = self._project_poly(self._world_inner)
         self._screen_outer = self._project_poly(self._world_outer)

--- a/tests/surfaces/test_arcade_track_viewport.py
+++ b/tests/surfaces/test_arcade_track_viewport.py
@@ -1,0 +1,139 @@
+"""The circuit gets the space the panels actually leave (#1103).
+
+`MARGIN_LEFT` reserved 340 px for a left column 320 px wide and `TRACK_PADDING`
+took another 5% off each side, so the trace drew 612 px wide in a 1280 px window
+while the free band between the panels was 700. The circuit is the reason this
+window exists and it was the smallest it could be.
+
+**Asserted on pure functions, not on a rendered frame.** `update_scaling` runs
+between GL calls, so a check on the drawn result needs a display and a check
+that needs a display does not run in CI. `legend_mode` (#1096) and
+`_weather_rows` (#1087) were split out for the same reason.
+
+The numbers pinned in `test_the_usable_width_matches_what_was_measured_on_screen`
+were read off the projected polylines of the real Melbourne 2025 track on a
+hidden window, so if the arithmetic here drifts from what is drawn, it fails
+there rather than silently changing what everything else is about.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.arcade.config import (
+    CAR_LABEL_MAX_HALF_WIDTH,
+    DRIVER_BOX_WIDTH,
+    LEADERBOARD_RIGHT_MARGIN,
+    LEFT_PANEL_X,
+    PROGRESS_BAR_BOTTOM,
+    PROGRESS_BAR_HEIGHT,
+    SCREEN_HEIGHT,
+    SCREEN_WIDTH,
+    WEATHER_WIDTH,
+)
+from src.arcade.track import track_inset, track_viewport
+
+# Window sizes a user can produce: the default, a dragged-smaller window, and
+# maximised on a 1080p and a 1440p display.
+SIZES = ((1000, 600), (1280, 720), (1600, 900), (1920, 1080), (2560, 1400))
+
+# Right edge of the widest thing in the left column. The weather card is
+# narrower than the driver table, so the table is what the margin has to clear.
+LEFT_COLUMN_RIGHT = LEFT_PANEL_X + max(DRIVER_BOX_WIDTH, WEATHER_WIDTH)
+
+# The most the viewport may reserve beyond what the panels occupy. Enough to
+# keep the trace off the cards, not enough to hide a stale constant: it was 20
+# px before the fix, from a 340 px margin over a 320 px column.
+MAX_WASTED_INSET = 12
+
+
+def _usable(width: int, height: int) -> tuple[float, float]:
+    viewport = track_viewport(width, height)
+    inset_x, inset_y = track_inset(viewport)
+    return viewport.width - 2 * inset_x, viewport.height - 2 * inset_y
+
+
+@pytest.mark.parametrize(("width", "height"), SIZES)
+def test_the_viewport_never_overlaps_a_panel(width: int, height: int) -> None:
+    """The trace has to stop where the cards start, at every window size."""
+    viewport = track_viewport(width, height)
+    assert viewport.left >= LEFT_COLUMN_RIGHT, "the trace would draw under the driver table"
+    assert viewport.right <= width - LEADERBOARD_RIGHT_MARGIN, "under the leaderboard"
+    assert viewport.bottom >= PROGRESS_BAR_BOTTOM + PROGRESS_BAR_HEIGHT, "under the progress bar"
+    assert viewport.top <= height
+
+
+@pytest.mark.parametrize(("width", "height"), SIZES)
+def test_the_viewport_does_not_reserve_space_no_panel_uses(width: int, height: int) -> None:
+    """The assertion that is RED against the old margin.
+
+    `MARGIN_LEFT` was 340 against a column whose right edge is 320, so 20 px
+    came off the circuit for nothing. A margin is allowed to be a round number
+    only while it stays close to the thing it clears.
+    """
+    viewport = track_viewport(width, height)
+    assert viewport.left - LEFT_COLUMN_RIGHT <= MAX_WASTED_INSET
+    assert (width - LEADERBOARD_RIGHT_MARGIN) - viewport.right == 0
+
+
+@pytest.mark.parametrize(("width", "height"), SIZES)
+def test_a_car_label_can_never_reach_a_panel(width: int, height: int) -> None:
+    """What clears the panels is the LABEL, not the polyline.
+
+    Cars are drawn on the trace with a three-letter code centred above or below
+    the dot, and the widest such label renders 42 px. RED without the absolute
+    floor under `TRACK_PADDING`: the fraction alone gives 13.8 px at 1280 and
+    less below it, so a code at the trace's rightmost point would paint into the
+    leaderboard.
+    """
+    inset_x, inset_y = track_inset(track_viewport(width, height))
+    assert inset_x >= CAR_LABEL_MAX_HALF_WIDTH, f"{width}x{height}: a label overruns sideways"
+    assert inset_y >= CAR_LABEL_MAX_HALF_WIDTH, f"{width}x{height}: a label overruns vertically"
+
+
+def test_a_bigger_window_draws_a_bigger_circuit() -> None:
+    """Plainly the point, and not true of a viewport pinned to constants."""
+    widths = [_usable(w, h)[0] for w, h in SIZES]
+    heights = [_usable(w, h)[1] for w, h in SIZES]
+    assert widths == sorted(widths)
+    assert heights == sorted(heights)
+    assert widths[-1] > widths[0] * 2
+
+
+def test_the_usable_width_matches_what_was_measured_on_screen() -> None:
+    """Pins this file's arithmetic to the trace's real drawn bounds.
+
+    A pure test of a duplicated formula is the shape where the test and the code
+    agree with each other and neither agrees with the window. These were read
+    off the projected Melbourne polylines after `on_draw` on a hidden window.
+    The trace is limited by the viewport's WIDTH at every size here, so its drawn
+    width is the usable width exactly.
+    """
+    assert _usable(1280, 720)[0] == 646
+    assert _usable(1920, 1080)[0] == pytest.approx(1276.6, abs=0.5)
+
+
+def test_the_default_window_gained_what_the_fix_claims() -> None:
+    """612 px before, 646 after, in the window the arcade opens at.
+
+    Both halves stated so the claim is checkable rather than remembered: 10 px
+    from the margin that reserved space no panel used, and 24 from the padding
+    fraction, which is what the clearance floor then gives 22 of back.
+    """
+    assert (SCREEN_WIDTH, SCREEN_HEIGHT) == (1280, 720)
+    assert _usable(SCREEN_WIDTH, SCREEN_HEIGHT)[0] - 612 == 34
+
+
+def test_the_circuit_sits_in_the_middle_of_the_band_the_panels_leave() -> None:
+    """Centred on the free space, which is not the window's own centre.
+
+    The left column is 320 px and the leaderboard reserves 260, so the free band
+    is not symmetric and neither is the circuit's place in it. #1103 read the
+    offset as the trace being "pushed toward the right edge"; it is the correct
+    consequence of asymmetric panels, and what would be wrong is centring on the
+    window instead.
+    """
+    for width, height in SIZES:
+        viewport = track_viewport(width, height)
+        free_centre = (LEFT_COLUMN_RIGHT + (width - LEADERBOARD_RIGHT_MARGIN)) / 2
+        assert abs(viewport.centre_x - free_centre) <= MAX_WASTED_INSET / 2


### PR DESCRIPTION
## What

The replay is laid out around the circuit: it gets the space the panels actually leave, it draws brighter than they do, and the playback state moves down to the playback control.

## Why

Measured on a hidden window against the real Melbourne 2025 polylines, two drivers:

| | 1280x720 before | after | 1920x1080 before | after |
|---|---:|---:|---:|---:|
| viewport | 340..1020 (680) | 330..1020 (690) | 340..1660 (1320) | 330..1660 (1330) |
| trace drawn | 612 x 305 | **646 x 322** | 1188 x 592 | **1277 x 637** |
| share of viewport width | 90% | 94% | 90% | 96% |
| share of window width | 48% | 50% | 62% | 67% |
| clearance to the panels | 34 px | 22 px | 66 px | 27 px |

`MARGIN_LEFT` was 340 against a left column whose right edge is 320, so 10 px came off the circuit for nothing, and `TRACK_PADDING` at 0.05 took another 34 px per side of a 680 px viewport.

**Two of #1103's stated mechanisms did not survive measurement, and the issue is wrong on both.** They are worth recording because the fix would have been different if I had taken them at face value:

- *"the track draws in the remainder rather than being centred in it"* — it was centred exactly. Track centre x and viewport centre x were both 680 at 1280x720. `update_scaling` has always centred on the viewport.
- *"at 1280 wide the trace takes about a third of the window, pushed toward the right edge"* — it took **48%**, and its centre sat 40 px right of the window's centre, which is the correct consequence of a 320 px left column against a 260 px right one. Centring the circuit on the window instead would be the bug.

What was true is the third finding: nothing in the composition said which element was the subject. The trace drew at 150 grey and 4 px while the panels carried full-opacity cards, 1 px borders and saturated team strips.

## How

- `track_viewport(window_width, window_height)` and `track_inset(viewport)` in `src/arcade/track.py`, both pure. `update_scaling` takes the rectangle instead of four margins, so where the circuit may draw is decided in one place and is checkable without a display.
- `MARGIN_LEFT` 340 -> 330 and `TRACK_PADDING` 0.05 -> 0.02.
- **`TRACK_MIN_CLEARANCE`, an absolute floor under that fraction.** What has to clear the panels is not the polyline but the car's label: cars draw on the trace with a three-letter code centred on the dot, and the widest renders 42 px. At 0.02 the fraction alone gives 13.8 px in a 1280 px window, so a code at the trace's rightmost point would have painted into the leaderboard. The old 0.05 cleared it by accident, and dropping it without the floor would have introduced the bug. Floor is 22, against a measured 21.
- `TRACK_EDGE_COLOR` to 188 grey at 5 px, and the three panel cards drop to `PANEL_FILL_ALPHA`.
- The speed multiplier and `PAUSED` move out of `_time_text` into a readout in the band above the progress bar, at the bar's left edge. The lap and the clock describe the race, the speed and `PAUSED` describe the replay, and the band was empty while the playback control sat in it alone.
- `LEFT_PANEL_X` names the `20` that both the weather card and the driver table were using as a literal, since the viewport is now derived from it.

## What this does NOT do

**It does not make the circuit much larger, and it cannot.** The free horizontal band at 1280x720 is 320..1020, which is 700 px, against a viewport of 690: the panels are already as tight as their contents allow, so 10 px is all the margin had to give and the rest of the gain is the padding. The trace is limited by the viewport's WIDTH at every size measured, so the 144 px of vertical slack above and below it cannot be spent either. Making it materially bigger means taking rows off the panels, which #1098 rules out.

The replay's panels also do not scale with the window the way the menu now does (#1100). At 1920x1080 they are the same physical size they are at 720. That is a separate change with its own blast radius across four panel classes and is not in this sprint.

## Checks

- New `tests/surfaces/test_arcade_track_viewport.py`, 19 guards on the two pure functions, no skips. Each inset is asserted against the panel that justifies it, so a panel that grows fails here rather than being drawn over.
- Three mutants watched red:
  - **N**, `MARGIN_LEFT` back to 340: 8 failures.
  - **O**, `track_inset` without the floor: 6 failures, and correctly **not** at 2560 wide, where the fraction alone already clears the label.
  - **P**, `TRACK_PADDING` back to 0.05: 2 failures.
- `test_the_usable_width_matches_what_was_measured_on_screen` pins the arithmetic to the trace's real drawn bounds, so if this file's model drifts from the window it fails there rather than silently changing what the other assertions are about.
- `tests/surfaces` 415 -> 434, executed.
- `ruff check .` and `ruff format --check .` clean, 193 files.
- Rendered offscreen with real telemetry at 1280x720 (one driver and two) and 1920x1080 and looked at all three, plus a paused frame at 2x to check the new readout says `x2.0  PAUSED` where the old one did.

Part of #1098, and the last of its five.
