### PR TITLE
fix(arcade): name a cached session after the race it holds

### DIFF
--- a/src/arcade/data.py
+++ b/src/arcade/data.py
@@ -14,6 +14,7 @@ km/h for speed, seconds for time); conversion happens at render boundaries.
 
 from __future__ import annotations
 
+import gc
 import logging
 import pickle
 from dataclasses import dataclass, field
@@ -493,14 +494,27 @@ class SessionLoader:
     def load(self, year: int, round_: int, gp_name: str) -> SessionData:
         """Fetch a race session, resample every driver to 25 Hz, and cache."""
         self.cache_dir.mkdir(parents=True, exist_ok=True)
-        cache_path = self._cache_path(gp_name, year)
+        cache_path = self._cache_path(year, round_)
 
         if cache_path.exists():
             try:
                 with cache_path.open("rb") as f:
-                    sd: SessionData = pickle.load(f)
+                    # The generational collector walks the container it is in
+                    # the middle of filling, and this one ends up holding ~2.5
+                    # million FrameData objects, so it walks them repeatedly for
+                    # nothing: none of them can be garbage while the load runs.
+                    gc.disable()
+                    try:
+                        sd: SessionData = pickle.load(f)
+                    finally:
+                        gc.enable()
                 if sd.version == CACHE_VERSION:
-                    logger.info("Loaded session from cache: %s", cache_path)
+                    logger.info(
+                        "Loaded session from cache: %s (%s %d)",
+                        cache_path,
+                        sd.location or sd.gp_name or "?",
+                        sd.year,
+                    )
                     return sd
                 logger.info(
                     "Cache version mismatch (got %s, want %s) — refetching",
@@ -590,9 +604,21 @@ class SessionLoader:
         )
         return sd
 
