### PR TITLE
fix(arcade): a missing driver costs his column, not the whole table

### DIFF
--- a/src/arcade/overlays.py
+++ b/src/arcade/overlays.py
@@ -11,7 +11,7 @@ rows, a bug that bit both the reference and earlier attempts here.
 from __future__ import annotations
 
 import logging
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Final
 
 import arcade
@@ -252,7 +252,7 @@ DRIVER_ROW_LABELS: Final[tuple[str, ...]] = (
 
 
 def driver_rows(
-    data: dict,
+    data: dict | None,
     ahead: str,
     behind: str,
 ) -> list[tuple[str, str, tuple[int, int, int]]]:
@@ -261,7 +261,16 @@ def driver_rows(
     Split out of the panel's draw call for the reason ``_weather_rows`` was
     (#1087): the rendered TEXT is then assertable without a GL context, and a
     check that needs a window is a check that does not run in CI.
+
+    ``data`` is ``None`` when the frame carries nothing for this driver, and the
+    row set comes back as six ``N/A`` cells in the tertiary colour rather than
+    as nothing. Two cards each guarded themselves, so an absent rival cost the
+    rival card alone; the merged table returned before drawing anything and took
+    the other driver's live telemetry with it (#1110). Absent data has to look
+    absent, which is the same rule the weather panel's readings follow.
     """
+    if data is None:
+        return [(label, "N/A", TEXT_TERTIARY) for label in DRIVER_ROW_LABELS]
     tyre = int(data.get("tyre", 1))
     drs = data.get("drs", 0)
     return [
@@ -320,6 +329,23 @@ def driver_column_edges(
     inner = width - 2 * pad_x
     column = (inner - label_min) / column_count
     return tuple(pad_x + label_min + column * (i + 1) for i in range(column_count))
+
+
+def present_drivers(
+    codes: Sequence[str],
+    drivers_in_frame: Mapping[str, dict] | None,
+) -> tuple[str, ...]:
+    """Which of the followed drivers this frame actually carries.
+
+    Pure, so the panel's one all-or-nothing decision is checkable without a GL
+    context. It is the decision that regressed: two cards each guarded
+    themselves and an absent rival cost the rival card, while the merged table
+    returned before drawing anything and took the other driver's live telemetry
+    with it (#1110). The card goes only when this comes back empty.
+    """
+    if not drivers_in_frame:
+        return ()
+    return tuple(code for code in codes if drivers_in_frame.get(code))
 
 
 class DriverInfoPanel:
@@ -422,11 +448,13 @@ class DriverInfoPanel:
         drivers_in_frame = frame.get("drivers") or {}
         per_driver: list[list[tuple[str, str, tuple[int, int, int]]]] = []
         for code in self.codes:
-            data = drivers_in_frame.get(code)
-            if not data:
-                return
+            data = drivers_in_frame.get(code) or None
             ahead, behind = self._neighbor_gaps(code, all_drivers_sorted, gaps, frame, frame_idx)
             per_driver.append(driver_rows(data, ahead, behind))
+        # The card goes only when NOT ONE followed driver is in the frame, which
+        # is what the two separate cards did between them (#1110).
+        if not present_drivers(self.codes, drivers_in_frame):
+            return
 
         self._draw_card()
         self._draw_header()

--- a/tests/surfaces/test_arcade_driver_table.py
+++ b/tests/surfaces/test_arcade_driver_table.py
@@ -27,12 +27,14 @@ from src.arcade.config import (
     DRIVER_PAD_X,
     TEXT_PRIMARY,
     TEXT_SECONDARY,
+    TEXT_TERTIARY,
 )
 from src.arcade.overlays import (
     DRIVER_ROW_LABELS,
     driver_column_edges,
     driver_rows,
     driver_table,
+    present_drivers,
 )
 
 # Rendered widths of the label and the widest value each row produced, measured
@@ -203,3 +205,81 @@ def test_a_third_column_would_not_fit_and_the_test_says_so() -> None:
     assert column < WORST_CASE_VALUE, (
         "three columns now fit, so this bound is stale rather than the panel wrong"
     )
+
+
+# --- One absent driver costs his column, not the table (#1110) -------------
+
+
+def test_an_absent_driver_produces_six_absences_rather_than_nothing() -> None:
+    """Absent data has to look absent, the rule `_weather_rows` follows (#1087).
+
+    A column that simply vanished would change the table's width frame to frame
+    while a driver dropped in and out of the feed.
+    """
+    rows = driver_rows(None, "N/A", "N/A")
+    assert [label for label, _, _ in rows] == list(DRIVER_ROW_LABELS)
+    assert {value for _, value, _ in rows} == {"N/A"}
+
+
+def test_an_absent_column_is_dimmer_than_a_real_reading() -> None:
+    """Colour is what separates a missing value from a measured one at a glance.
+
+    `TEXT_PRIMARY` on an absent cell would read as data, which is the
+    sentinel-shaped failure this repo keeps paying for: an unknown that cannot
+    be told apart from a real value.
+    """
+    absent = {colour for _, _, colour in driver_rows(None, "N/A", "N/A")}
+    assert absent == {TEXT_TERTIARY}
+    assert TEXT_TERTIARY != TEXT_PRIMARY
+
+
+def test_the_present_driver_keeps_his_telemetry_when_the_other_is_missing() -> None:
+    """The regression, stated as the assertion that catches it.
+
+    Two cards each guarded themselves, so an absent rival cost the rival card
+    alone. The merged table returned from `draw` on the first driver without
+    frame data, before the card was drawn at all, and took the other driver's
+    live telemetry with it (#1110).
+    """
+    present = driver_rows(_frame(speed=232, gear=6), "VER +2.36s (L)", "PIA -1.80s (L)")
+    table = driver_table([present, driver_rows(None, "N/A", "N/A")])
+
+    assert len(table) == len(DRIVER_ROW_LABELS)
+    assert all(len(cells) == 2 for _, cells in table)
+    by_label = {label: [value for value, _ in cells] for label, cells in table}
+    assert by_label["Speed"] == ["232 km/h", "N/A"]
+    assert by_label["Ahead"] == ["VER +2.36s (L)", "N/A"]
+
+
+def test_a_table_of_nobody_is_all_absences() -> None:
+    """What the panel checks before deciding not to draw its card at all.
+
+    Every followed driver missing is the one case where the whole card goes,
+    which is what the two separate cards did between them.
+    """
+    table = driver_table([driver_rows(None, "N/A", "N/A")] * 2)
+    values = {value for _, cells in table for value, _ in cells}
+    assert values == {"N/A"}
+
+
+@pytest.mark.parametrize(
+    ("frame_drivers", "expected"),
+    [
+        ({"NOR": {"speed": 1}, "VER": {"speed": 2}}, ("NOR", "VER")),
+        ({"NOR": {"speed": 1}}, ("NOR",)),
+        ({"VER": {"speed": 2}}, ("VER",)),
+        ({}, ()),
+        (None, ()),
+        ({"NOR": {}}, ()),
+    ],
+)
+def test_presence_is_read_per_driver_not_all_or_nothing(
+    frame_drivers: dict | None, expected: tuple[str, ...]
+) -> None:
+    """The panel draws its card whenever ANY followed driver is in the frame.
+
+    The last case matters on its own: an empty dict for a driver is not a
+    driver, and the old code's `if not data` treated it the same way. Whatever
+    the frame says, one missing driver must not remove the other.
+    """
+    assert present_drivers(("NOR", "VER"), frame_drivers) == expected


### PR DESCRIPTION
## What

One followed driver missing from a frame now costs his own column. It used to erase the whole table, the other driver's live telemetry included.

## Why

Before #1102 each driver had a card that guarded itself (`58a1b92a:src/arcade/overlays.py:318`, `if not data: return`), so an absent rival cost the rival card and nothing else. The merged table looped over both codes and returned from `draw` on the first one without frame data, **before `_draw_card` ran**, so the main driver went with it.

Proved with a counter monkeypatched onto `_draw_card`, frame 1000 of Melbourne 2025:

| | card drawn |
|---|---:|
| both drivers present | 1 |
| VER removed from `frame["drivers"]`, before | **0** |
| VER removed, after | 1 |
| nobody present, after | 0 |

**Not reachable in the shipped session**, and the issue says so: all twenty drivers carry exactly 125,279 frames and `has_position` is all-True in the Melbourne cache, so `_build_frame_dict` never omits a followed code there. The trigger is a session whose per-driver frame lists differ in length, which is what the `frame_idx >= len(frames)` guard in `_draw_car` exists for. Filed and fixed as a latent regression: the mechanism is proved, the reach is not.

## How

- `driver_rows` takes `dict | None` and returns six `N/A` cells in `TEXT_TERTIARY` for an absent driver. The column stays and reads as absent, which is the rule `_weather_rows` follows (#1087): a column that simply vanished would change the table's width frame to frame while a driver dropped in and out of the feed.
- `present_drivers(codes, drivers_in_frame)` carries the one all-or-nothing decision left, and it is pure. The card goes only when that comes back empty, which is what the two cards did between them.

`TEXT_TERTIARY` rather than `TEXT_PRIMARY` on the absent cells is the point of the second guard: an unknown drawn in the same colour as a reading is the sentinel shape this repo keeps paying for.

## Checks

- Six new guards, `tests/surfaces` 434 -> 444 on this branch, executed.
- Three mutants watched red:
  - **R**, the whole-table return restored: the guards crash rather than fail, which is what showed the `draw`-level decision had no pure seam. That is why `present_drivers` was extracted rather than left inline.
  - **S**, `present_drivers` ignoring presence: 3 failures, including the empty-dict-is-not-a-driver case.
  - **T**, absent cells in `TEXT_PRIMARY`: 1 failure.
- Rendered a full frame with VER removed and looked at it: NOR keeps `HAM +6.16s (L)` and `PIA -1.80s (L)`, the rival column reads `N/A` throughout, dimmer than the readings beside it.

Closes #1110. Found by the closing adversarial gate on #1098.
