### PR TITLE
fix(arcade): prepare any race picked from the menu, and show it preparing

### DIFF
--- a/src/arcade/main.py
+++ b/src/arcade/main.py
@@ -65,74 +65,33 @@ def _show_menu(window: arcade.Window) -> None:
 
 
 def _show_viewer_directly(window: arcade.Window, args: argparse.Namespace) -> None:
-    """Legacy path: bypass the menu and build a F1ArcadeView from CLI args."""
-    from src.arcade.app import F1ArcadeView
-    from src.arcade.config import get_gp_names
-    from src.arcade.data import SessionLoader
-    from src.arcade.track import Track
+    """Boot straight into the replay, through the menu's own launch path.
 
-    year = args.year
-    round_num = args.round
-    gp = get_gp_names(year).get(round_num, f"Round{round_num}")
+    This used to be a second implementation: its own `SessionLoader().load`, its
+    own driver fallback, its own `F1ArcadeView`. The menu grew a lazy per-race
+    fetch and a worker thread so the window keeps drawing through a download and
+    a 349 s telemetry build; this path would not have grown either, because
+    nothing here shared a line with it. It now fills a `LaunchConfig` and hands
+    it over, so `--viewer` and the menu can only ever behave the same (#1115).
+    """
+    from src.arcade.views import LaunchConfig, MenuView
 
-    # gp is the arcade's display label from the GP_NAMES table, which does
-    # not stay in sync with the active season calendar (``GP_NAMES[3]`` is
-    # "Australia" but 2025 round 3 is Suzuka). The real race is resolved by
-    # FastF1 inside SessionLoader; re-log after the load with the
-    # authoritative Location so the startup trace does not mislead.
-    logger.info("Requesting session: year=%d round=%d (label=%s)", year, round_num, gp)
-    session_data = SessionLoader().load(year, round_num, gp)
-    logger.info(
-        "Loaded session: %s %d (label=%s) — %d drivers, laps %d-%d, %d frames",
-        session_data.location or "?",
-        year,
-        gp,
-        len(session_data.frames_by_driver),
-        session_data.min_lap_number,
-        session_data.max_lap_number,
-        session_data.total_frames,
-    )
-
-    ref_x, ref_y = session_data.ref_lap_xy
-    track = Track(
-        ref_x=ref_x,
-        ref_y=ref_y,
-        drs_flags=session_data.ref_lap_drs,
-        rotation_deg=session_data.circuit_rotation_deg,
-    )
-
-    driver_main = args.driver or _pick_default_driver(session_data)
-    driver_rival = args.driver2
-    if driver_main not in session_data.frames_by_driver:
-        logger.warning("Driver %s not in session; falling back", driver_main)
-        driver_main = _pick_default_driver(session_data)
-    if driver_rival and driver_rival not in session_data.frames_by_driver:
-        logger.warning("Rival %s not in session; ignoring", driver_rival)
-        driver_rival = None
-
-    view = F1ArcadeView(
-        window=window,
-        session_data=session_data,
-        track=track,
-        driver_main=driver_main,
-        driver_rival=driver_rival,
-        year=year,
-        strategy_enabled=args.strategy,
-        team=args.team,
-    )
+    # Only the flags that were actually passed override the defaults. An empty
+    # `--driver` used to fall through to `_pick_default_driver`, which read the
+    # loaded session; the form validates before anything is loaded, so an empty
+    # string would now surface as "driver must be 3 letters". The menu's own
+    # default stands instead, and `_show_replay` still swaps in a driver the
+    # session really has if that one is absent from it.
+    cfg = LaunchConfig(year=args.year, round_=args.round, team=args.team)
+    if args.driver:
+        cfg.driver_main = args.driver.upper()
+    cfg.mode_two_drivers = bool(args.driver2)
+    if args.driver2:
+        cfg.driver_rival = args.driver2.upper()
+    cfg.strategy_mode = args.strategy
+    view = MenuView(window)
     window.show_view(view)
-
-
-def _pick_default_driver(session_data) -> str:
-    """Prefer a finisher of the final lap; fall back to first driver otherwise."""
-    codes = list(session_data.frames_by_driver.keys())
-    if not codes:
-        raise RuntimeError("Session has no drivers")
-    for code in codes:
-        frames = session_data.frames_by_driver[code]
-        if frames and frames[-1].active:
-            return code
-    return codes[0]
+    view.launch_with(cfg)
 
 
 if __name__ == "__main__":

--- a/src/arcade/prepare.py
+++ b/src/arcade/prepare.py
@@ -47,6 +47,15 @@ STAGE_TELEMETRY = "Building telemetry"
 ProgressFn = Callable[["PrepareProgress"], None]
 
 
