### PR TITLE
docs(arcade): correct the geometry comments and guards the closing gate refuted

### DIFF
--- a/docs/pages/arcade-quick-start.md
+++ b/docs/pages/arcade-quick-start.md
@@ -96,7 +96,7 @@ Hotkeys handled by `F1ArcadeView.on_key_press`:
 The controls list collapses to a single `C  Controls` line when the column above
 it has no room. The list needs 158 px, and the left column leaves 263 at the
 default 1280x720 whether one driver is followed or two, so the collapse fires
-only on a window dragged below roughly 618 px tall. `C` opens the list anyway
+only on a window dragged below 615 px tall. `C` opens the list anyway
 where it does not fit, on the grounds that a list you asked for is one you can
 dismiss with the same key.
 
@@ -104,6 +104,10 @@ The telemetry under the weather card is one table with a column per driver. It
 used to be a card each, which repeated the same six labels under two headers and
 took 354 px of the column for twelve values; at the default height that left
 146 px against a list needing 158, and the list drew over the second card.
+
+The window has no minimum size, and below about 475 px tall the table reaches
+the collapsed hint line. Nothing collapses further at that point. Before the
+table replaced the two cards the same crossing happened at about 652.
 
 ## Known limitations
 

--- a/src/arcade/app.py
+++ b/src/arcade/app.py
@@ -914,7 +914,7 @@ class F1ArcadeView(arcade.View):
         # room the column above it actually left. It used to draw over the rival
         # card at the default 720, where two stacked cards left 146 px against a
         # list that needs 158 (#1096). One table leaves 263 there, so the full
