### PR TITLE
fix(arcade): make the menu's strategy emphasis reach the glyphs on the first frame

### DIFF
--- a/src/arcade/views.py
+++ b/src/arcade/views.py
@@ -103,8 +103,9 @@ def menu_content_extents(
     would move both its edges on every focus change, which reads worse than a
     band that is a little loose on the short rows.
 
-    The two extents are not equal. At 1280 the widest label is STRATEGY and the
-    widest value is the round's GP name, and those render at 83 and 131 pixels.
+    The two extents are not equal. At 1280 the widest label is STRATEGY, drawn a
+    step larger than its siblings, and the widest value is the round's GP name,
+    and those render at 107 and 120 pixels.
     """
     widest_label = max(label_widths) if label_widths else 0.0
     widest_value = max(value_widths) if value_widths else 0.0
@@ -244,6 +245,22 @@ def menu_bands(window_height: int, groups: Sequence[str]) -> MenuBands:
     )
 
 
+def scale_changed(previous: float | None, current: float) -> bool:
+    """Whether the menu's Text objects need their font sizes pushed again.
+
+    `previous` is `None` until something has actually been pushed, and it is
+    `None` rather than a float because 1.0 is BOTH what a freshly built view
+    would carry and a scale `menu_scale` genuinely returns at SCREEN_HEIGHT. A
+    view opened at the default size therefore skipped its own first push, so the
+    strategy row's emphasis never reached the glyphs and appeared only after a
+    resize away and back (#1109). That is the sentinel collision `CLAUDE.md`
+    section 11 names: a placeholder that is also a value the code can find.
+
+    Pure, so the collision is checkable without a window.
+    """
+    return previous is None or previous != current
+
+
 class MenuFormGeometry(NamedTuple):
     """Where the menu form sits, in offsets from the window's centre axis.
 
@@ -379,8 +396,9 @@ class MenuView(arcade.View):
         self._error: str = ""
         self._loading: bool = False
         self._focus_idx: int = 0
-        # Last scale pushed into the Text objects; see `_apply_scale`.
-        self._scale: float = 1.0
+        # Last scale pushed into the Text objects, or None while nothing has
+        # been. See `scale_changed` for why it cannot be a float.
+        self._scale: float | None = None
 
         self._fields: list[_FormField] = self._build_fields()
 
@@ -517,7 +535,7 @@ class MenuView(arcade.View):
         Text objects here, so the guard is what keeps a resize from costing that
         on every one of sixty frames a second.
         """
-        if scale == self._scale:
+        if not scale_changed(self._scale, scale):
             return
         self._scale = scale
         self._title.font_size = MENU_TITLE_FONT * scale

--- a/tests/surfaces/test_arcade_menu_layout.py
+++ b/tests/surfaces/test_arcade_menu_layout.py
@@ -39,18 +39,25 @@ from src.arcade.views import (
     menu_row_offsets,
     menu_scale,
     round_label,
+    scale_changed,
 )
 
-# (row, rendered label width, rendered value width), measured 2026-08-27 at
-# 1280x720 with the menu's default LaunchConfig, seven rows visible.
+# (row, rendered label width, rendered value width), read off a FRESH MenuView
+# at 1280x720 after one `on_draw`, with the default LaunchConfig and all seven
+# rows visible. Re-measured 2026-08-27 after two changes in the same sprint
+# invalidated the first pass: #1101 dropped the round value's `%2d` padding
+# (131 -> 120) and gave STRATEGY its emphasis step, which #1109 then made
+# actually reach the glyphs (83/36 -> 107/47). Taking these from a fresh view
+# rather than a resized one is deliberate: it is the state a user sees, and it
+# is the state the bug hid in.
 ROW_WIDTHS: list[tuple[str, float, float]] = [
-    ("Year", 43, 46),
-    ("Round", 62, 131),
-    ("Mode", 51, 99),
-    ("Driver", 61, 44),
-    ("Rival", 48, 33),
-    ("Team", 47, 81),
-    ("Strategy", 83, 36),
+    ("Year", 42.7, 46.0),
+    ("Round", 62.1, 120.3),
+    ("Mode", 50.7, 99.4),
+    ("Driver", 60.5, 44.0),
+    ("Rival", 47.6, 33.3),
+    ("Team", 47.5, 80.5),
+    ("Strategy", 107.1, 46.8),
 ]
 
 
@@ -75,8 +82,8 @@ def test_band_is_sized_to_the_content_and_not_to_a_constant() -> None:
     """The band may exceed the widest row by the padding and by nothing else.
 
     This is the assertion the old code fails. It drew a fixed 540 px rectangle
-    with a 460 px rule under a form whose content spans 254 px, so the excess
-    was 143 px on the right where the padding allows 24 (#1099).
+    with a 460 px rule under a form whose content spans 267 px, so the excess
+    was 130 px on the right where the padding allows 24 (#1099).
     """
     left, right = _extents_for(ROW_WIDTHS)
     widest_label = max(r[1] for r in ROW_WIDTHS)
@@ -448,3 +455,52 @@ def test_the_round_value_still_names_the_circuit() -> None:
 def test_an_unknown_round_says_so_rather_than_inventing_a_circuit() -> None:
     """Absent data has to look absent, per the weather panel's `N/A` (#1087)."""
     assert round_label(2025, 99).endswith("?")
+
+
+# --- The emphasis reaches the glyphs on the first frame (#1109) ------------
+
+
+def test_a_fresh_view_has_never_pushed_a_scale() -> None:
+    """`None`, not 1.0, is what "nothing applied yet" means.
+
+    A float cannot carry that state: `menu_scale(SCREEN_HEIGHT)` is exactly 1.0,
+    so a view built at the default size and initialised to 1.0 reads as though
+    its own first push had already happened. It had not, and the strategy row's
+    emphasis never reached the glyphs until the window was resized and back.
+    """
+    assert scale_changed(None, 1.0) is True
+    assert scale_changed(None, menu_scale(SCREEN_HEIGHT)) is True
+
+
+def test_a_repeated_scale_is_not_pushed_twice() -> None:
+    """The cache still has to earn its keep.
+
+    Assigning `font_size` re-lays out the glyph run and the view holds sixteen
+    Text objects, so this is what keeps a steady window off that cost sixty
+    times a second.
+    """
+    assert scale_changed(1.0, 1.0) is False
+    assert scale_changed(0.85, 0.85) is False
+
+
+@pytest.mark.parametrize("height", HEIGHTS)
+def test_every_reachable_scale_is_pushed_from_the_initial_state(height: int) -> None:
+    """No window size may reproduce the collision at some other value.
+
+    1.0 is the one that bit, because it is the default window's scale, but the
+    clamps make 0.85 and 2.0 reachable by dragging too. A `None` initial state
+    is the only one that cannot collide with any of them.
+    """
+    assert scale_changed(None, menu_scale(height)) is True
+
+
+def test_the_emphasised_row_is_the_widest_label_once_it_is_applied() -> None:
+    """What the bug looked like in the fixture, stated so it cannot come back.
+
+    STRATEGY is 83 px unemphasised and 107 emphasised. While the emphasis never
+    reached the glyphs, the widest label was STRATEGY at its plain size, and the
+    focus band was cut for text a third smaller than what a resized window drew.
+    """
+    widest = max(ROW_WIDTHS, key=lambda row: row[1])
+    assert widest[0] == "Strategy"
+    assert widest[1] > 100, "the fixture was taken before the emphasis reached the glyphs"


### PR DESCRIPTION
## What

`Strategy`'s emphasis, which is what #1101 was opened for, now renders in the window the arcade opens in. It used to appear only after the user resized the window and back.

## Why

`MenuView.__init__` set `self._scale = 1.0`, and `_apply_scale` is the only place `MENU_EMPHASIS` reaches a `Text.font_size`, guarded by `if scale == self._scale: return`. At the default 1280x720 `menu_scale(720)` is exactly 1.0, so the guard fired on the first frame and the emphasis step never ran.

Measured on a hidden window at 1280x720, fresh `MenuView`, one `on_draw`:

| | STRATEGY label | STRATEGY value | label width |
|---|---:|---:|---:|
| before, fresh launch | 13 pt | 15 pt | 82.8 px |
| before, after a resize away and back | 16.9 pt | 19.5 pt | 107.1 px |
| after | 16.9 pt | 19.5 pt | 107.1 px |

Same `LaunchConfig`, two different renders depending on resize history. The focused row still drew its `row_pitch * 1.3 - 4` band, because that reads `MENU_EMPHASIS` directly rather than the font, so a fresh launch showed an oversized band around normal-sized text.

`1.0` was both the placeholder for "nothing pushed yet" and a value `menu_scale` genuinely returns. That is the sentinel collision `CLAUDE.md` section 11 names.

## How

- `self._scale` becomes `float | None`, `None` meaning nothing has been pushed.
- `scale_changed(previous, current)` carries the decision and is pure, so the collision is checkable without a window. The cache still works: a steady window is not charged sixteen re-layouts a frame.
- `ROW_WIDTHS` re-measured. **Two changes from the same sprint had invalidated it**, not one: #1101 also dropped the round value's `%2d` padding (131 -> 120), on top of the emphasis (83/36 -> 107/47). The fixture now says it was taken from a fresh view, since that is both the state a user sees and the state the bug hid in.

## Checks

- Four new guards, 445 in `tests/surfaces` from 434, executed.
- Mutant Q, the collision restored (`(previous if previous is not None else 1.0) != current`), watched red on two assertions, and **only at height 720**, which is the honest boundary: 720 is the one window size where the collision bites.
- Rendered offscreen at 1280x720 before and after: 30,250 pixels differ, bounded to the form.

## What this says about the sprint that shipped it

I looked at a rendered frame of #1101 and read it as showing the emphasis. It did not. The measurement that would have caught it, reading `font_size` off the Text objects rather than judging glyph size by eye, is what the closing gate ran. Looking at the result is necessary and it is not sufficient when the thing being checked is a size difference of a third.

Closes #1109. Found by the closing adversarial gate on #1098.