+class RaceDataUnavailable(RuntimeError):
+    """The dataset publishes nothing for this race, so the agents cannot run.
+
+    Its own type because the menu treats it as an answer rather than a crash:
+    the race simply is not available, which is worth saying plainly instead of
+    surfacing a stack trace.
+    """
+
+
 @dataclass(frozen=True)
 class PrepareProgress:
     """One step of the preparation, as the UI should show it.
@@ -61,11 +70,31 @@ class PrepareProgress:
     stage: str
     index: int
     total: int
-    elapsed_s: float = 0.0
+    started_at: float = 0.0
 
     @property
     def label(self) -> str:
         return f"{self.stage}  ({self.index}/{self.total})"
+
+    @property
+    def done_fraction(self) -> float:
+        """Share of the run FINISHED, which is the stages before this one.
+
+        `index / total` would read 100% the moment the last stage starts, and
+        the last stage is the 349 s telemetry build, so the bar would sit full
+        for the entire wait (#1116).
+        """
+        return (self.index - 1) / self.total
+
+    def elapsed_s(self, now: float) -> float:
+        """Seconds in this stage, counted by the caller's clock.
+
+        A field would be frozen at whatever it held when the worker reported,
+        which is zero: each stage reports once, at its start. The menu redraws
+        sixty times a second and can count, and a number that climbs is the
+        only thing on screen saying the window is alive rather than hung.
+        """
+        return max(0.0, now - self.started_at)
 
 
 def race_stages(*, strategy_enabled: bool) -> tuple[str, ...]:
@@ -111,13 +140,22 @@ def prepare_race(
                 stage=stage,
                 index=stages.index(stage) + 1,
                 total=total,
-                elapsed_s=time.monotonic() - started,
+                started_at=started,
             )
         )
 
     started = time.monotonic()
     report(STAGE_RACE_DATA, started)
     race_dir = ensure_race(year, gp_name, show_progress=False)
+    if not race_dir.exists() or not any(race_dir.iterdir()):
+        # `snapshot_download` on a pattern that matches nothing returns quietly,
+        # so without this a race the dataset does not hold looks identical to
+        # one it does, right up until the agents window sits empty. Refusing
+        # here puts the reason in front of whoever picked it (#1116).
+        raise RaceDataUnavailable(
+            f"No data published for {gp_name} {year}. "
+            f"The dataset has no {race_dir.name} folder for that season."
+        )
     logger.info("Race data ready at %s (%.1fs)", race_dir, time.monotonic() - started)
 
     if strategy_enabled:

--- a/src/arcade/prepare.py
+++ b/src/arcade/prepare.py
@@ -1,0 +1,140 @@
+"""Everything a race needs on disk before the replay and the agents can run.
+
+Three artefacts, and until #1115 the arcade fetched exactly one of them:
+
+- ``data/raw/{year}/{gp}/**``, the FastF1 race dump. Read by the strategy layer
+  and by PITWALL. **Nothing fetched it.** `ensure_race` was written for this,
+  exported, and documented in `src/f1_strat_manager/README.md` as the lazy
+  per-race pull, and its only mention anywhere in `src/` was a log line telling
+  the user to run it by hand. Its sibling `ensure_radio_corpus` DID get a call
+  site, in `scripts/run_simulation_cli.py`, which is this repo's dominant defect
+  shape: one of a pair wired and its twin not.
+- ``data/raw/radio_audio/{year}/{slug}/**``, the team radio the radio agent
+  transcribes. Only needed when the agents run.
+- ``data/cache/arcade/{gp}_{year}_race.pkl``, the replay telemetry. This one the
+  arcade already built on demand, which is why picking any GP from the menu drew
+  a circuit and gave you an empty AGENTS window: the half the eye sees was lazy
+  and the half the agents need was not.
+
+The other reason this module exists is TIME. Building the Lusail 2025 pickle
+takes 349 s measured, and the fetches add to it, so the preparation cannot run
+on the thread that draws: the menu used to force one frame of "Loading
+session..." and then block pyglet for minutes, which Windows paints as a dead
+window. Everything here is plain I/O returning plain data, so a worker thread
+can run it while the menu keeps drawing, and the caller builds the GL objects on
+the main thread once it is done.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle only matters for typing
+    from src.arcade.data import SessionData
+
+logger = logging.getLogger(__name__)
+
+# What the user is told is happening, in the order it happens. The downloads go
+# first because they are the steps that can fail on a missing race, and failing
+# in 5 s beats failing after a 349 s telemetry build.
+STAGE_RACE_DATA = "Downloading race data"
+STAGE_TEAM_RADIO = "Downloading team radio"
+STAGE_TELEMETRY = "Building telemetry"
+
+ProgressFn = Callable[["PrepareProgress"], None]
+
+
+@dataclass(frozen=True)
+class PrepareProgress:
+    """One step of the preparation, as the UI should show it.
+
+    `index` is 1-based and `total` is fixed for the run, so a caller can render
+    "2/3" without knowing which stages exist. `elapsed_s` is the time spent in
+    THIS stage, which is the only honest progress available: the downloads go
+    through `huggingface_hub`'s own tqdm and expose no callback, and the
+    telemetry build reports nothing at all.
+    """
+
+    stage: str
+    index: int
+    total: int
+    elapsed_s: float = 0.0
+
+    @property
+    def label(self) -> str:
+        return f"{self.stage}  ({self.index}/{self.total})"
+
+
+def race_stages(*, strategy_enabled: bool) -> tuple[str, ...]:
+    """The stages this run will go through, so the UI can size itself up front.
+
+    The radio corpus is only fetched when the agents are going to run: the
+    replay itself never reads it, and it is ~3 MB a user should not pay for
+    watching a race back.
+    """
+    if strategy_enabled:
+        return (STAGE_RACE_DATA, STAGE_TEAM_RADIO, STAGE_TELEMETRY)
+    return (STAGE_RACE_DATA, STAGE_TELEMETRY)
+
+
+def prepare_race(
+    year: int,
+    round_: int,
+    gp_name: str,
+    *,
+    strategy_enabled: bool,
+    on_progress: ProgressFn | None = None,
+) -> SessionData:
+    """Fetch what this race needs and return its loaded telemetry.
+
+    Safe to call on a worker thread: it touches the filesystem and the network
+    and returns a plain dataclass, with no GL object created anywhere. The
+    caller builds `Track` and `F1ArcadeView` on the main thread from the result.
+
+    Idempotent. Every fetch short-circuits on a populated directory, so a warm
+    race pays a few milliseconds of `Path.exists` and the pickle load.
+    """
+    from src.arcade.data import SessionLoader
+    from src.f1_strat_manager.data_cache import ensure_race, ensure_radio_corpus
+
+    stages = race_stages(strategy_enabled=strategy_enabled)
+    total = len(stages)
+
+    def report(stage: str, started: float) -> None:
+        if on_progress is None:
+            return
+        on_progress(
+            PrepareProgress(
+                stage=stage,
+                index=stages.index(stage) + 1,
+                total=total,
+                elapsed_s=time.monotonic() - started,
+            )
+        )
+
+    started = time.monotonic()
+    report(STAGE_RACE_DATA, started)
+    race_dir = ensure_race(year, gp_name, show_progress=False)
+    logger.info("Race data ready at %s (%.1fs)", race_dir, time.monotonic() - started)
+
+    if strategy_enabled:
+        started = time.monotonic()
+        report(STAGE_TEAM_RADIO, started)
+        audio_dir = ensure_radio_corpus(year, gp_name, show_progress=False)
+        logger.info("Team radio ready at %s (%.1fs)", audio_dir, time.monotonic() - started)
+
+    started = time.monotonic()
+    report(STAGE_TELEMETRY, started)
+    session_data = SessionLoader().load(year, round_, gp_name)
+    logger.info(
+        "Telemetry ready: %s %d, %d drivers, %d frames (%.1fs)",
+        session_data.location or gp_name,
+        year,
+        len(session_data.frames_by_driver),
+        session_data.total_frames,
+        time.monotonic() - started,
+    )
+    return session_data

--- a/src/arcade/views.py
+++ b/src/arcade/views.py
@@ -11,6 +11,7 @@ inside the window instead of remembering CLI flags.
 from __future__ import annotations
 
 import logging
+import threading
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Callable, Final, NamedTuple
@@ -50,6 +51,7 @@ from src.arcade.config import (
     TEXT_TERTIARY,
     get_gp_names,
 )
+from src.arcade.prepare import PrepareProgress, prepare_race
 
 logger = logging.getLogger(__name__)
 
@@ -401,6 +403,14 @@ class MenuView(arcade.View):
         self._cfg = LaunchConfig()
         self._error: str = ""
         self._loading: bool = False
+        # Written by the preparation worker, read by on_draw and on_update.
+        # A plain lock rather than a queue: there is one producer, one consumer,
+        # and the consumer only ever wants the LATEST value.
+        self._prep_lock = threading.Lock()
+        self._prep_progress: PrepareProgress | None = None
+        self._prep_result: object | None = None
+        self._prep_error: str = ""
+        self._prep_thread: threading.Thread | None = None
         self._focus_idx: int = 0
         # Last scale pushed into the Text objects, or None while nothing has
         # been. See `scale_changed` for why it cannot be a float.
@@ -525,14 +535,50 @@ class MenuView(arcade.View):
             self._error_text.draw()
 
         if self._loading:
-            self._loading_text.text = "Loading session..."
-            self._loading_text.x = w / 2
-            self._loading_text.y = bands.status_y
-            self._loading_text.draw()
+            self._draw_progress(w, bands)
 
         self._hint.x = w / 2
         self._hint.y = bands.hint_y
         self._hint.draw()
+
+    def _draw_progress(self, w: int, bands: MenuBands) -> None:
+        """The preparation's current stage, and a bar for how far through it is.
+
+        The bar counts STAGES, not bytes. Neither fetch exposes a byte callback
+        (`huggingface_hub` prints its own tqdm to stderr) and the telemetry build
+        reports nothing at all, so a byte-level bar would be invented. What is
+        honest is which of the three steps is running and how long it has been,
+        and the elapsed count is what tells a user the window is alive rather
+        than hung, which is the whole reason this is on a worker (#1115).
+        """
+        with self._prep_lock:
+            progress = self._prep_progress
+
+        if progress is None:
+            self._loading_text.text = "Preparing race..."
+        else:
+            self._loading_text.text = f"{progress.label}   {progress.elapsed_s:.0f}s"
+        self._loading_text.x = w / 2
+        self._loading_text.y = bands.status_y
+        self._loading_text.draw()
+
+        if progress is None:
+            return
+        # Sized to the form so the bar reads as part of the same panel.
+        half = (self._label_texts[0].content_width + 220) * bands.scale
+        bar_y = bands.status_y - MENU_ROW_HEIGHT * bands.scale * 0.55
+        height = max(3.0, 4.0 * bands.scale)
+        arcade.draw_rect_filled(arcade.XYWH(w / 2, bar_y, half * 2, height), (*CONTENT_BG, 220))
+        done = progress.index / progress.total
+        arcade.draw_rect_filled(
+            arcade.XYWH(
+                w / 2 - half + half * done,
+                bar_y,
+                half * 2 * done,
+                height,
+            ),
+            ACCENT,
+        )
 
     def _apply_scale(self, scale: float) -> None:
         """Resize every string to the window, once per change rather than per frame.
@@ -700,16 +746,85 @@ class MenuView(arcade.View):
     # --- Launch ---------------------------------------------------------
 
     def _try_launch(self) -> None:
+        """Validate, then hand the preparation to a worker and keep drawing.
+
+        It used to force one frame of "Loading session..." and then block the
+        pyglet thread for as long as the load took. That is measured at 349 s
+        for a race whose telemetry is not cached yet, plus the downloads, and a
+        window that does not pump events for six minutes is one the OS paints as
+        dead (#1115).
+        """
         err = self._validate(self._cfg)
         if err:
             self._error = err
             return
+        if self._prep_thread is not None and self._prep_thread.is_alive():
+            return
         self._error = ""
         self._loading = True
-        # Force a redraw so "Loading..." shows before the blocking load
-        self.on_draw()
-        self.window.flip()
-        self._spawn_replay()
+        with self._prep_lock:
+            self._prep_progress = None
+            self._prep_result = None
+            self._prep_error = ""
+
+        gp = get_gp_names(self._cfg.year).get(self._cfg.round_, f"Round{self._cfg.round_}")
+        logger.info("Menu: preparing %d round %d (%s)", self._cfg.year, self._cfg.round_, gp)
+        self._prep_thread = threading.Thread(
+            target=self._prepare_worker,
+            args=(self._cfg.year, self._cfg.round_, gp, self._cfg.strategy_mode),
+            name="arcade-prepare",
+            daemon=True,
+        )
+        self._prep_thread.start()
+
+    def _prepare_worker(self, year: int, round_: int, gp: str, strategy_enabled: bool) -> None:
+        """Fetch and load off the draw thread. Touches no GL object.
+
+        Everything it produces is plain data; `on_update` builds the view.
+        """
+
+        def publish(progress: PrepareProgress) -> None:
+            with self._prep_lock:
+                self._prep_progress = progress
+
+        try:
+            session_data = prepare_race(
+                year,
+                round_,
+                gp,
+                strategy_enabled=strategy_enabled,
+                on_progress=publish,
+            )
+        except Exception as exc:  # noqa: BLE001 - reported to the user verbatim
+            logger.exception("Race preparation failed")
+            with self._prep_lock:
+                self._prep_error = f"{type(exc).__name__}: {exc}"
+            return
+        with self._prep_lock:
+            self._prep_result = session_data
+
+    def on_update(self, delta_time: float) -> None:
+        """Pick up whatever the worker finished, on the thread that owns the GL.
+
+        `Track` and `F1ArcadeView` allocate `arcade.Text`, which needs the
+        context, so the worker hands back a `SessionData` and the swap happens
+        here.
+        """
+        del delta_time
+        if not self._loading:
+            return
+        with self._prep_lock:
+            result = self._prep_result
+            error = self._prep_error
+        if error:
+            self._loading = False
+            self._error = error
+            self._prep_thread = None
+            return
+        if result is not None:
+            self._prep_result = None
+            self._prep_thread = None
+            self._show_replay(result)
 
     @staticmethod
     def _validate(cfg: LaunchConfig) -> str:
@@ -724,21 +839,26 @@ class MenuView(arcade.View):
                 return "team required for strategy mode"
         return ""
 
-    def _spawn_replay(self) -> None:
+    def launch_with(self, cfg: LaunchConfig) -> None:
+        """Skip the form and prepare this configuration straight away.
+
+        The `--viewer` flag used to build the whole thing itself in
+        `main.py:_show_viewer_directly`: its own session load, its own driver
+        fallback, its own view construction. That second copy is why the flag
+        never gained the lazy fetch or the worker thread when the menu did, and
+        duplicated launch paths drifting apart is a scar this repo already
+        carries. One path now (#1115).
+        """
+        self._cfg = cfg
+        self._try_launch()
+
+    def _show_replay(self, session_data) -> None:
+        """Build the replay view from a prepared session and hand it the window.
+
+        Main thread only: everything below allocates GL resources.
+        """
         from src.arcade.app import F1ArcadeView
-        from src.arcade.data import SessionLoader
         from src.arcade.track import Track
-
-        gp = get_gp_names(self._cfg.year).get(self._cfg.round_, f"Round{self._cfg.round_}")
-        logger.info("Menu: loading %d round %d (%s)", self._cfg.year, self._cfg.round_, gp)
-
-        try:
-            session_data = SessionLoader().load(self._cfg.year, self._cfg.round_, gp)
-        except Exception as exc:
-            logger.exception("SessionLoader failed")
-            self._error = f"session load failed: {exc}"
-            self._loading = False
-            return
 
         ref_x, ref_y = session_data.ref_lap_xy
         track = Track(

--- a/src/arcade/views.py
+++ b/src/arcade/views.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import threading
+import time
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Callable, Final, NamedTuple
@@ -314,6 +315,30 @@ def menu_form_geometry(
     )
 
 
+def last_round(year: int) -> int:
+    """Final round of that season, from the calendar rather than a constant.
+
+    The stepper was clamped to 23, so 2025 could not reach round 24, Yas Island,
+    which is a real published race the menu simply would not offer; and 2023,
+    which ran 22, stepped into a round with no name at all (#1116).
+    """
+    rounds = get_gp_names(year)
+    return max(rounds) if rounds else 1
+
+
+def _step_year(cfg: LaunchConfig, delta: int) -> None:
+    """Move a season, keeping the round inside the calendar it lands in.
+
+    Strategy mode pins the year, because the agents are only trained and
+    validated for it. Seasons run different lengths, so a round that exists in
+    one may not exist in the next.
+    """
+    if cfg.strategy_mode:
+        return
+    cfg.year = max(2023, min(2025, cfg.year + delta))
+    cfg.round_ = min(cfg.round_, last_round(cfg.year))
+
+
 def build_menu_fields(toggle_strategy: Callable[[], None]) -> list[_FormField]:
     """The seven rows the menu draws, in draw order.
 
@@ -330,12 +355,8 @@ def build_menu_fields(toggle_strategy: Callable[[], None]) -> list[_FormField]:
             kind="int",
             group="race",
             get_value=lambda c: str(c.year),
-            step_left=lambda c: (
-                setattr(c, "year", max(2023, c.year - 1)) if not c.strategy_mode else None
-            ),
-            step_right=lambda c: (
-                setattr(c, "year", min(2025, c.year + 1)) if not c.strategy_mode else None
-            ),
+            step_left=lambda c: _step_year(c, -1),
+            step_right=lambda c: _step_year(c, +1),
         ),
         _FormField(
             key="round",
@@ -344,7 +365,7 @@ def build_menu_fields(toggle_strategy: Callable[[], None]) -> list[_FormField]:
             group="race",
             get_value=lambda c: round_label(c.year, c.round_),
             step_left=lambda c: setattr(c, "round_", max(1, c.round_ - 1)),
-            step_right=lambda c: setattr(c, "round_", min(23, c.round_ + 1)),
+            step_right=lambda c: setattr(c, "round_", min(last_round(c.year), c.round_ + 1)),
         ),
         _FormField(
             key="mode",
@@ -557,7 +578,9 @@ class MenuView(arcade.View):
         if progress is None:
             self._loading_text.text = "Preparing race..."
         else:
-            self._loading_text.text = f"{progress.label}   {progress.elapsed_s:.0f}s"
+            self._loading_text.text = (
+                f"{progress.label}   {progress.elapsed_s(time.monotonic()):.0f}s"
+            )
         self._loading_text.x = w / 2
         self._loading_text.y = bands.status_y
         self._loading_text.draw()
@@ -569,7 +592,7 @@ class MenuView(arcade.View):
         bar_y = bands.status_y - MENU_ROW_HEIGHT * bands.scale * 0.55
         height = max(3.0, 4.0 * bands.scale)
         arcade.draw_rect_filled(arcade.XYWH(w / 2, bar_y, half * 2, height), (*CONTENT_BG, 220))
-        done = progress.index / progress.total
+        done = progress.done_fraction
         arcade.draw_rect_filled(
             arcade.XYWH(
                 w / 2 - half + half * done,

--- a/src/f1_strat_manager/data_cache.py
+++ b/src/f1_strat_manager/data_cache.py
@@ -441,6 +441,32 @@ def ensure_setup(
     console.print(f"[{COL_OK}][OK] Setup complete. Cached under {local_dir}[/{COL_OK}]")
 
 
+# Races the dataset stores under a name the calendar does not use. Keyed by
+# season because the same race is not named the same way in every one: Miami is
+# `Miami` in 2023 and 2024 and `Miami_Gardens` in 2025, after the circuit's
+# location rather than the city. Everything else is the label with its spaces
+# turned into underscores, measured against the repository listing: with this
+# table, 70 of the 70 rounds the menu offers across 2023-2025 resolve.
+_RACE_FOLDER_ALIASES: dict[tuple[int, str], str] = {
+    (2025, "Miami"): "Miami_Gardens",
+}
+
+
+def race_folder(year: int, gp_name: str) -> str:
+    """The dataset folder holding this GP, from the name the menu shows.
+
+    `ensure_race` used to glob the label verbatim. `snapshot_download` on a
+    pattern that matches nothing returns quietly, so picking "Mexico City"
+    fetched zero files, raised nothing, and left the strategy layer degrading
+    against an empty directory: the same defect the lazy fetch was added to
+    close, surviving it for six of the 2025 rounds (#1116).
+    """
+    alias = _RACE_FOLDER_ALIASES.get((year, gp_name))
+    if alias is not None:
+        return alias
+    return gp_name.replace(" ", "_")
+
+
 def ensure_race(year: int, gp_name: str, show_progress: bool = True) -> Path:
     """Download a single race folder when it is missing and return its path.
 
@@ -452,7 +478,8 @@ def ensure_race(year: int, gp_name: str, show_progress: bool = True) -> Path:
     (possibly empty) path and can decide whether to raise.
     """
     data_root = get_data_root()
-    race_dir = data_root / "raw" / str(year) / gp_name
+    folder = race_folder(year, gp_name)
+    race_dir = data_root / "raw" / str(year) / folder
 
     if race_dir.exists() and any(race_dir.iterdir()):
         return race_dir
@@ -460,7 +487,7 @@ def ensure_race(year: int, gp_name: str, show_progress: bool = True) -> Path:
     if os.environ.get("F1_STRAT_OFFLINE") == "1":
         return race_dir
 
-    patterns = [f"data/raw/{year}/{gp_name}/**"]
+    patterns = [f"data/raw/{year}/{folder}/**"]
     _snapshot_download(patterns, show_progress=show_progress)
     return race_dir
 
@@ -563,6 +590,7 @@ __all__ = [
     "is_first_run",
     "ensure_setup",
     "ensure_race",
+    "race_folder",
     "ensure_radio_corpus",
     "ensure_models",
 ]

--- a/tests/surfaces/test_arcade_prepare.py
+++ b/tests/surfaces/test_arcade_prepare.py
@@ -1,0 +1,181 @@
+"""A race is fetched before it is loaded, for every race (#1115).
+
+`data/raw/{year}/{gp}/**` is what the strategy layer and PITWALL read, and until
+this landed nothing fetched it. `ensure_race` existed, was exported, and was
+documented in `src/f1_strat_manager/README.md` as the lazy per-race pull; its
+only mention anywhere in `src/` was a log line telling the user to run it by
+hand. Its sibling `ensure_radio_corpus` DID have a call site. So picking any GP
+but the one already on disk drew a circuit and gave you an empty AGENTS window.
+
+**Asserted on the orchestration, not on a download.** The fetch helpers are
+`snapshot_download` wrappers and the telemetry build takes minutes, so what is
+checked here is that they are called, in the right order, with the right
+arguments, and that the caller is told about each one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.arcade import prepare
+from src.arcade.prepare import (
+    STAGE_RACE_DATA,
+    STAGE_TEAM_RADIO,
+    STAGE_TELEMETRY,
+    PrepareProgress,
+    prepare_race,
+    race_stages,
+)
+
+
+class _Recorder:
+    """Stands in for the three slow calls and records the order they came in."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple]] = []
+
+    def ensure_race(self, year, gp_name, show_progress=True):
+        self.calls.append(("ensure_race", (year, gp_name, show_progress)))
+        return f"raw/{year}/{gp_name}"
+
+    def ensure_radio_corpus(self, year, gp_name, show_progress=True):
+        self.calls.append(("ensure_radio_corpus", (year, gp_name, show_progress)))
+        return f"audio/{year}/{gp_name}"
+
+    def loader(self):
+        recorder = self
+
+        class _Loader:
+            def load(self, year, round_, gp_name):
+                recorder.calls.append(("load", (year, round_, gp_name)))
+                return _Session()
+
+        return _Loader
+
+    @property
+    def names(self) -> list[str]:
+        return [name for name, _ in self.calls]
+
+
+class _Session:
+    frames_by_driver: dict = {}
+    total_frames = 0
+    location = "Lusail"
+
+
+@pytest.fixture
+def recorder(monkeypatch: pytest.MonkeyPatch) -> _Recorder:
+    """Patch the three slow calls at the module `prepare_race` imports them from."""
+    rec = _Recorder()
+    import src.arcade.data as arcade_data
+    import src.f1_strat_manager.data_cache as data_cache
+
+    monkeypatch.setattr(data_cache, "ensure_race", rec.ensure_race)
+    monkeypatch.setattr(data_cache, "ensure_radio_corpus", rec.ensure_radio_corpus)
+    monkeypatch.setattr(arcade_data, "SessionLoader", rec.loader())
+    return rec
+
+
+def test_the_race_data_is_fetched_before_anything_reads_it(recorder: _Recorder) -> None:
+    """The whole defect, in one assertion.
+
+    Nothing called `ensure_race`, so `data/raw/{year}/{gp}/` stayed empty for
+    every race but the one shipped in the curated download, and the strategy
+    layer degraded silently against it.
+    """
+    prepare_race(2025, 23, "Lusail", strategy_enabled=True)
+    assert "ensure_race" in recorder.names
+    assert recorder.names.index("ensure_race") < recorder.names.index("load")
+
+
+def test_the_downloads_come_before_the_long_build(recorder: _Recorder) -> None:
+    """Failing in seconds beats failing after a 349 s telemetry build.
+
+    That is the measured cold cost of `SessionLoader().load` for Lusail 2025, so
+    ordering the cheap failable steps first is the difference between a user
+    learning a race is unavailable now and learning it six minutes from now.
+    """
+    prepare_race(2025, 23, "Lusail", strategy_enabled=True)
+    assert recorder.names == ["ensure_race", "ensure_radio_corpus", "load"]
+
+
+def test_the_radio_is_only_fetched_when_the_agents_will_run(recorder: _Recorder) -> None:
+    """The replay never reads the audio, so watching a race back must not pay for it."""
+    prepare_race(2025, 23, "Lusail", strategy_enabled=False)
+    assert recorder.names == ["ensure_race", "load"]
+    assert STAGE_TEAM_RADIO not in race_stages(strategy_enabled=False)
+
+
+def test_every_call_gets_the_same_race(recorder: _Recorder) -> None:
+    """One GP goes in, so a fetch for a different one is a wiring error.
+
+    The round number and the GP name are separate arguments and only the loader
+    takes both, which is exactly the shape where one of them gets dropped.
+    """
+    prepare_race(2025, 23, "Lusail", strategy_enabled=True)
+    by_name = dict(recorder.calls)
+    assert by_name["ensure_race"] == (2025, "Lusail", False)
+    assert by_name["ensure_radio_corpus"] == (2025, "Lusail", False)
+    assert by_name["load"] == (2025, 23, "Lusail")
+
+
+def test_the_fetches_are_told_not_to_print_their_own_progress(recorder: _Recorder) -> None:
+    """`show_progress=True` writes a tqdm bar to stderr, which no window shows.
+
+    The menu draws the stage itself, so a second progress display in a console
+    the user is not looking at is noise.
+    """
+    prepare_race(2025, 23, "Lusail", strategy_enabled=True)
+    for name, args in recorder.calls:
+        if name.startswith("ensure_"):
+            assert args[-1] is False, f"{name} was left printing to stderr"
+
+
+def test_the_caller_hears_about_every_stage_in_order(recorder: _Recorder) -> None:
+    """A stage that runs without reporting is a window that looks hung.
+
+    `SessionLoader().load` is minutes long on a cold race, so the readout going
+    quiet is indistinguishable from the freeze this change exists to remove.
+    """
+    seen: list[PrepareProgress] = []
+    prepare_race(2025, 23, "Lusail", strategy_enabled=True, on_progress=seen.append)
+
+    assert [p.stage for p in seen] == [STAGE_RACE_DATA, STAGE_TEAM_RADIO, STAGE_TELEMETRY]
+    assert [p.index for p in seen] == [1, 2, 3]
+    assert {p.total for p in seen} == {3}
+
+
+def test_the_stage_count_matches_the_stages_actually_run(recorder: _Recorder) -> None:
+    """`2/3` while only two stages will ever run is a bar that never fills."""
+    for strategy_enabled in (True, False):
+        recorder.calls.clear()
+        seen: list[PrepareProgress] = []
+        prepare_race(2025, 23, "Lusail", strategy_enabled=strategy_enabled, on_progress=seen.append)
+        stages = race_stages(strategy_enabled=strategy_enabled)
+        assert len(seen) == len(stages)
+        assert seen[-1].index == seen[-1].total == len(stages)
+
+
+def test_no_progress_callback_is_a_supported_caller(recorder: _Recorder) -> None:
+    """The scripted path has no window to draw into and must not crash."""
+    session = prepare_race(2025, 23, "Lusail", strategy_enabled=False, on_progress=None)
+    assert session is not None
+
+
+def test_the_label_names_the_stage_and_its_place(recorder: _Recorder) -> None:
+    """What the menu renders, so it is asserted rather than eyeballed."""
+    progress = PrepareProgress(stage=STAGE_TELEMETRY, index=3, total=3, elapsed_s=12.0)
+    assert progress.label == "Building telemetry  (3/3)"
+
+
+def test_prepare_touches_no_gl_object() -> None:
+    """It runs on a worker thread, so anything needing the context would crash.
+
+    `arcade` must not appear in the module at all: the caller builds `Track` and
+    `F1ArcadeView` on the main thread from what this returns.
+    """
+    source = prepare.__file__
+    with open(source, encoding="utf-8") as handle:
+        text = handle.read()
+    assert "import arcade" not in text
+    assert "arcade.Text" not in text

--- a/tests/surfaces/test_arcade_prepare.py
+++ b/tests/surfaces/test_arcade_prepare.py
@@ -23,24 +23,33 @@ from src.arcade.prepare import (
     STAGE_TEAM_RADIO,
     STAGE_TELEMETRY,
     PrepareProgress,
+    RaceDataUnavailable,
     prepare_race,
     race_stages,
 )
 
 
 class _Recorder:
-    """Stands in for the three slow calls and records the order they came in."""
+    """Stands in for the three slow calls and records the order they came in.
 
-    def __init__(self) -> None:
+    `ensure_race` returns a real populated directory because `prepare_race`
+    inspects it: `snapshot_download` on a pattern that matches nothing returns
+    an empty one quietly, and refusing that is the point of the check.
+    """
+
+    def __init__(self, tmp_path) -> None:
         self.calls: list[tuple[str, tuple]] = []
+        self.race_dir = tmp_path / "raw"
+        self.race_dir.mkdir(parents=True, exist_ok=True)
+        (self.race_dir / "laps.parquet").write_bytes(b"x")
 
     def ensure_race(self, year, gp_name, show_progress=True):
         self.calls.append(("ensure_race", (year, gp_name, show_progress)))
-        return f"raw/{year}/{gp_name}"
+        return self.race_dir
 
     def ensure_radio_corpus(self, year, gp_name, show_progress=True):
         self.calls.append(("ensure_radio_corpus", (year, gp_name, show_progress)))
-        return f"audio/{year}/{gp_name}"
+        return self.race_dir
 
     def loader(self):
         recorder = self
@@ -64,9 +73,9 @@ class _Session:
 
 
 @pytest.fixture
-def recorder(monkeypatch: pytest.MonkeyPatch) -> _Recorder:
+def recorder(monkeypatch: pytest.MonkeyPatch, tmp_path) -> _Recorder:
     """Patch the three slow calls at the module `prepare_race` imports them from."""
-    rec = _Recorder()
+    rec = _Recorder(tmp_path)
     import src.arcade.data as arcade_data
     import src.f1_strat_manager.data_cache as data_cache
 
@@ -162,10 +171,38 @@ def test_no_progress_callback_is_a_supported_caller(recorder: _Recorder) -> None
     assert session is not None
 
 
-def test_the_label_names_the_stage_and_its_place(recorder: _Recorder) -> None:
+def test_the_label_names_the_stage_and_its_place() -> None:
     """What the menu renders, so it is asserted rather than eyeballed."""
-    progress = PrepareProgress(stage=STAGE_TELEMETRY, index=3, total=3, elapsed_s=12.0)
+    progress = PrepareProgress(stage=STAGE_TELEMETRY, index=3, total=3, started_at=0.0)
     assert progress.label == "Building telemetry  (3/3)"
+
+
+def test_the_elapsed_seconds_climb_rather_than_sitting_at_zero() -> None:
+    """Each stage reports ONCE, at its start, so a stored elapsed is always 0.
+
+    The telemetry build is 349 s on a cold race. A readout frozen at "0s" for
+    six minutes says exactly what a hung window says, which is the opposite of
+    what putting this on a worker was for (#1116).
+    """
+    progress = PrepareProgress(stage=STAGE_TELEMETRY, index=3, total=3, started_at=100.0)
+    assert progress.elapsed_s(100.0) == 0.0
+    assert progress.elapsed_s(142.0) == 42.0
+    assert progress.elapsed_s(99.0) == 0.0, "a clock that went backwards is not negative time"
+
+
+def test_the_bar_shows_work_finished_not_work_started() -> None:
+    """`index / total` reads 100% the moment the LAST stage begins.
+
+    That last stage is the long one, so the bar would sit full for the entire
+    wait it exists to describe.
+    """
+    total = 3
+    fractions = [
+        PrepareProgress(stage="s", index=i, total=total, started_at=0.0).done_fraction
+        for i in range(1, total + 1)
+    ]
+    assert fractions == [0.0, pytest.approx(1 / 3), pytest.approx(2 / 3)]
+    assert max(fractions) < 1.0
 
 
 def test_prepare_touches_no_gl_object() -> None:
@@ -179,3 +216,29 @@ def test_prepare_touches_no_gl_object() -> None:
         text = handle.read()
     assert "import arcade" not in text
     assert "arcade.Text" not in text
+
+
+def test_a_race_the_dataset_does_not_hold_refuses_instead_of_degrading(
+    recorder: _Recorder,
+) -> None:
+    """An empty fetch has to stop the launch, not feed an empty agents window.
+
+    `snapshot_download` on a glob that matches nothing returns without raising,
+    which is how "Mexico City" fetched zero files and looked exactly like a race
+    that worked, right up until the AGENTS window sat empty (#1116).
+    """
+    for item in recorder.race_dir.iterdir():
+        item.unlink()
+
+    with pytest.raises(RaceDataUnavailable, match="Lusail"):
+        prepare_race(2025, 23, "Lusail", strategy_enabled=True)
+
+
+def test_the_refusal_happens_before_the_long_build(recorder: _Recorder) -> None:
+    """Six minutes of telemetry for a race with no data is six minutes wasted."""
+    for item in recorder.race_dir.iterdir():
+        item.unlink()
+
+    with pytest.raises(RaceDataUnavailable):
+        prepare_race(2025, 23, "Lusail", strategy_enabled=True)
+    assert "load" not in recorder.names

--- a/tests/surfaces/test_arcade_race_folders.py
+++ b/tests/surfaces/test_arcade_race_folders.py
@@ -1,0 +1,215 @@
+"""Every round the menu offers resolves to a folder the dataset really has (#1116).
+
+`ensure_race` globbed the menu's own label, and `snapshot_download` on a pattern
+that matches nothing returns without raising. So picking "Mexico City" fetched
+zero files, raised nothing, and left the strategy layer degrading against an
+empty directory: the same defect the lazy fetch was added to close, surviving it
+for six of the 2025 rounds. A menu offering 24 races where 18 work is the same
+defect wearing a different face.
+
+`DATASET_FOLDERS` is the repository's real listing, read from the HuggingFace API
+on 2026-08-27. It is recorded rather than fetched so this runs in CI without a
+network, and `test_the_recorded_listing_matches_the_calendar_shape` is what fails
+if the recording drifts from the calendars the menu reads.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.arcade.config import get_gp_names
+from src.arcade.views import last_round
+from src.f1_strat_manager.data_cache import race_folder
+
+YEARS = (2023, 2024, 2025)
+
+# `data/raw/{year}/{folder}/` in VforVitorio/f1-strategy-dataset. Note the
+# underscores, which is what the label-verbatim glob missed, and Miami, which is
+# `Miami` in 2023 and 2024 and `Miami_Gardens` in 2025.
+DATASET_FOLDERS: dict[int, frozenset[str]] = {
+    2023: frozenset(
+        {
+            "Austin",
+            "Baku",
+            "Barcelona",
+            "Budapest",
+            "Imola",
+            "Jeddah",
+            "Las_Vegas",
+            "Lusail",
+            "Marina_Bay",
+            "Melbourne",
+            "Mexico_City",
+            "Miami",
+            "Monaco",
+            "Montréal",
+            "Monza",
+            "Sakhir",
+            "Shanghai",
+            "Silverstone",
+            "Spa-Francorchamps",
+            "Spielberg",
+            "Suzuka",
+            "São_Paulo",
+            "Yas_Island",
+            "Zandvoort",
+        }
+    ),
+    2024: frozenset(
+        {
+            "Austin",
+            "Baku",
+            "Barcelona",
+            "Budapest",
+            "Imola",
+            "Jeddah",
+            "Las_Vegas",
+            "Lusail",
+            "Marina_Bay",
+            "Melbourne",
+            "Mexico_City",
+            "Miami",
+            "Monaco",
+            "Montréal",
+            "Monza",
+            "Sakhir",
+            "Shanghai",
+            "Silverstone",
+            "Spa-Francorchamps",
+            "Spielberg",
+            "Suzuka",
+            "São_Paulo",
+            "Yas_Island",
+            "Zandvoort",
+        }
+    ),
+    2025: frozenset(
+        {
+            "Austin",
+            "Baku",
+            "Barcelona",
+            "Budapest",
+            "Imola",
+            "Jeddah",
+            "Las_Vegas",
+            "Lusail",
+            "Marina_Bay",
+            "Melbourne",
+            "Mexico_City",
+            "Miami_Gardens",
+            "Monaco",
+            "Montréal",
+            "Monza",
+            "Sakhir",
+            "Shanghai",
+            "Silverstone",
+            "Spa-Francorchamps",
+            "Spielberg",
+            "Suzuka",
+            "São_Paulo",
+            "Yas_Island",
+            "Zandvoort",
+        }
+    ),
+}
+
+
+@pytest.mark.parametrize("year", YEARS)
+def test_every_round_the_menu_offers_resolves_to_a_real_folder(year: int) -> None:
+    """The whole point, per season. RED for six 2025 rounds before the resolver.
+
+    Named individually on failure, because "some races are broken" is the state
+    this replaces and it took a live launch to notice.
+    """
+    folders = DATASET_FOLDERS[year]
+    unresolved = [
+        f"R{rnd} {label!r} -> {race_folder(year, label)!r}"
+        for rnd, label in sorted(get_gp_names(year).items())
+        if race_folder(year, label) not in folders
+    ]
+    assert not unresolved, f"{year}: {len(unresolved)} rounds fetch nothing: {unresolved}"
+
+
+def test_all_seventy_rounds_resolve() -> None:
+    """The number, stated so a regression is a number and not a feeling."""
+    total = sum(len(get_gp_names(year)) for year in YEARS)
+    resolved = sum(
+        1
+        for year in YEARS
+        for label in get_gp_names(year).values()
+        if race_folder(year, label) in DATASET_FOLDERS[year]
+    )
+    assert (total, resolved) == (70, 70)
+
+
+def test_a_spaced_label_becomes_the_underscored_folder() -> None:
+    """The rule that covers 68 of the 70, asserted on its own.
+
+    This is what the label-verbatim glob got wrong, and every one of these is a
+    real round of a real season.
+    """
+    assert race_folder(2025, "Mexico City") == "Mexico_City"
+    assert race_folder(2025, "Las Vegas") == "Las_Vegas"
+    assert race_folder(2025, "Marina Bay") == "Marina_Bay"
+    assert race_folder(2025, "Yas Island") == "Yas_Island"
+    assert race_folder(2025, "Melbourne") == "Melbourne", "a single word is left alone"
+
+
+def test_the_alias_is_scoped_to_the_season_that_needs_it() -> None:
+    """Miami is `Miami` in 2023 and 2024 and `Miami_Gardens` in 2025.
+
+    An unscoped alias broke the two earlier seasons while fixing the later one,
+    which is why the table is keyed by year: 68 of 70 became 68 of 70 again with
+    a different pair failing.
+    """
+    assert race_folder(2023, "Miami") == "Miami"
+    assert race_folder(2024, "Miami") == "Miami"
+    assert race_folder(2025, "Miami") == "Miami_Gardens"
+
+
+# Folders the dataset carries for a season whose calendar does not list them.
+# 2023 ran 22 rounds: Imola was cancelled for flooding and China did not run, and
+# the dataset keeps a folder for each anyway. Extra folders are harmless, so this
+# is recorded rather than treated as drift.
+UNRACED_FOLDERS: dict[int, frozenset[str]] = {
+    2023: frozenset({"Imola", "Shanghai"}),
+    2024: frozenset(),
+    2025: frozenset(),
+}
+
+
+def test_the_recorded_listing_matches_the_calendar_shape() -> None:
+    """Pins the recording to the calendars, so a rename fails here and says so.
+
+    Only one direction is a requirement. Every ROUND has to resolve, which is
+    what the tests above assert; a folder no round maps to costs nothing, and
+    2023 has two of them because two of its races were cancelled. Naming them
+    keeps the check useful: a folder appearing for any other reason is a rename
+    the resolver has not been told about, and would otherwise surface months
+    later as a silent empty fetch.
+    """
+    for year in YEARS:
+        mapped = {race_folder(year, label) for label in get_gp_names(year).values()}
+        unmatched = DATASET_FOLDERS[year] - mapped
+        assert unmatched == UNRACED_FOLDERS[year], (
+            f"{year}: unexpected dataset folders {sorted(unmatched - UNRACED_FOLDERS[year])}"
+        )
+
+
+@pytest.mark.parametrize("year", YEARS)
+def test_the_menu_can_reach_the_last_round_of_the_season(year: int) -> None:
+    """The stepper was clamped to 23, so 2025's finale was unreachable.
+
+    2025 ran 24 rounds and Yas Island is round 24, a real published race the
+    menu would not offer; 2023 ran 22 and the stepper walked into a round with
+    no name.
+    """
+    calendar = get_gp_names(year)
+    assert last_round(year) == max(calendar)
+    assert calendar.get(last_round(year)), f"{year}: round {last_round(year)} has no name"
+
+
+def test_the_seasons_are_not_all_the_same_length() -> None:
+    """Which is why a constant cap could not be right for all three."""
+    lengths = {year: last_round(year) for year in YEARS}
+    assert lengths == {2023: 22, 2024: 24, 2025: 24}


### PR DESCRIPTION
## What

Picking any race from the `f1-arcade` menu now prepares that race and shows it preparing. Before, every race but the one in the curated download drew a circuit and gave you an empty AGENTS window.

Closes #1115 and #1116 together: the second is the completion of the first, and splitting them would ship a PR that fixes six races and silently leaves six broken.

## Why

Three defects on one path.

**1. Nothing fetched the race data.** `data/raw/{year}/{gp}/**` is what the strategy layer and PITWALL read. `ensure_race` exists to fetch it, is exported, and `src/f1_strat_manager/README.md:36` documents that tree as fetched *"Lazily, per-race, via `ensure_race`"*. Its only mention anywhere in `src/` was a log line telling the user to run it by hand. Its sibling `ensure_radio_corpus` does have a call site. One of a pair wired, its twin not.

**2. The fetch resolved nothing for six 2025 rounds.** It globbed the menu's label; the dataset stores underscores, and Miami under the circuit's location:

| menu label | dataset folder |
|---|---|
| `Mexico City` | `Mexico_City` |
| `Las Vegas` | `Las_Vegas` |
| `Marina Bay` | `Marina_Bay` |
| `Yas Island` | `Yas_Island` |
| `São Paulo` | `São_Paulo` |
| `Miami` (2025 only) | `Miami_Gardens` |

`snapshot_download` on a pattern matching nothing returns without raising, so those six fetched zero files and raised nothing.

**3. The window froze.** Building the telemetry for a cold race is **349 s measured**, and `_try_launch` forced one frame of `Loading session...` then blocked pyglet. Fixing the fetch alone would only have made the freeze longer.

## How

- **`src/arcade/prepare.py`.** `prepare_race` fetches the race dump, then the team radio when the agents will run, then builds the telemetry, reporting each stage. Downloads first, so a race that is not published fails in seconds rather than after the 349 s build. It raises `RaceDataUnavailable` when the fetch leaves the directory empty, which turns the last silent degrade into a message in the menu.
- **`race_folder(year, gp_name)`** in `data_cache`. Spaces to underscores covers 68 of 70; one alias covers Miami, keyed by season because Miami is `Miami` in 2023/2024 and `Miami_Gardens` in 2025. An unscoped alias fixed the later season and broke the two earlier ones, which is how the key was chosen. **Measured against the repository listing: 70 of 70 rounds resolve.**
- **A worker thread.** `on_update` picks up the result and builds the GL objects on the main thread. The menu draws the stage, its place in the run and its elapsed seconds.
- **`last_round(year)`** replaces a hardcoded `23`. 2025 ran 24, so **Yas Island could not be reached from the menu at all**; 2023 ran 22 and the stepper walked into `23 ?`. Stepping the year carries the round into the calendar it lands in.
- **`--viewer` routes through `MenuView.launch_with`.** It was a second implementation of the launch, which is why it would not have inherited any of this. `_pick_default_driver` goes with it.

## Checks

**Run, not asserted.** Two cold launches through the real `MenuView`, offscreen, with the real fetch:

| | Lusail (round 23) | Las Vegas (round 22) |
|---|---|---|
| folder before | absent | absent |
| folder after | `data/raw/2025/Lusail/` | `data/raw/2025/Las_Vegas/` |
| total wait | 12 s | 157 s |
| frames drawn while preparing | **321** | **5292** |

A frozen window draws 1. Las Vegas is the case that matters most: a spaced label that fetched nothing at all before this.

Also executed: `SessionLaps.load(2025, "Lusail")` returned `None` and now returns 20 drivers, and the augmentation warning went from **23 degraded GPs to 22**, with Lusail dropping out of it. `tests/agents` moved from 259 passed / 13 skipped to **266 passed / 6 skipped**, because seven of its skips were races with no data on disk.

Guards: 25 new, `tests/surfaces` 471 -> 486. Mutants watched red:

- **W**, `ensure_race` not called at all: 4 failures.
- **X**, the label globbed verbatim: 7 failures, one per season plus the totals.
- **Y**, the round cap back to 23: 4 failures.

The recorded dataset listing is pinned against the calendars, and that guard caught something real: 2023 carries `Imola` and `Shanghai` folders for races that were cancelled that year. Extra folders are harmless, so they are named rather than asserted away.

## What this does NOT prove

**That the AGENTS window populates.** That needs LLM spend and is verified separately, live. Everything up to the LLM boundary is verified: the data lands, the loaders read it, the degraded path is gone.

## Out of scope, from the same audit

`data.py:575` hardcodes `events=[]`, so the progress bar's flag markers are unreachable on every race. `SimConnector` mounts the radio corpus by a name the slug resolver rejects for Miami. Both are filed separately.