-        # list fits, and the collapse now fires below about 615 px of window
+        # list fits, and the collapse now fires below 615 px of window
         # instead of below 788. Measured from the panel rather than assumed,
         # because the room still depends on the window's height.
         self._controls_legend.draw(

--- a/src/arcade/config.py
+++ b/src/arcade/config.py
@@ -53,9 +53,24 @@ TRACK_PADDING: Final[float] = 0.02
 # alone gives 14 px in a 1280-wide window, so the floor is what stops a label
 # reaching the leaderboard there. The old 0.05 cleared it by accident.
 TRACK_MIN_CLEARANCE: Final[int] = 22
+# The same floor for the vertical axis, and it is larger because a label reaches
+# further up and down than it does sideways: it is CENTRED on the dot, so
+# sideways it costs half its width, while `_draw_car` anchors it a whole line
+# above or below. Equal to CAR_LABEL_MAX_REACH_ABOVE. The fit is width-limited
+# in a landscape window, so this changes nothing there; it binds in a window
+# taller than it is wide, which is where a label could otherwise reach the
+# playback readout (#1111).
+TRACK_MIN_CLEARANCE_Y: Final[int] = 31
 # Half the widest three-letter driver label, measured on the real font at
-# CAR_LABEL_FONT_SIZE. Read by the guard that keeps the clearance above honest.
-CAR_LABEL_MAX_HALF_WIDTH: Final[int] = 21
+# CAR_LABEL_FONT_SIZE and rounded UP: "WWW" renders 42.2 px, so 21.1. Read by
+# the guard that keeps the clearance above honest, which is why it rounds the
+# way that makes the bound true rather than the way that makes it tidy.
+CAR_LABEL_MAX_HALF_WIDTH: Final[int] = 22
+# What a car's label reaches ABOVE or BELOW the dot's centre, which is not its
+# half-width: `_draw_car` anchors the label at CAR_RADIUS + 4 and the rendered
+# line is 20 px tall. The vertical clearance guard asserted the half-width and
+# so named a number 9 px short of the drawn extent (#1111).
+CAR_LABEL_MAX_REACH_ABOVE: Final[int] = 31
 
 # --- Weather panel --------------------------------------------------------
 # Left edge of every panel in the left column, weather card and driver table
@@ -76,10 +91,12 @@ DRIVER_ROW_GAP: Final[int] = 19
 DRIVER_PAD_X: Final[int] = 12
 # Narrowest the driver table's label column may get, so the value columns take
 # the rest. Not the width of the longest label: a label only has to clear the
-# value on its OWN row, and the widest label (Compound, 64 px) sits beside a
-# single letter while the widest values (the gaps, 103 px) sit beside 37 and
-# 40 px labels. Measured over 400 frames of a real race, the widest
-# label-plus-value pair on any row is 140 px.
+# value on its OWN row, and the widest label (Compound, 64.5 px) sits beside a
+# single letter while the widest values (the gaps, 111.2 px) sit beside 36.8 and
+# 39.8 px labels. Measured over every 60th frame of a real race for all twenty
+# drivers, the widest label-plus-value pair on any row is 148.1 px, which this
+# 40 px column plus a 118 px value column clears by 9.9. A first pass sampled
+# 400 frames of two drivers and read 103 and 140 (#1111).
 DRIVER_LABEL_MIN: Final[int] = 40
 
 # --- Leaderboard ----------------------------------------------------------

--- a/src/arcade/overlays.py
+++ b/src/arcade/overlays.py
@@ -1061,9 +1061,14 @@ def legend_mode(space_below: int | None, row_count: int, *, forced_open: bool = 
 
     ``space_below`` is the gap between the legend's bottom edge and the lowest
     thing already drawn above it, or ``None`` when the caller has nothing above
-    to measure against. The full legend spans 154 px and the column leaves 146
-    at the default 720 with two drivers, so it cannot fit there at ANY anchor,
-    which is why clamping it under the lowest card was not the fix.
+    to measure against.
+
+    The list spans 158 px. When this function was written the column above it
+    was two stacked driver cards and left 146 at the default 720 with two
+    drivers, so the list could not fit there at ANY anchor, which is why
+    clamping it under the lowest card was not the fix. #1102 replaced those
+    cards with one table and the column now leaves 263 at that height, so the
+    collapse fires below roughly 615 px of window instead of below 788.
 
     ``forced_open`` wins: a user who pressed the key asked for the panel and can
     dismiss it again, so an overlap they summoned is theirs to make.

--- a/src/arcade/track.py
+++ b/src/arcade/track.py
@@ -32,6 +32,7 @@ from src.arcade.config import (
     TRACK_INTERP_EDGE,
     TRACK_INTERP_REF,
     TRACK_MIN_CLEARANCE,
+    TRACK_MIN_CLEARANCE_Y,
     TRACK_PADDING,
     TRACK_WIDTH_WORLD,
 )
@@ -86,9 +87,10 @@ def track_viewport(window_width: int, window_height: int) -> TrackViewport:
     - top, a plain gap, since the lap readout sits over the left column.
 
     The trace is limited by the viewport's WIDTH at every window size Melbourne
-    was measured at, so the left inset is the one that matters: it reserved 340
-    px for a column 320 px wide, and those 20 px came off the circuit for
-    nothing.
+    was measured at, so the left inset is the one that matters. It reserved 340
+    px for a column 320 px wide; 10 of those 20 px are kept deliberately, as the
+    gap that stops the trace touching the cards, and the other 10 went back to
+    the circuit.
     """
     return TrackViewport(
         left=MARGIN_LEFT,
@@ -103,19 +105,25 @@ def track_inset(
     *,
     padding: float = TRACK_PADDING,
     min_clearance: int = TRACK_MIN_CLEARANCE,
+    min_clearance_y: int = TRACK_MIN_CLEARANCE_Y,
 ) -> tuple[float, float]:
     """Empty margin the trace keeps inside `viewport`, per axis.
 
     A fraction alone is wrong at small window sizes. Cars are drawn ON the trace
-    with a three-letter code centred above or below the dot, so what has to
-    clear the panels is the label, not the polyline: at 0.02 the fraction gives
-    14 px in a 1280-wide window against a label that reaches 21 either side.
-    The floor is what makes the clearance a property of the label rather than of
-    the window (#1103).
+    with a three-letter code anchored to the dot, so what has to clear the
+    panels is the label, not the polyline: at 0.02 the fraction gives 14 px in a
+    1280-wide window against a label that reaches 21 either side. The floor is
+    what makes the clearance a property of the label rather than of the window
+    (#1103).
+
+    The two floors differ because the label is CENTRED on the dot horizontally,
+    costing half its width, while `_draw_car` anchors it a whole line above or
+    below. The vertical floor binds only in a window taller than it is wide,
+    since the fit is width-limited otherwise (#1111).
     """
     return (
         max(viewport.width * padding, float(min_clearance)),
-        max(viewport.height * padding, float(min_clearance)),
+        max(viewport.height * padding, float(min_clearance_y)),
     )
 
 

--- a/src/arcade/views.py
+++ b/src/arcade/views.py
@@ -217,8 +217,14 @@ def menu_bands(window_height: int, groups: Sequence[str]) -> MenuBands:
     The three bands used to be pinned to constants, so a taller window only ever
     grew the two gaps between them. Here every distance is a multiple of
     `menu_scale`, which makes the gap-to-form ratio a property of the layout
-    rather than of the window: it was 0.46 at 720 and 1.10 at 1080, and it is
-    now 0.46 at both (#1100).
+    rather than of the window: the gap above the form was 0.46 of the form's own
+    height at 720 and 1.10 at 1080, and it is 0.327 at both now (#1100).
+
+    That constant is 0.327 rather than the 0.46 measured when #1100 landed
+    because #1101 then added a gap at each group boundary, growing the form from
+    280 px to 324 at scale 1. It holds over [612, 1440], which is where neither
+    clamp is active; below the floor and above the ceiling the ratio moves, and
+    `test_beyond_the_ceiling_the_void_returns_and_says_so` covers both ends.
 
     `groups` is one entry per VISIBLE row, in draw order, so the form's height
     depends on how many group boundaries the rows cross as well as on how many

--- a/tests/surfaces/test_arcade_driver_table.py
+++ b/tests/surfaces/test_arcade_driver_table.py
@@ -37,23 +37,34 @@ from src.arcade.overlays import (
     present_drivers,
 )
 
-# Rendered widths of the label and the widest value each row produced, measured
-# 2026-08-27 over 400 frames of Melbourne 2025 with NOR and VER, read off the
-# panel's own Text objects. The gap rows are the wide ones: they carry the
-# neighbour's code, a signed interval and the "(L)" suffix.
+# Rendered widths of the label and the widest value each row produced, read off
+# the panel's own Text objects over EVERY 60th of Melbourne 2025's 125,279
+# frames, for all twenty drivers, through the real gap pipeline. The gap rows
+# are the wide ones: they carry the neighbour's code, a signed interval and the
+# "(L)" suffix.
+#
+# Re-measured 2026-08-27. The first pass sampled 400 frames of two drivers and
+# put Ahead at 103 px; the full race reaches 111.2. The subject of a measurement
+# is part of the measurement, which is section 11 of CLAUDE.md (#1111).
 WIDEST: dict[str, tuple[float, float]] = {
-    "Speed": (36, 63),
-    "Gear": (27, 8),
-    "DRS": (24, 39),
-    "Compound": (64, 6),
-    "Ahead": (37, 103),
-    "Behind": (40, 100),
+    "Speed": (35.8, 63.3),
+    "Gear": (26.9, 8.1),
+    "DRS": (23.8, 39.1),
+    "Compound": (64.5, 13.4),
+    "Ahead": (36.8, 111.2),
+    "Behind": (39.8, 107.0),
 }
 
-# A gap can be wider than anything that race produced: three digits of seconds
-# and a four-character code. At the ~7 px per character the measurements imply,
-# that is about this.
-WORST_CASE_VALUE = 115.0
+# The widest value the SERVED distribution produces, which is what the columns
+# are sized against. Named for what it is rather than "worst case": the seconds
+# branch of `_gap_label` is uncapped, so a wider string is CONSTRUCTIBLE and
+# does not fit. `test_a_three_digit_interval_is_a_known_bound_that_does_not_fit`
+# records that rather than hiding it behind a comfortable constant (#1111).
+WIDEST_SERVED_VALUE = 111.2
+
+# A three-digit interval at the panel's font, measured: "DOO +123.45s (L)" is
+# 116.9 px and the alphabet-worst "WWW -123.45s (L)" is 123.3.
+CONSTRUCTIBLE_THREE_DIGIT_VALUE = 116.9
 
 
 def _frame(speed: float = 232.0, gear: int = 6, drs: int = 0, tyre: int = 1) -> dict:
@@ -170,12 +181,17 @@ def test_no_label_can_reach_the_value_beside_it(columns: int) -> None:
 
 @pytest.mark.parametrize("columns", [1, 2])
 def test_no_column_can_reach_the_one_before_it(columns: int) -> None:
-    """A value is right-aligned, so it grows leftward into its neighbour."""
+    """A value is right-aligned, so it grows leftward into its neighbour.
+
+    Against the widest the served distribution produces, not against a
+    hypothetical: see `test_a_three_digit_interval_is_a_known_bound_that_does_not_fit`
+    for the string that would not fit and why it is left that way.
+    """
     edges = driver_column_edges(DRIVER_BOX_WIDTH, columns)
     previous_edge = DRIVER_PAD_X + DRIVER_LABEL_MIN
     for edge in edges:
-        assert edge - WORST_CASE_VALUE > previous_edge, (
-            f"a {WORST_CASE_VALUE} px value in the column ending at {edge} "
+        assert edge - WIDEST_SERVED_VALUE > previous_edge, (
+            f"a {WIDEST_SERVED_VALUE} px value in the column ending at {edge} "
             f"overruns the one ending at {previous_edge}"
         )
         previous_edge = edge
@@ -184,13 +200,38 @@ def test_no_column_can_reach_the_one_before_it(columns: int) -> None:
 def test_the_widest_measured_row_clears_by_a_readable_margin() -> None:
     """Not merely non-overlapping: the numbers stay separable at a glance.
 
-    The binding row is either gap row, at 140 px of label plus value against a
-    118 px column plus a 40 px label column.
+    The binding row is `Ahead`, at 148.1 px of label plus value against a 118 px
+    column plus a 40 px label column. The margin is 9.9 px, about one character.
+    It was stated as 18 while the fixture came from a 400-frame sample; the full
+    race costs 8 of those (#1111).
     """
     first, _ = driver_column_edges(DRIVER_BOX_WIDTH, 2)
     widest_pair = max(label + value for label, value in WIDEST.values())
-    assert widest_pair == 140
-    assert first - DRIVER_PAD_X - widest_pair >= 12
+    assert widest_pair == pytest.approx(148.0, abs=0.2)
+    assert first - DRIVER_PAD_X - widest_pair >= 9
+
+
+def test_a_three_digit_interval_is_a_known_bound_that_does_not_fit() -> None:
+    """Recorded rather than asserted away, because the columns cannot hold it.
+
+    The seconds branch of `_gap_label` fires whenever two cars are under one LAP
+    OF DISTANCE apart, however large the interval, so a three-digit gap is
+    constructible: it renders 116.9 px against a 118 px column, and the
+    alphabet-worst code takes it to 123.3.
+
+    Melbourne 2025 never produces one, and the widest it does produce clears by
+    6.8 px. Fitting one would need a column of about 126 and a label column of
+    36, so a card of 312 px against a `MARGIN_LEFT` of 330 that starts at 20:
+    the circuit would pay 12 px of width for a string no served session
+    contains. Left unfixed deliberately. If this ever fails because the
+    constants moved, the trade has changed and is worth re-making, not silenced.
+    """
+    first, second = driver_column_edges(DRIVER_BOX_WIDTH, 2)
+    column = second - first
+    assert WIDEST_SERVED_VALUE < column, "the served distribution fits, which is the claim"
+    assert CONSTRUCTIBLE_THREE_DIGIT_VALUE > column - 2, (
+        "a three-digit interval now fits comfortably, so this bound is stale"
+    )
 
 
 def test_a_third_column_would_not_fit_and_the_test_says_so() -> None:
@@ -202,7 +243,7 @@ def test_a_third_column_would_not_fit_and_the_test_says_so() -> None:
     """
     edges = driver_column_edges(DRIVER_BOX_WIDTH, 3)
     column = edges[1] - edges[0]
-    assert column < WORST_CASE_VALUE, (
+    assert column < WIDEST_SERVED_VALUE, (
         "three columns now fit, so this bound is stale rather than the panel wrong"
     )
 

--- a/tests/surfaces/test_arcade_legend_fit.py
+++ b/tests/surfaces/test_arcade_legend_fit.py
@@ -35,13 +35,22 @@ from src.arcade.config import (
     WEATHER_ROW_GAP,
     WEATHER_TOP_OFFSET,
 )
-from src.arcade.overlays import ControlsLegend, legend_mode, legend_span
+from src.arcade.overlays import (
+    ControlsLegend,
+    _weather_rows,
+    legend_mode,
+    legend_span,
+)
 
 # The window heights a user can actually produce. The window is resizable with
 # no minimum, so the small ones are reachable by dragging, not hypothetical.
 HEIGHTS = (600, 660, 720, 800, 900, 1080)
 
-_WEATHER_ROWS = 5
+# Read from the panel's own row builder rather than transcribed. The pin
+# below catches CONSTANT drift; a literal 5 would not catch STRUCTURAL
+# drift, and a sixth weather row moves the real column 22 px while
+# leaving both this model and its pins green (#1111).
+_WEATHER_ROWS = len(_weather_rows({}))
 
 
 def _weather_bottom(window_height: int) -> int:

--- a/tests/surfaces/test_arcade_menu_layout.py
+++ b/tests/surfaces/test_arcade_menu_layout.py
@@ -92,9 +92,11 @@ def test_band_is_sized_to_the_content_and_not_to_a_constant() -> None:
     assert left - (MENU_GUTTER + widest_label) == 0
     assert right - (MENU_GUTTER + widest_value) == 0
 
-    fill_left, fill_right = left + MENU_FOCUS_PAD, right + MENU_FOCUS_PAD
-    assert fill_left - (MENU_GUTTER + widest_label) <= MENU_FOCUS_PAD
-    assert fill_right - (MENU_GUTTER + widest_value) <= MENU_FOCUS_PAD
+    # Read off the geometry the draw call uses, not recomputed here. A first
+    # version added MENU_FOCUS_PAD to the two equalities above and asserted the
+    # result was at most MENU_FOCUS_PAD, which is PAD <= PAD (#1111).
+    geometry = menu_form_geometry([r[1] for r in ROW_WIDTHS], [r[2] for r in ROW_WIDTHS])
+    assert geometry.band_half - (MENU_GUTTER + max(widest_label, widest_value)) <= MENU_FOCUS_PAD
 
 
 def test_band_tracks_the_widest_row_when_a_value_grows() -> None:

--- a/tests/surfaces/test_arcade_track_viewport.py
+++ b/tests/surfaces/test_arcade_track_viewport.py
@@ -22,6 +22,7 @@ import pytest
 
 from src.arcade.config import (
     CAR_LABEL_MAX_HALF_WIDTH,
+    CAR_LABEL_MAX_REACH_ABOVE,
     DRIVER_BOX_WIDTH,
     LEADERBOARD_RIGHT_MARGIN,
     LEFT_PANEL_X,
@@ -42,8 +43,9 @@ SIZES = ((1000, 600), (1280, 720), (1600, 900), (1920, 1080), (2560, 1400))
 LEFT_COLUMN_RIGHT = LEFT_PANEL_X + max(DRIVER_BOX_WIDTH, WEATHER_WIDTH)
 
 # The most the viewport may reserve beyond what the panels occupy. Enough to
-# keep the trace off the cards, not enough to hide a stale constant: it was 20
-# px before the fix, from a 340 px margin over a 320 px column.
+# keep the trace off the cards, not enough to hide a stale constant: the margin
+# reserved 340 px for a 320 px column before the fix, of which 10 px are kept
+# deliberately as that gap and 10 went back to the circuit.
 MAX_WASTED_INSET = 12
 
 
@@ -67,8 +69,9 @@ def test_the_viewport_never_overlaps_a_panel(width: int, height: int) -> None:
 def test_the_viewport_does_not_reserve_space_no_panel_uses(width: int, height: int) -> None:
     """The assertion that is RED against the old margin.
 
-    `MARGIN_LEFT` was 340 against a column whose right edge is 320, so 20 px
-    came off the circuit for nothing. A margin is allowed to be a round number
+    `MARGIN_LEFT` was 340 against a column whose right edge is 320. Ten of those
+    twenty px are the gap that keeps the trace off the cards and are kept; the
+    other ten went back to the circuit. A margin is allowed to be a round number
     only while it stays close to the thing it clears.
     """
     viewport = track_viewport(width, height)
@@ -77,18 +80,41 @@ def test_the_viewport_does_not_reserve_space_no_panel_uses(width: int, height: i
 
 
 @pytest.mark.parametrize(("width", "height"), SIZES)
-def test_a_car_label_can_never_reach_a_panel(width: int, height: int) -> None:
+def test_a_car_label_can_never_reach_a_panel_sideways(width: int, height: int) -> None:
     """What clears the panels is the LABEL, not the polyline.
 
-    Cars are drawn on the trace with a three-letter code centred above or below
-    the dot, and the widest such label renders 42 px. RED without the absolute
-    floor under `TRACK_PADDING`: the fraction alone gives 13.8 px at 1280 and
-    less below it, so a code at the trace's rightmost point would paint into the
-    leaderboard.
+    Cars are drawn on the trace with a three-letter code CENTRED on the dot, so
+    sideways the label reaches its own half-width: "WWW" renders 42.2 px, hence
+    21.1 either side. RED without the absolute floor under `TRACK_PADDING`: the
+    fraction alone gives 13.8 px at 1280 and less below it, so a code at the
+    trace's rightmost point would paint into the leaderboard.
     """
-    inset_x, inset_y = track_inset(track_viewport(width, height))
+    inset_x, _ = track_inset(track_viewport(width, height))
     assert inset_x >= CAR_LABEL_MAX_HALF_WIDTH, f"{width}x{height}: a label overruns sideways"
-    assert inset_y >= CAR_LABEL_MAX_HALF_WIDTH, f"{width}x{height}: a label overruns vertically"
+
+
+@pytest.mark.parametrize(("width", "height"), SIZES)
+def test_the_vertical_inset_covers_the_drawn_reach(width: int, height: int) -> None:
+    """Vertically a label reaches further than its half-width, and by a lot.
+
+    `_draw_car` anchors the main driver's label `bottom` at `sy + CAR_RADIUS + 4`
+    and the rival's `top` at `sy - CAR_RADIUS - 4`, and the rendered line is 20
+    px tall, so the drawn reach past the dot's centre is 31 px, not the 21 of
+    its half-width. The first version of this guard asserted the half-width on
+    this axis and called it "a label overruns vertically", which is the #1096
+    lesson repeating: a guard that models geometry instead of reading it, 9 px
+    out on the axis it names.
+
+    Fixing the guard turned up a real shortfall rather than only a wording
+    error. In a window taller than it is wide the fit is height-limited, and a
+    22 px inset left a rival's label bottom at 81 against a playback readout
+    whose top is 82 (#1111).
+    """
+    _, inset_y = track_inset(track_viewport(width, height))
+    assert inset_y >= CAR_LABEL_MAX_REACH_ABOVE, (
+        f"{width}x{height}: a label reaches {CAR_LABEL_MAX_REACH_ABOVE} px into a "
+        f"{inset_y:.1f} px inset"
+    )
 
 
 def test_a_bigger_window_draws_a_bigger_circuit() -> None:


### PR DESCRIPTION
## What

The three comments and four guards the closing gate on #1098 refuted. One of the guard fixes turned up a real shortfall rather than only a wording error.

## The comments

| where | said | measured today |
|---|---|---|
| `overlays.py`, `legend_mode` | the list spans 154 px and the column leaves 146, so it cannot fit at any anchor | spans **158**, column leaves **263**, returns `full` |
| `views.py`, `menu_bands` | the gap-to-form ratio "is now 0.46 at both" | **0.327** at both |
| `track.py` + the viewport test | 20 px "came off the circuit for nothing" | 20 px was reserved beyond the column; **10** of it is kept as the gap and 10 went back |

The first two are the same shape: a change later in the same sprint moved the geometry a neighbouring docstring describes, and the neighbour was not revisited. #1102 replaced the two cards `legend_mode` was written against, and #1101's group gaps grew the form from 280 px to 324 after #1100's ratio was measured. The third is not false, it is ambiguous: both numbers are real and they are different quantities.

## The guards

- **The car-label guard asserted the label's half-width on the VERTICAL axis** while calling it a vertical overrun. A label is centred on the dot sideways, so it costs half its width there, but `_draw_car` anchors it a whole line above or below, so the drawn reach is **31 px, not 21**. This is the #1096 lesson repeating: a guard that models geometry instead of reading it, 9 px out on the axis it names.

  **Fixing the assertion found the shortfall real.** In a window taller than it is wide the fit is height-limited, and a 22 px inset left a rival's label bottom at 81 against a playback readout whose top is 82. Added `TRACK_MIN_CLEARANCE_Y = 31`. It costs nothing where the fit is width-limited: the trace is byte-identical at 1280x720 (646 x 322) and 1920x1080 (1277 x 637), and only a portrait-ish window pays.

- **`WIDEST` was measured over 400 frames of two drivers.** Swept over every 60th of the race's 125,279 frames for all twenty drivers through the real gap pipeline, `Ahead` reaches **111.2 px, not 103**, and the widest label-plus-value pair is **148.1, not 140**. The readable margin is **9.9 px**, not the 18 the docstring claimed. The subject of a measurement is part of the measurement.

- **`WORST_CASE_VALUE = 115` was below a producible string.** The seconds branch of `_gap_label` is uncapped, and a three-digit interval renders 116.9 px against a 118 px column, 123.3 for the alphabet-worst code. Renamed to `WIDEST_SERVED_VALUE`, which is what it measures, and the string that does not fit is now its own test with the trade priced: fitting it needs a 312 px card against a `MARGIN_LEFT` of 330 starting at 20, so the circuit would pay 12 px of width for a string no served session contains. Left unfixed deliberately, and the test fails if the constants move rather than silently going stale.

- **The legend-fit model transcribed the weather panel's row count** (`_WEATHER_ROWS = 5`) while `_weather_rows` is importable from the module under test. It reads it live now. Demonstrated with mutant V, a sixth weather row: three tests fail where the literal would have left them green.

- **Two assertions in the menu band test reduced to `PAD <= PAD`.** They read `band_half` off the geometry the draw call uses.

## Checks

- `tests/surfaces` 444 -> 461 on this branch, executed. `tests/agents` 259 / 13 skipped, unchanged.
- Two mutants watched red: **U**, the vertical floor back to the half-width (5 failures, every size); **V**, a sixth weather row (3 failures, which is F6's whole point).
- `ruff check .` and `ruff format --check .` clean, 193 files.
- Re-measured the trace on hidden windows after the vertical floor: unchanged at 1280x720 and 1920x1080, as predicted.

Also aligned two hedges: the quick-start page said the collapse fires below "roughly 618" and `app.py` said "about 615" where the arithmetic says exactly 615. The page now also records that the table reaches the collapsed hint line below about 475 px of window, which nothing collapses further, and that the same crossing was at about 652 before the table.

Closes #1111. Found by the closing adversarial gate on #1098.