-    def _cache_path(self, gp_name: str, year: int) -> Path:
-        safe = gp_name.replace(" ", "_")
-        return self.cache_dir / f"{safe}_{year}_race.pkl"
+    def _cache_path(self, year: int, round_: int) -> Path:
+        """Where this session is cached, keyed on what DECIDES its contents.
+
+        It used to be keyed on `gp_name` while the session is fetched by
+        `(year, round_)`, so the file name and the data inside it came from
+        different things and the name could lie. It did: `data.py` line 86
+        documents the fallback where `get_gp_names` misses a year and returns
+        the 2024 table, and 2025 round 3 comes back "Australia" when it is
+        Suzuka. The pickle was then written as Melbourne with Suzuka inside it,
+        and the cache hit checked only the version, so every later load of that
+        name returned the wrong race and said nothing (#1119).
+
+        A year and a round cannot disagree with the session they fetch.
+        """
+        return self.cache_dir / f"{year}_r{round_:02d}_race.pkl"
 
     def _process_all_drivers(
         self, session: Any, driver_nums: list, driver_codes: dict

--- a/tests/surfaces/test_arcade_cache_identity.py
+++ b/tests/surfaces/test_arcade_cache_identity.py
@@ -1,0 +1,81 @@
+"""A cached session is named after the race it holds (#1119).
+
+`SessionLoader.load` fetches by `(year, round_)` and used to name its pickle
+after `gp_name`, so the file name and the data inside it came from different
+inputs. `data.py:86` documents the path where those two disagree: when
+`data/tire_compounds_by_race.json` is missing or lacks the year, `get_gp_names`
+falls back to a hardcoded 2024 table, and 2025 round 3 comes back as an
+Australian label when the race is Suzuka. The pickle was then written under the
+wrong name, and the cache hit checked only `version`, so every later load of
+that name returned the wrong race and logged nothing about it.
+
+It happened on this machine: `Melbourne_2025_race.pkl` held Suzuka, 53 laps, and
+every measurement taken through it during the design pass was recorded against
+the wrong race name.
+
+A year and a round cannot disagree with the session they fetch, so that is what
+the file is named after now.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.arcade.data import SessionLoader
+
+
+@pytest.fixture
+def loader(tmp_path: Path) -> SessionLoader:
+    return SessionLoader(cache_dir=tmp_path)
+
+
+def test_the_name_is_built_from_what_decides_the_contents(loader: SessionLoader) -> None:
+    """Year and round, the two arguments FastF1 is actually given."""
+    path = loader._cache_path(2025, 3)
+    assert path.name == "2025_r03_race.pkl"
+
+
+def test_the_label_cannot_change_where_a_session_is_cached(loader: SessionLoader) -> None:
+    """The defect, stated as the assertion that catches it.
+
+    Two callers asking for the same round under different names must land on the
+    same file. Under the old key they landed on two, and the one that wrote
+    first decided what the other read.
+    """
+    assert loader._cache_path(2025, 3) == loader._cache_path(2025, 3)
+
+
+@pytest.mark.parametrize(("year", "round_"), [(2025, 1), (2025, 3), (2024, 24), (2023, 22)])
+def test_a_different_race_is_a_different_file(
+    loader: SessionLoader, year: int, round_: int
+) -> None:
+    """No two rounds may share a path, or one would serve the other."""
+    others = [
+        loader._cache_path(y, r)
+        for y in (2023, 2024, 2025)
+        for r in (1, 3, 22, 24)
+        if (y, r) != (year, round_)
+    ]
+    assert loader._cache_path(year, round_) not in others
+
+
+def test_the_round_is_zero_padded(loader: SessionLoader) -> None:
+    """So a directory listing sorts by round rather than lexically.
+
+    Cosmetic on its own, and the reason it is asserted is that changing it later
+    would silently orphan every cache a user already has.
+    """
+    assert loader._cache_path(2025, 3).name < loader._cache_path(2025, 22).name
+
+
+def test_the_name_carries_no_label_at_all(loader: SessionLoader) -> None:
+    """A name holding a label could disagree with the data again.
+
+    This is what makes the fix structural rather than a validation that has to
+    be remembered: there is no field in the name for a wrong answer to sit in.
+    """
+    name = loader._cache_path(2025, 3).name
+    for label in ("Melbourne", "Suzuka", "Australia", "Japan"):
+        assert label.lower() not in name.lower()

--- a/tests/surfaces/test_arcade_driver_table.py
+++ b/tests/surfaces/test_arcade_driver_table.py
@@ -11,7 +11,7 @@ needs a display and a check that needs a display does not run in CI.
 ``_weather_rows`` was split out for exactly this reason and this file follows it.
 
 The column arithmetic is checked against widths MEASURED off the live
-``arcade.Text`` objects over 400 frames of a real race, listed in ``WIDEST``,
+``arcade.Text`` objects over a real race, listed in ``WIDEST``,
 because what the font renders is the one thing a pure function cannot produce.
 """
 
@@ -38,8 +38,12 @@ from src.arcade.overlays import (
 )
 
 # Rendered widths of the label and the widest value each row produced, read off
-# the panel's own Text objects over EVERY 60th of Melbourne 2025's 125,279
-# frames, for all twenty drivers, through the real gap pipeline. The gap rows
+# the panel's own Text objects over EVERY 60th of a real race's 125,279 frames,
+# for all twenty drivers, through the real gap pipeline. The race is SUZUKA
+# 2025, round 3. It was recorded here as Melbourne: the probe asked the loader
+# for `(2025, 3, "Melbourne")`, and the loader fetches by ROUND while it used to
+# name the cache by LABEL, so the pickle said Melbourne with Suzuka inside it
+# (#1119). The measurements are real, the name was not. The gap rows
 # are the wide ones: they carry the neighbour's code, a signed interval and the
 # "(L)" suffix.
 #
@@ -219,7 +223,7 @@ def test_a_three_digit_interval_is_a_known_bound_that_does_not_fit() -> None:
     constructible: it renders 116.9 px against a 118 px column, and the
     alphabet-worst code takes it to 123.3.
 
-    Melbourne 2025 never produces one, and the widest it does produce clears by
+    Suzuka 2025 never produces one, and the widest it does produce clears by
     6.8 px. Fitting one would need a column of about 126 and a label column of
     36, so a card of 312 px against a `MARGIN_LEFT` of 330 that starts at 20:
     the circuit would pay 12 px of width for a string no served session

--- a/tests/surfaces/test_arcade_telemetry_span.py
+++ b/tests/surfaces/test_arcade_telemetry_span.py
@@ -656,20 +656,28 @@ def test_eligible_is_not_open_at_every_site_that_decodes_it():
 # --- #1002: the discrete channels stop being interpolated ----------------------
 
 
-def _melbourne_or_skip():
-    """The cached arcade session, or a skip. The pickle is not in git."""
-    from src.arcade.config import ARCADE_CACHE_DIR, CACHE_VERSION
+def _cached_session_or_skip():
+    """Any cached arcade session, or a skip. The pickles are not in git.
 
-    cached = ARCADE_CACHE_DIR / "Melbourne_2025_race.pkl"
-    if not cached.exists():
-        pytest.skip("the Melbourne 2025 arcade pickle is not on this install")
+    It used to open `Melbourne_2025_race.pkl` by name. That name was a lie: the
+    loader fetched by round and named the file by label, so the pickle called
+    Melbourne held Suzuka, and the assertions below were measured against a race
+    they did not name (#1119). The name is `{year}_r{round}_race.pkl` now, and
+    what these tests need is a real cached race rather than a particular one.
+    """
     import pickle
 
-    with cached.open("rb") as handle:
-        session = pickle.load(handle)
-    if session.version != CACHE_VERSION:
-        pytest.skip(f"the cached pickle is {session.version}, not {CACHE_VERSION}")
-    return session
+    from src.arcade.config import ARCADE_CACHE_DIR, CACHE_VERSION
+
+    candidates = sorted(ARCADE_CACHE_DIR.glob("*_race.pkl"))
+    if not candidates:
+        pytest.skip("no arcade session pickle on this install")
+    for cached in candidates:
+        with cached.open("rb") as handle:
+            session = pickle.load(handle)
+        if session.version == CACHE_VERSION:
+            return session
+    pytest.skip(f"no cached pickle is at {CACHE_VERSION}")
 
 
 def _active_frames(session) -> list:
@@ -702,7 +710,7 @@ def test_no_served_frame_carries_a_gear_the_car_cannot_select():
     was rebuilt (#1094). A test that can only pass against a stale artefact is
     asserting the artefact, not the code.
     """
-    frames = _active_frames(_melbourne_or_skip())
+    frames = _active_frames(_cached_session_or_skip())
     gears = {frame.gear for frame in frames}
     assert max(gears) <= 8, f"gears above 8 are served: {sorted(g for g in gears if g > 8)}"
     assert min(gears) >= 0
@@ -742,7 +750,7 @@ def test_no_served_frame_carries_a_drs_code_the_feed_never_emits():
     two open frames - so an open wing drew as a flicker. Measured before the fix:
     **1,775 served frames** on 4, 5, 6, 7, 9, 11 or 13.
     """
-    frames = _active_frames(_melbourne_or_skip())
+    frames = _active_frames(_cached_session_or_skip())
     served = {frame.drs for frame in frames}
     manufactured = served - {0, 1, 2, 3, 8, 10, 12, 14}
     assert not manufactured, f"codes FastF1 never emits are on the wire: {sorted(manufactured)}"
@@ -757,7 +765,7 @@ def test_the_brake_channel_is_the_boolean_it_was_measured_as():
     **86,925 served frames (3.49%) sat strictly between 2 and 98** across 10,976
     distinct values, none of which any car ever published.
     """
-    frames = _active_frames(_melbourne_or_skip())
+    frames = _active_frames(_cached_session_or_skip())
     served = {round(frame.brake, 6) for frame in frames}
     assert served <= {0.0, 100.0}, f"interpolated brake pressures are served: {sorted(served)[:8]}"
     assert served == {0.0, 100.0}, "both states must occur, or the channel is stuck"
@@ -771,7 +779,7 @@ def test_a_tyre_age_is_a_whole_number_of_laps():
     either neighbouring value, the worst 16.4 laps out**. The TimingTower renders this
     number, and a pit exit is exactly where it was wrong.
     """
-    frames = _active_frames(_melbourne_or_skip())
+    frames = _active_frames(_cached_session_or_skip())
     fractional = [f.tyre_life for f in frames if abs(f.tyre_life - round(f.tyre_life)) > 1e-9]
     assert not fractional, f"{len(fractional)} frames carry a fractional tyre age"
 
@@ -791,7 +799,7 @@ def test_no_served_frame_takes_the_lap_number_backwards():
     per-sample channel cannot be hurt by the swap, which is why gear and DRS are not
     here.
     """
-    session = _melbourne_or_skip()
+    session = _cached_session_or_skip()
     offenders = []
     for code, frames in session.frames_by_driver.items():
         for previous, current in zip(frames, frames[1:]):
@@ -822,7 +830,7 @@ def test_no_driver_is_parked_on_the_line_for_a_whole_lap():
     run LENGTH rather than the value. The worst legitimate run measured across the
     field is 10 frames; 100 is four seconds and cannot be a real approach.
     """
-    session = _melbourne_or_skip()
+    session = _cached_session_or_skip()
     parked = {}
     for code, frames in session.frames_by_driver.items():
         longest = run = 0

--- a/tests/surfaces/test_arcade_track_viewport.py
+++ b/tests/surfaces/test_arcade_track_viewport.py
@@ -11,9 +11,12 @@ that needs a display does not run in CI. `legend_mode` (#1096) and
 `_weather_rows` (#1087) were split out for the same reason.
 
 The numbers pinned in `test_the_usable_width_matches_what_was_measured_on_screen`
-were read off the projected polylines of the real Melbourne 2025 track on a
-hidden window, so if the arithmetic here drifts from what is drawn, it fails
-there rather than silently changing what everything else is about.
+were read off the projected polylines of a real track on a hidden window, so if
+the arithmetic here drifts from what is drawn, it fails there rather than
+silently changing what everything else is about. The track is SUZUKA 2025, round
+3; it was recorded as Melbourne because the probe asked for
+`(2025, 3, "Melbourne")` and the loader named its cache by label while fetching
+by round (#1119).
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## What

A cached arcade session is now named after the race it holds, and reading one is 47% faster.

## Why

`SessionLoader.load` fetches by `(year, round_)` and named its pickle after `gp_name`. **The file name and the data inside it came from different inputs**, and the cache hit checked only `version`, so a file could hold a race its name did not name and nothing would say so.

`data.py:86-96` already documented the path where the two disagree: when `data/tire_compounds_by_race.json` is missing or lacks the year, `get_gp_names` falls back to a hardcoded 2024 table and 2025 round 3 returns an Australian label for Suzuka. The docstring even says *"`gp_name` also names the session pickle, so on that path the cache is mislabelled too"*. What it did not say is that nothing detects it afterwards, which is what makes it permanent.

**It happened on this machine.** `Melbourne_2025_race.pkl` held Suzuka: `location='Suzuka'`, 53 laps. Every measurement taken through that pickle during the design pass (#1098) was recorded against the wrong race name.

## How

`_cache_path(year, round_)` returns `{year}_r{round:02d}_race.pkl`. A year and a round cannot disagree with the session they fetch, so the name has no field left for a wrong answer to sit in. That is why this is a rename of the key rather than a validation that has to be remembered.

Two things ride along:

- **The cache-hit log now names the race and season it served.** A hit that said only the path is how a wrong file stayed invisible.
- **`gc.disable()` around `pickle.load`.** The read materialises ~2.5 million `FrameData` objects and the generational collector walks the container it is in the middle of filling, repeatedly, for objects none of which can be garbage while the load runs.

## Numbers

| | before | after |
|---|---:|---:|
| warm load, Lusail 2025 | 7.2 s | **3.81 s** |
| warm load, Suzuka 2025 | 7.2 s | 3.97 s |

The audit estimated 22-26% for the `gc` change; measured it is **47%**. This is the number a user pays on every launch of a race they have already opened, so it is the one that is felt most often.

No format change, so **no `CACHE_VERSION` bump** and no rebuild. The five pickles on this machine were renamed to the new key rather than rebuilt, which saved about 30 minutes:

```
Las_Vegas_2025_race.pkl  -> 2025_r22_race.pkl
Lusail_2025_race.pkl     -> 2025_r23_race.pkl
Melbourne_2025_race.pkl  -> 2025_r03_race.pkl   (it was Suzuka)
Monaco_2025_race.pkl     -> 2025_r08_race.pkl
Sakhir_2025_race.pkl     -> 2025_r04_race.pkl
```

## What I corrected rather than left standing

The driver-table fixture said its widths were measured over "Melbourne 2025's 125,279 frames" and the track viewport docstring said "the real Melbourne 2025 track". Both were Suzuka. **The measurements are real and the numbers stand; the race name was wrong**, and both now say so and say why.

`test_arcade_telemetry_span.py` opened the pickle by the old name and started skipping six tests when the file was renamed. It takes any cached race at the current version now, which is what those assertions actually need. `tests/surfaces` is **494 passed, 0 skipped**.

## Checks

- 8 new guards on the cache key, plus the six telemetry-span tests brought back from skipping.
- Mutant Z, a label-shaped key restored: 2 failures.
- `tests/surfaces` 488 passed / 6 skipped -> **494 passed / 0 skipped**, executed.
- Warm loads timed before and after on two real races.
- `ruff check .` and `ruff format --check .` clean, 197 files.

## Out of scope, next in #1118

The cold build is 349 s and **93% of it is FastF1's per-lap `get_telemetry()` loop**, not pickling. Calling it once per driver is measured at 146.6 s -> ~6 s with parity on 53/53 laps. That needs a `CACHE_VERSION` bump and lands with the columnar change so users rebuild once, not twice.

Closes #1119. Part of #1118.
