### PR TITLE
fix(agents,arcade,pitwall,docs): the correctness batch for 2.6

### DIFF
--- a/docs/pages/roadmap.md
+++ b/docs/pages/roadmap.md
@@ -111,7 +111,7 @@
 .rl-date {
   font-family: var(--font-mono);
   font-size: 12px;
-  color: var(--fg-4);
+  color: var(--fg-3);
   white-space: nowrap;
 }
 .rl-badge {
@@ -177,7 +177,7 @@
   font-weight: 700;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--fg-4);
+  color: var(--fg-3);
   margin: 36px 0 20px 44px;
 }
 

--- a/docs/styles/docs.css
+++ b/docs/styles/docs.css
@@ -117,7 +117,7 @@ body::after {
   background: rgba(255,255,255,0.04);
   box-shadow: 0 0 0 3px rgba(108,92,231,0.12);
 }
-.search-input::placeholder { color: var(--fg-4); }
+.search-input::placeholder { color: var(--fg-3); }
 .search-icon {
   position: absolute; left: 12px; top: 50%;
   transform: translateY(-50%);
@@ -129,7 +129,7 @@ body::after {
   transform: translateY(-50%);
   font-family: var(--font-mono);
   font-size: 11px;
-  color: var(--fg-4);
+  color: var(--fg-3);
   padding: 2px 6px;
   border: 1px solid var(--hairline);
   border-radius: 4px;
@@ -201,7 +201,7 @@ body::after {
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.14em;
-  color: var(--fg-4);
+  color: var(--fg-3);
   margin-bottom: 8px;
 }
 .search-tag-row {
@@ -318,7 +318,7 @@ body::after {
   text-transform: uppercase;
   letter-spacing: 0.14em;
   font-weight: 600;
-  color: var(--fg-4);
+  color: var(--fg-3);
   padding: 0 12px;
   margin: 0 0 6px;
   display: flex;
@@ -366,7 +366,7 @@ body::after {
   margin-left: auto;
   font-family: var(--font-mono);
   font-size: 10px;
-  color: var(--fg-4);
+  color: var(--fg-3);
   letter-spacing: 0;
 }
 
@@ -401,7 +401,7 @@ body::after {
   gap: 8px;
   font-family: var(--font-mono);
   font-size: 11.5px;
-  color: var(--fg-4);
+  color: var(--fg-3);
   margin-bottom: 16px;
 }
 .breadcrumb a { color: var(--fg-3); }
@@ -689,7 +689,7 @@ body::after {
   text-transform: uppercase;
   letter-spacing: 0.14em;
   font-weight: 600;
-  color: var(--fg-4);
+  color: var(--fg-3);
   margin: 0 0 12px;
 }
 .toc-list {
@@ -985,7 +985,7 @@ body::after {
 .agent-card-tag {
   font-family: var(--font-mono);
   font-size: 10px;
-  color: var(--fg-4);
+  color: var(--fg-3);
   letter-spacing: 0.14em;
   text-transform: uppercase;
   margin-bottom: 8px;
@@ -1018,7 +1018,7 @@ body::after {
   border-top: 1px solid var(--hairline);
   font-size: 11.5px;
   font-family: var(--font-mono);
-  color: var(--fg-4);
+  color: var(--fg-3);
 }
 .agent-card-meta strong { color: var(--purple-300); font-weight: 500; }
 
@@ -1180,7 +1180,7 @@ body::after {
   font-family: var(--font-mono);
   text-transform: uppercase;
   letter-spacing: 0.14em;
-  color: var(--fg-4);
+  color: var(--fg-3);
   margin-bottom: 6px;
 }
 .page-footer-title {
@@ -1406,7 +1406,7 @@ body::after {
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.16em;
-  color: var(--fg-4);
+  color: var(--fg-3);
   font-weight: 600;
   margin-bottom: 12px;
 }
@@ -1425,7 +1425,7 @@ body::after {
   display: flex;
   justify-content: space-between;
   font-size: 11.5px;
-  color: var(--fg-4);
+  color: var(--fg-3);
   font-family: var(--font-mono);
 }
 

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -29,6 +29,7 @@ import numpy as np
 import pandas as pd
 import xgboost as xgb
 
+from src.agents.race_state_builder import UNKNOWN_TYRE_LIFE
 from src.agents._shared_defaults import (
     DEFAULT_AIR_TEMP_C,
     DEFAULT_TRACK_TEMP_C,
@@ -241,6 +242,38 @@ class PaceOutput:
 # ─────────────────────────────────────────────────────────────────────────────
 # PaceAgent class
 # ─────────────────────────────────────────────────────────────────────────────
+
+
+def _unknown_if_missing(tyre_life) -> int:
+    """A tyre age, with an absent one encoded as the shared unknown.
+
+    `or` cannot be used for this and that is the whole point: it is false for 0,
+    which is the value `race_state_builder` publishes when it does not know the
+    age, so `d.get("tyre_life") or 1` rewrote every unknown as a one-lap-old set.
+    A missing key and a stored None both mean the same thing and both land on the
+    same constant, which is what keeps this reader and the builder from drifting.
+    """
+    return UNKNOWN_TYRE_LIFE if tyre_life is None else int(tyre_life)
+
+
+def _laps_since_pit(driver_state: dict) -> int:
+    """Laps since the last stop, falling back to the tyre age under N01's rule.
+
+    Written as branches rather than as an `or` chain, and the chain is why: it
+    ended in `or 1`, so an unknown age fell straight through to a one-lap-old
+    stint. That is the same fabrication `_unknown_if_missing` exists to stop, one
+    keyword argument further down, and the first version of this fix kept it.
+
+    The fallback to the age is N01's own definition on an unpitted stint, so it is
+    a lookup rather than an approximation (#800). When neither is known the answer
+    is the shared unknown: N06 predicts identically at 0, 1 and 2 on a real row
+    (86.712000 against 86.654000 at 12), so nothing served moves, and the value
+    that does not collide is the one to publish.
+    """
+    laps = driver_state.get("laps_since_pit")
+    if laps is not None:
+        return int(laps)
+    return _unknown_if_missing(driver_state.get("tyre_life"))
 
 
 def _previous_tyre_life(tyre_life: Optional[int]) -> Optional[int]:
@@ -992,7 +1025,22 @@ class PaceAgent:
             fresh_tyre=d.get("fresh_tyre"),
             lap_number=lap_number,
             stint=d.get("stint") or 1,
-            tyre_life=d.get("tyre_life") or 1,
+            # `.get`, not `or 1`. The state manager already publishes
+            # UNKNOWN_TYRE_LIFE for an age it does not have
+            # (`race_state_builder.py:379`), and `or` is false for 0, so the `or 1`
+            # here turned that unknown back into a fresh set one hop after it was
+            # chosen - undoing the sentinel at the only consumer that matters.
+            # Same shape as the `position` fix three lines below, which this file
+            # already carries the reasoning for (#628), and the same defect #832
+            # removed from N15's own reader.
+            #
+            # Measured on the shipped N06 booster: tyre_life 0, 1 and 2 predict
+            # 86.712000 identically on a real Lusail row (12 predicts 86.654000),
+            # so passing the unknown through changes no served number today. What
+            # it changes is `_previous_tyre_life`, which returns None at <= 1 and
+            # so sends Prev_TyreLife to the model as NaN rather than as a
+            # fabricated age.
+            tyre_life=_unknown_if_missing(d.get("tyre_life")),
             compound=d.get("compound") or "MEDIUM",
             # Plain .get, no `or` fallback: `d.get('position') or 1` collapsed a
             # missing telemetry reading AND the #428 sentinel (a stored `0`)
@@ -1015,7 +1063,7 @@ class PaceAgent:
             # (#800). `or` rather than the two-arg get: a producer that has not been
             # updated reports the key absent, and lap 1 of an unpitted race is 1
             # under N01's rule anyway.
-            laps_since_pit=d.get("laps_since_pit") or d.get("tyre_life") or 1,
+            laps_since_pit=_laps_since_pit(d),
             fuel_load=laps_remaining / max(total_laps, 1),
             year=meta.get("year") or 2025,
             # ``d.get('prev_lap_time') or 90.0``, NOT ``d.get('lap_time_s')``: the

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -41,6 +41,7 @@ from src.strategy.inference.guard_rails import (
 )
 
 from src.agents._shared_defaults import DEFAULT_TOTAL_LAPS
+from src.agents.race_state_builder import UNKNOWN_TYRE_LIFE
 
 # ── Repo root (with root-stop guard for uv tool install) ─────────────────────
 _REPO_ROOT = Path(__file__).resolve().parent
@@ -867,29 +868,45 @@ class PitStrategyAgent:
         (1.98%) of the 2025 featured parquet have a NaN TyreLife. That is the same
         Series.get trap as #428/#462, on a third column.
 
-        A missing tyre age means "fresh" is the only defensible read: a car with no
-        recorded TyreLife has just been given a set, and 1 is what the dead default was
-        reaching for anyway. It is also the conservative direction for N15, which is
-        predicting how long the stop takes, not whether to make it.
+        An absent age is served as UNKNOWN_TYRE_LIFE, the shared constant, and NOT
+        as a fabricated 1 (#832, #1008). This used to argue that a missing age means
+        the set is fresh, which is a reasonable-sounding case for the wrong number:
+        1 is a reading N15 legitimately finds on the first lap of every stint, so the
+        sentinel and the measurement were the same value and nothing downstream could
+        tell them apart. `race_state_builder` rejects 1 for exactly that reason and
+        its comment says so; one member of the pair had the rule and its twin did not.
+        0 occurs zero times across 2023, 2024 and 2025, so it collides with nothing,
+        and it sits below the envelope's floor, which is what turns the absence from
+        silent into audible: the call is labelled an extrapolation rather than a fit.
         """
         value = row.get('TyreLife')
         if value is None or pd.isna(value):
-            logger.warning('TyreLife missing on the lap row; N15 reads it as a fresh set')
-            return 1
+            logger.warning(
+                'TyreLife missing on the lap row; N15 is served %d, the non-colliding '
+                'unknown, so its stop-duration prediction is not a fit',
+                UNKNOWN_TYRE_LIFE,
+            )
+            value = UNKNOWN_TYRE_LIFE
 
         # Label the call BEFORE clipping, because after the clip the evidence is gone:
         # every value reads as in-range once it has been forced there. The clip is what
         # keeps N15 inside its fitted range and it is unchanged; this only makes the
         # moment it bites visible instead of silent (#710).
+        #
+        # The message reports what is SERVED rather than the ceiling, because `min`
+        # only clips the top. Saying "clipped to 50" for a value below the floor was
+        # false the moment an unknown could reach here, which is what #832 made
+        # possible: 0 is passed through untouched.
+        served  = min(int(value), _MAX_TRAINED_TYRE_LIFE)
         verdict = _N15_TYRE_LIFE_ENVELOPE.check({'tyre_life_in': float(value)})
         if not verdict:
             logger.warning(
-                'N15 called outside its trained range: %s; the value is clipped to %d, '
-                'so the prediction is an extrapolation to the boundary rather than a fit',
+                'N15 called outside its trained range: %s; it is served %d, so the '
+                'prediction is an extrapolation rather than a fit',
                 dict(verdict.violations),
-                _MAX_TRAINED_TYRE_LIFE,
+                served,
             )
-        return min(int(value), _MAX_TRAINED_TYRE_LIFE)
+        return served
 
     def _build_pit_duration_features(
         self,

--- a/src/arcade/config.py
+++ b/src/arcade/config.py
@@ -235,7 +235,13 @@ ARCADE_CACHE_DIR: Final[Path] = get_data_root() / "cache" / "arcade"
 # v15: a NaN Rainfall sample now pickles as None instead of "WET" (#1087). The bytes differ only
 # for a session that HAS a NaN weather row, which is exactly the session the fix exists for, so
 # leaving the version at v14 would have delivered the fix to everyone except the affected.
-CACHE_VERSION: Final[str] = "v15"  # + the shared lap-boundary sample sorts stably (#1069)
+# v16: the replay now runs the shared tyre-stint repair over the session before extracting, so its
+# tyre ages match PITWALL's tower instead of disagreeing with it on the same screen (#951). Same
+# shape as v15 and the same reason to move: measured over the four 2025 races on hand, three come
+# back byte-identical (Lusail, Monaco, Las Vegas, zero rows touched) and Melbourne moves 162 rows
+# across 5 drivers, taking unknown ages from 5 to 167. A pickle of a healthy race is unchanged, so
+# holding the version would have shipped the fix to everyone except the races that need it.
+CACHE_VERSION: Final[str] = "v16"  # + the shared lap-boundary sample sorts stably (#1069)
 
 # --- Multiprocessing pool -------------------------------------------------
 # Serial. The reason recorded here used to be a hang: Windows spawn plus pickling

--- a/src/arcade/data.py
+++ b/src/arcade/data.py
@@ -34,6 +34,7 @@ from src.arcade.config import (
     FASTF1_CACHE_DIR,
     POOL_SIZE,
 )
+from src.f1_strat_manager.tyre_stint_repair import repair_tyre_stints
 
 logger = logging.getLogger(__name__)
 
@@ -224,6 +225,54 @@ def _lap_fraction_from_distance(
         fraction[lo:hi] = np.clip((dist[lo:hi] - start) / length, 0.0, 1.0)
         previous_length = length
     return fraction
+
+
+def _repair_session_stints(session) -> None:
+    """Apply the shared tyre-stint repair to this session's laps, in place.
+
+    The replay used to read `TyreLife` straight off FastF1 while the two other
+    consumers of the same race repaired it first: `laps_augment` on the way into
+    the models, `session_data` on the way into PITWALL's timing tower. Both
+    surfaces launch from one `f1-arcade --strategy` and sit on screen together,
+    so a race with corrupted stint data showed two different ages for one tyre
+    and nothing said which to believe (#951). Two members of a trio had the fix
+    and the third did not, which is this repo's most frequent defect wearing a
+    cross-surface costume: each surface was self-consistent, so neither could
+    catch it alone.
+
+    Written back column by column rather than by replacing `session.laps`,
+    because the repair returns a plain DataFrame and the code below needs the
+    FastF1 `Laps` subclass: `pick_drivers` in the per-driver extraction and
+    `pick_fastest` for the reference lap are both methods on it. The repair
+    reindexes its result to the input's index, so the assignment aligns row for
+    row.
+
+    Silent on a healthy race, which is the repair's own contract rather than a
+    check here: a frame that needs nothing comes back unchanged with an empty
+    report.
+    """
+    laps = getattr(session, "laps", None)
+    if laps is None or laps.empty:
+        return
+
+    repaired, report = repair_tyre_stints(pd.DataFrame(laps))
+    if not report.changed_anything:
+        return
+
+    # The three columns the repair writes. Named rather than copying the whole
+    # frame, so this cannot quietly overwrite a column FastF1 owns; a column the
+    # repair starts touching later would simply not arrive, and the guard for
+    # that is the parity check against session_data, not this loop.
+    for column in ("TyreLife", "Stint", "Compound"):
+        if column in repaired.columns:
+            laps[column] = repaired[column]
+
+    logger.info(
+        "Arcade tyre-stint repair: %d driver(s) touched, %d lap(s) now carry an "
+        "unknown age, which is what PITWALL's tower shows for the same race",
+        len(report.drivers_touched),
+        report.unknown_after,
+    )
 
 
 def _enable_fastf1_cache() -> None:
@@ -528,6 +577,7 @@ class SessionLoader:
         logger.info("Loading FastF1 session: %d round %d", year, round_)
         session = fastf1.get_session(year, round_, "R")
         session.load(telemetry=True, weather=True, laps=True)
+        _repair_session_stints(session)
 
         # Read FastF1's authoritative Location (``Suzuka``, ``Melbourne``, …)
         # so the strategy pipeline can find the right per-race folder

--- a/src/f1_strat_manager/data_cache.py
+++ b/src/f1_strat_manager/data_cache.py
@@ -340,6 +340,31 @@ def _snapshot_download(
     return local_dir
 
 
+def _resolve_repo() -> None:
+    """Ask the Hub for the dataset's metadata, and nothing else.
+
+    This is what the spinner in :func:`ensure_data` is actually waiting on: is
+    the Hub reachable, does the revision exist, do the credentials work. One
+    API call answers all three, and it answers them before any bytes are
+    fetched, which is the fail-fast the caller wants.
+
+    It replaces a full silent `snapshot_download` that was standing in for the
+    probe (#168). That call downloaded the whole 7-8 GB with progress bars
+    switched off, under a spinner reading "Resolving...", and only then did the
+    second call run with progress on, find every file present and return at
+    once. A first-time user watched a spinner for the entire download and then
+    a progress bar that completed instantly, and the Hub metadata sweep ran
+    twice.
+    """
+    from huggingface_hub import HfApi
+
+    HfApi().repo_info(
+        repo_id=HF_DATASET_REPO_ID,
+        repo_type="dataset",
+        revision=HF_DATASET_REVISION,
+    )
+
+
 def _render_header(console, data_root: Path) -> None:
     """Print the first-run banner using the same Rich palette as the CLI.
 
@@ -422,10 +447,7 @@ def ensure_setup(
             f"[{COL_DIM}]Resolving {HF_DATASET_REPO_ID} from HuggingFace Hub…[/{COL_DIM}]",
             spinner="dots",
         ):
-            local_dir = _snapshot_download(patterns, show_progress=False)
-        # A second call with progress=True streams the actual download; the
-        # first call warms the HTTP client and validates credentials so we
-        # fail fast if the Hub is unreachable.
+            _resolve_repo()
         local_dir = _snapshot_download(patterns, show_progress=show_progress)
     except Exception as exc:
         raise RuntimeError(

--- a/src/f1_strat_manager/tyre_stint_repair.py
+++ b/src/f1_strat_manager/tyre_stint_repair.py
@@ -74,10 +74,12 @@ real stop explains the change by itself; that is the Monaco case).
   2025 it nulls 162 of 927 rows (17.5%), the whole opening stint of five cars, and leaves all
   24 of that race's genuine stops alone.
 * **A nulled age is not neutral downstream, and that bounds how far this should ever go.**
-  `pit_strategy_agent._tyre_life_in` reads a NaN `TyreLife` as a FRESH SET (1), so a null
-  reaches N15 as a number, not as an unknown, and a wronger one than the artefact it
-  replaced. That is why repair 2 is scoped to a shape that is provably not a stop rather
-  than to every drop this module cannot explain.
+  `pit_strategy_agent._tyre_life_in` used to read a NaN `TyreLife` as a FRESH SET (1), so
+  a null reached N15 as a number, and a wronger one than the artefact it replaced. It now
+  serves `UNKNOWN_TYRE_LIFE` and logs the call as an extrapolation (#832, #1008), which
+  removes the cost but not the scoping: repair 2 stays narrow because a null still travels
+  to consumers this module cannot see, and widening it is a separate decision with its own
+  evidence rather than a consequence of one reader being fixed.
 * **Raw-fed surfaces see feed values.** Consumers that read a raw parquet directly rather
   than through `augment_featured_laps` -- the replay engine and the backend's own race
   loader -- are not repaired. Unifying that is a wider change than this repair.
@@ -359,6 +361,11 @@ def _age_restarted_on_an_unchanged_set(ordered: pd.DataFrame, position: int) -> 
     a number further from the truth than the one the feed published. Requiring a landing
     on exactly 1 removes all 435, and Melbourne 2025's five republished ages all land on
     exactly 1, so the pair of conditions keeps the artefact and drops the false positives.
+
+    The "N15 reads a NaN as a fresh set" half of that argument is no longer true (#832):
+    N15 now serves `UNKNOWN_TYRE_LIFE` and says so in the log. The measured half stands on
+    its own, and is why this test did not change: 435 genuine same-compound stops in 53
+    grands prix would be nulled by a plain drop test, whatever the reader does with a null.
 
     --- WHAT THAT 435 DOES AND DOES NOT SHOW ---
     It shows the plain drop test is unusable. It does **not** show that a genuine

--- a/src/pitwall/host.py
+++ b/src/pitwall/host.py
@@ -20,6 +20,8 @@ traps before a line was written:
 from __future__ import annotations
 
 import logging
+import threading
+import time
 
 from src.f1_strat_manager.data_cache import get_data_root
 from src.pitwall.agents_view import AgentsViewBuilder
@@ -135,6 +137,11 @@ class PitwallHost:
         # `_session_for`. It has no revision of its own: it rides in the bulk
         # payload because it is a function of the bulk's signature exactly.
         self._radio: RadioCorpus | None = None
+        # Serialises the swap in `_session_for`. Two windows poll this host on
+        # their own threads and the pre-warm below is a third, so without it the
+        # first bulk and the warm-up could load the same race twice.
+        self._session_lock = threading.Lock()
+        self._warm_thread: threading.Thread | None = None
         # The LIVE channel's state, masked by the clock rather than by
         # completed laps. `_live_view` is the last block SERVED, so the
         # revision moves exactly when the screen would change and not ten
@@ -144,7 +151,54 @@ class PitwallHost:
         self._live_view: dict[str, dict] = {}
 
     def start(self) -> None:
+        """Connect to the producer, then load this race off the request path.
+
+        The laps and the radio corpus used to load inside `_session_for` on the
+        first `get_bulk`, which is a call the window is blocked on while it
+        paints nothing: 1.1 s of a cold start spent where the user is watching
+        (#1004). Nothing about that work needs the request. It needs the race,
+        which arrives on the first tick.
+
+        So a daemon thread waits for that tick and loads the race itself. By the
+        time the window asks, `_session_for` finds its own cache warm and
+        returns. A window that asks first anyway is not wrong, only unlucky: the
+        lock makes the two paths take turns instead of both loading.
+        """
         self._client.start()
+        self._warm_thread = threading.Thread(
+            target=self._warm_session, name="pitwall-warm", daemon=True
+        )
+        self._warm_thread.start()
+
+    def _warm_session(self, timeout_s: float = 30.0, poll_s: float = 0.05) -> None:
+        """Load this race as soon as the producer names it, off the request path.
+
+        Gives up quietly after `timeout_s`. A producer that never publishes a
+        race is a real state (the arcade is still building its telemetry, or was
+        never started), and the windows already have a story for it; turning it
+        into an error here would replace a waiting screen with a broken one.
+
+        The race lives under the payload's `arcade` block, which is where
+        `get_bulk` and `get_live_lap` read it from (`app.py:658` puts it there).
+        Reading the top level instead finds nothing on a real producer, so the
+        thread would poll for the full timeout and warm nothing while every test
+        with a flattened fixture went on passing. That is what the first version
+        of this did.
+        """
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            payload = self._client.latest
+            arcade = (payload or {}).get("arcade") or {}
+            if arcade.get("location"):
+                started = time.monotonic()
+                self._session_for(arcade)
+                logger.info(
+                    "Pit-wall session pre-warmed in %.0f ms, off the first bulk",
+                    (time.monotonic() - started) * 1000,
+                )
+                return
+            time.sleep(poll_s)
+        logger.info("Pit-wall pre-warm gave up after %.0fs: the producer named no race", timeout_s)
 
     def get_tick(self, since_seq: int = -1) -> dict | None:
         """Return the latest payload if the caller has not seen it yet.
@@ -417,16 +471,21 @@ class PitwallHost:
         because the branch exists to be defensive and was not.
         """
         year, location = arcade.get("year"), arcade.get("location")
-        if not isinstance(year, int) or not isinstance(location, str):
-            self._session_key = None
-            self._session = None
-            self._radio = None
-            return None
-        if self._session_key != (year, location):
-            self._session_key = (year, location)
-            self._session = SessionLaps.load(get_data_root(), year, location)
-            self._radio = RadioCorpus.load(get_data_root(), year, location)
-        return self._session
+        # The whole body is under the lock, the clearing branch included. Leaving
+        # that one outside would let a malformed tick null the three fields while
+        # the pre-warm thread was mid-load, and the loader would then publish a
+        # race the clearing had just decided nobody should be served.
+        with self._session_lock:
+            if not isinstance(year, int) or not isinstance(location, str):
+                self._session_key = None
+                self._session = None
+                self._radio = None
+                return None
+            if self._session_key != (year, location):
+                self._session_key = (year, location)
+                self._session = SessionLaps.load(get_data_root(), year, location)
+                self._radio = RadioCorpus.load(get_data_root(), year, location)
+            return self._session
 
     def _masked_view(self, arcade: dict, reveal: dict[str, int]) -> dict:
         """Load the race once, then slice it; or say it is not on disk.

--- a/src/pitwall/ui/src/features/data/BestsPanel.tsx
+++ b/src/pitwall/ui/src/features/data/BestsPanel.tsx
@@ -226,25 +226,47 @@ function useFitsRanked(card: HTMLElement | null, content: number): Fit {
   // **Re-fit once the webfont has actually arrived**, rather than reserving pixels
   // against the possibility. `document.fonts.ready` is the signal; the observer below
   // catches everything else that changes the card's box.
+  // **The observer is installed once and outlives every fit decision (#1083).**
+  //
+  // `fit` is a `useCallback` over the fit state, so its identity changes on each
+  // decision. An effect that depends on it therefore ran `observer.disconnect()`
+  // and built a new `ResizeObserver` every time the panel re-decided, and a
+  // resize landing inside that window had nothing watching it: the panel kept
+  // the previous height's answer until something else moved the card's box.
+  //
+  // That is what made the CI guard flaky rather than wrong. Two check-runs on
+  // one SHA four seconds apart, one green one red, `BESTS at h=593: room 69,
+  // floor card 113, rendered ranked 11` - eleven being the depth of the h=833
+  // client the sweep starts from, so the panel had not re-decided at all. It
+  // never reproduced locally, because a slower machine widens the gap.
+  //
+  // Holding the callback in a ref keeps the deps free of it. The observer calls
+  // whatever `fit` is at the moment it fires, which is the same behaviour the
+  // re-installation was reaching for, minus the window with no observer in it.
+  const fitRef = useRef(fit);
+  useEffect(() => {
+    fitRef.current = fit;
+  }, [fit]);
+
   useEffect(() => {
     let live = true;
     document.fonts?.ready.then(() => {
-      if (live) fit();
+      if (live) fitRef.current();
     });
     return () => {
       live = false;
     };
-  }, [fit]);
+  }, [card]);
 
   useEffect(() => {
     const column = card?.parentElement;
     if (!card || !column) return;
-    fit();
-    const observer = new ResizeObserver(fit);
+    fitRef.current();
+    const observer = new ResizeObserver(() => fitRef.current());
     observer.observe(column);
     observer.observe(card);
     return () => observer.disconnect();
-  }, [card, fit, content]);
+  }, [card, content]);
 
   return fitState;
 }

--- a/tests/agents/test_n15_envelope.py
+++ b/tests/agents/test_n15_envelope.py
@@ -76,9 +76,24 @@ def test_the_envelope_bound_is_the_clip_constant_not_a_second_number():
     assert upper == float(_MAX_TRAINED_TYRE_LIFE)
 
 
-def test_a_missing_tyre_life_is_still_read_as_a_fresh_set():
-    """The NaN path predates the envelope and must be untouched by it."""
+def test_a_missing_tyre_life_is_read_as_the_non_colliding_unknown():
+    """This asserted `== 1` until #832, and 1 was the defect.
+
+    The old name said "is still read as a fresh set", and the reason it read that
+    way was an argument that sounds right and picks the one value it must not: a
+    tyre on the first lap of a stint reads 1, so the sentinel and the measurement
+    were the same number. `race_state_builder` had already ruled 1 out in writing
+    for exactly that reason, and this consumer used it anyway.
+
+    The envelope half of the original claim still holds and is what this file is
+    about: the NaN path does not go through the bounds check to DECIDE anything.
+    What changed is that the value it substitutes now sits below the floor, so the
+    check labels the call an extrapolation instead of passing it silently.
+    """
     import numpy as np
 
-    assert _tyre_life_in(np.nan) == 1
-    assert _tyre_life_in(None) == 1
+    from src.agents.race_state_builder import UNKNOWN_TYRE_LIFE
+
+    assert _tyre_life_in(np.nan) == UNKNOWN_TYRE_LIFE
+    assert _tyre_life_in(None) == UNKNOWN_TYRE_LIFE
+    assert _tyre_life_in(np.nan) != _tyre_life_in(1.0), "the unknown collides with a fresh set"

--- a/tests/agents/test_tyre_life_unknown_is_not_a_reading.py
+++ b/tests/agents/test_tyre_life_unknown_is_not_a_reading.py
@@ -1,0 +1,195 @@
+"""An absent tyre age must not arrive at N15 as a real one (#832, #1008).
+
+`_tyre_life_in` used to return 1 for a missing `TyreLife`, arguing that a car
+with no recorded age has just been given a set. The argument sounds reasonable
+and picks the one value it must not: a tyre on the first lap of a stint reads 1,
+so the sentinel and the measurement were the same number and nothing downstream
+could tell an unknown from a fresh set. `race_state_builder` had already ruled
+that out in writing:
+
+    # TyreLife == 0 occurs ZERO times in 2023/2024/2025 (season minimums
+    # 2.0/2.0/1.0), so 0 is a non-colliding sentinel. The old arcade/backend
+    # default of 1 collides with real fresh-tyre laps.
+    UNKNOWN_TYRE_LIFE = 0
+
+One member of the pair had the rule and its twin did not, which is this repo's
+most frequent defect. It fires on 451 rows, 1.98% of the 2025 featured parquet,
+and it feeds the model that predicts how long a stop takes.
+
+The second half of the fix is the warning text. `min(value, ceiling)` only clips
+the top, so "the value is clipped to 50" was false for anything below the floor.
+Nothing could reach below the floor before, which is why it never showed; the
+unknown now can, so the message reports what is actually served.
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.agents.pace_agent import _previous_tyre_life, _unknown_if_missing
+from src.agents.pit_strategy_agent import _MAX_TRAINED_TYRE_LIFE, PitStrategyAgent
+from src.agents.race_state_builder import UNKNOWN_TYRE_LIFE
+
+read = PitStrategyAgent._tyre_life_in
+
+# Every way an age can be absent. The middle one is the original trap: a Series
+# `.get` returns the STORED NaN, so a default in the call never fires.
+ABSENT = {
+    "a NaN value in a present column": pd.Series({"TyreLife": np.nan}),
+    "the column missing entirely": pd.Series({"Driver": "NOR"}),
+    "an explicit None": pd.Series({"TyreLife": None}, dtype=object),
+}
+
+
+@pytest.mark.parametrize("shape", sorted(ABSENT))
+def test_an_absent_age_is_the_non_colliding_unknown(shape: str) -> None:
+    assert read(ABSENT[shape]) == UNKNOWN_TYRE_LIFE
+
+
+@pytest.mark.parametrize("shape", sorted(ABSENT))
+def test_an_absent_age_is_not_a_fresh_set(shape: str) -> None:
+    """The defect, stated as the assertion that catches it.
+
+    Separate from the test above because they fail for different reasons: that
+    one breaks if the constant drifts, this one breaks if the unknown ever again
+    becomes a number the data can also hold.
+    """
+    assert read(ABSENT[shape]) != read(pd.Series({"TyreLife": 1.0}))
+
+
+def test_a_real_fresh_set_is_untouched() -> None:
+    """The other half of a sentinel: it must not eat a legitimate reading."""
+    assert read(pd.Series({"TyreLife": 1.0})) == 1
+
+
+@pytest.mark.parametrize(
+    ("stored", "served"),
+    [(2.0, 2), (17.0, 17), (49.0, 49), (50.0, 50), (63.0, 50), (200.0, 50)],
+)
+def test_a_present_age_is_passed_through_and_clipped_at_the_ceiling(
+    stored: float, served: int
+) -> None:
+    assert read(pd.Series({"TyreLife": stored})) == served
+
+
+def test_the_unknown_is_below_the_trained_floor(caplog: pytest.LogCaptureFixture) -> None:
+    """Which is what makes the absence audible instead of silent.
+
+    The envelope's floor is 1 because a tyre on its first lap reads 1, never 0.
+    Serving 0 therefore violates it by construction, and the violation is the
+    signal: N15's answer on that row is an extrapolation, not a fit.
+    """
+    with caplog.at_level(logging.WARNING):
+        read(pd.Series({"TyreLife": np.nan}))
+    assert "outside its trained range" in caplog.text
+
+
+def test_the_warning_reports_what_is_served_not_the_ceiling(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """`min` clips the top only, so naming the ceiling below the floor was a lie.
+
+    Both directions are asserted in one test because the bug is the pair: a
+    message that happens to be right above the ceiling and wrong below it reads
+    as correct in every log anyone had ever seen.
+    """
+    with caplog.at_level(logging.WARNING):
+        read(pd.Series({"TyreLife": float(_MAX_TRAINED_TYRE_LIFE + 13)}))
+    assert f"served {_MAX_TRAINED_TYRE_LIFE}" in caplog.text
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        read(pd.Series({"TyreLife": np.nan}))
+    assert f"served {UNKNOWN_TYRE_LIFE}" in caplog.text
+    assert f"served {_MAX_TRAINED_TYRE_LIFE}" not in caplog.text
+
+
+def test_the_absence_is_logged_at_all(caplog: pytest.LogCaptureFixture) -> None:
+    """A silent substitution is how the old value survived for two years."""
+    with caplog.at_level(logging.WARNING):
+        read(pd.Series({"TyreLife": np.nan}))
+    assert "TyreLife missing" in caplog.text
+
+
+def test_the_constant_is_shared_rather_than_retyped() -> None:
+    """The two cannot drift apart again if there is only one of them.
+
+    A local literal is what let the canonical builder and this consumer disagree
+    while both looked deliberate.
+    """
+    import src.agents.pit_strategy_agent as module
+
+    assert module.UNKNOWN_TYRE_LIFE is UNKNOWN_TYRE_LIFE
+
+
+# ---------------------------------------------------------------------------
+# The twin. N15 was one of a pair and N06 kept the fabrication, in a form that
+# also destroyed the sentinel: `d.get("tyre_life") or 1` is 1 for a stored 0,
+# and 0 is exactly what `race_state_builder` publishes for an age it does not
+# have. So the unknown chosen in one module was rewritten as a fresh set one
+# hop later, by a line sitting three above the comment explaining why the same
+# `or` had already been removed for `position` (#628). Found by an adversarial
+# gate over the N15 fix.
+# ---------------------------------------------------------------------------
+
+PACE_SOURCE = Path(__file__).resolve().parents[2] / "src" / "agents" / "pace_agent.py"
+
+
+def test_the_published_unknown_survives_the_hop_to_n06() -> None:
+    """A stored 0 must arrive as 0, which is what `or` could not do."""
+    assert _unknown_if_missing(UNKNOWN_TYRE_LIFE) == UNKNOWN_TYRE_LIFE
+
+
+def test_a_missing_age_is_the_same_unknown_for_both_models() -> None:
+    """One constant, so N06 and N15 cannot drift the way N15 and the builder did."""
+    assert _unknown_if_missing(None) == read(pd.Series({"TyreLife": np.nan}))
+
+
+def test_n06_still_sees_a_real_fresh_set() -> None:
+    assert _unknown_if_missing(1) == 1
+    assert _unknown_if_missing(17) == 17
+
+
+def test_an_unknown_produces_no_previous_age() -> None:
+    """`_previous_tyre_life` returns None at <= 1, so the unknown reaches the
+    booster as NaN rather than as a fabricated lap count."""
+    assert _previous_tyre_life(_unknown_if_missing(0)) is None
+    assert _previous_tyre_life(_unknown_if_missing(17)) == 16
+
+
+def test_run_from_state_does_not_or_the_tyre_age() -> None:
+    """The shape of the bug, not just its current value.
+
+    `or` is false for 0, so any `... or <default>` around a tyre age silently
+    rewrites the unknown. Asserting the VALUE alone would pass again the moment
+    someone reintroduces the idiom with a different default, which is how this
+    line survived the `position` fix in the same function.
+    """
+    tree = ast.parse(PACE_SOURCE.read_text(encoding="utf-8"))
+    offenders = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or node.name != "run_from_state":
+            continue
+        for op in ast.walk(node):
+            if not isinstance(op, ast.BoolOp) or not isinstance(op.op, ast.Or):
+                continue
+            for value in op.values:
+                names = {
+                    arg.value
+                    for call in ast.walk(value)
+                    if isinstance(call, ast.Call)
+                    for arg in call.args
+                    if isinstance(arg, ast.Constant) and isinstance(arg.value, str)
+                }
+                if "tyre_life" in names:
+                    offenders.append(op.lineno)
+    assert not offenders, (
+        f"run_from_state ORs a tyre age at line(s) {sorted(set(offenders))}; `or` is "
+        "false for 0, which is the published unknown, so it becomes a fresh set"
+    )

--- a/tests/surfaces/test_arcade_stint_repair_parity.py
+++ b/tests/surfaces/test_arcade_stint_repair_parity.py
@@ -1,0 +1,239 @@
+"""The replay and the tower must not show two ages for one tyre (#951).
+
+`repair_tyre_stints` was applied on the way into the models (`laps_augment`) and
+on the way into PITWALL's timing tower (`session_data`), and not on the way into
+the pyglet replay, which read `TyreLife` straight off FastF1. Both surfaces come
+up from one `f1-arcade --strategy`, so on a race whose stint data needs repairing
+the compound pill and the tower's TYRE column sat on screen together showing
+different numbers, with nothing to say which to believe.
+
+Two of a trio had the fix and the third did not. Nothing caught it because each
+surface was self-consistent: the disagreement only exists across them, which is
+also why the assertion here compares the two paths rather than checking either
+one against a constant.
+
+Measured on the four 2025 races on this machine: Lusail, Monaco and Las Vegas
+come back untouched, and Melbourne moves 162 laps across 5 drivers, taking
+unknown ages from 5 to 167. That is the #988 safety-car pit-lane transit shape.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from src.arcade.data import _repair_session_stints
+from src.f1_strat_manager.tyre_stint_repair import repair_tyre_stints
+
+ROOT = Path(__file__).resolve().parents[2]
+REPAIRED_COLUMNS = ("TyreLife", "Stint", "Compound")
+
+
+LOADER_SOURCE = ROOT / "src" / "arcade" / "data.py"
+
+
+def _loader_ast() -> ast.FunctionDef:
+    """`SessionLoader.load`, parsed rather than imported.
+
+    Parsed because the property is about the ORDER of two statements, which a
+    text search cannot see, and imported nothing because this has to run on a
+    machine with no FastF1 cache and no races on disk.
+    """
+    tree = ast.parse(LOADER_SOURCE.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "load":
+            for sub in ast.walk(node):
+                if isinstance(sub, ast.Attribute) and sub.attr == "load":
+                    return node
+    raise AssertionError("SessionLoader.load is gone from src/arcade/data.py")
+
+
+def test_the_loader_repairs_before_it_reads_a_lap() -> None:
+    """The half the parity tests cannot see, and the one that silently rots.
+
+    Everything above exercises the helper directly, so deleting its call from
+    `SessionLoader.load` leaves them all green while the replay goes back to the
+    raw column. That is the same shape as a pre-warm that stops pre-warming: the
+    unit is correct and nothing reaches it.
+
+    The order matters as much as the call. `session.load(...)` has to have run,
+    or there are no laps to repair, and the repair has to precede the per-driver
+    extraction, or it corrects a frame the pickle was already built from.
+    """
+    body = _loader_ast()
+    repair_at = fastf1_load_at = extract_at = None
+    for node in ast.walk(body):
+        if isinstance(node, ast.Call):
+            if getattr(node.func, "id", None) == "_repair_session_stints":
+                repair_at = node.lineno
+            attr = getattr(node.func, "attr", None)
+            if attr == "load":
+                fastf1_load_at = node.lineno
+            elif attr == "_process_all_drivers":
+                extract_at = node.lineno
+
+    assert repair_at is not None, (
+        "SessionLoader.load never calls _repair_session_stints, so the replay is "
+        "back to reading TyreLife raw and disagrees with PITWALL's tower again"
+    )
+    gated = [
+        branch.lineno
+        for branch in ast.walk(body)
+        if isinstance(branch, ast.If)
+        for call in ast.walk(branch)
+        if isinstance(call, ast.Call) and getattr(call.func, "id", None) == "_repair_session_stints"
+    ]
+    assert not gated, (
+        f"the repair call sits inside a conditional at line(s) {gated}, so it can be "
+        "switched off without this file noticing - which `if False:` did"
+    )
+    assert fastf1_load_at is not None and fastf1_load_at < repair_at, (
+        "the repair runs before session.load(), so there are no laps to repair"
+    )
+    assert extract_at is not None and repair_at < extract_at, (
+        "the repair runs after the per-driver extraction, so the cached frames "
+        "were built from the unrepaired column"
+    )
+
+
+class FakeSession:
+    """`.laps` is the entire surface the helper touches.
+
+    A real FastF1 session would cost minutes to load and would add nothing: the
+    helper reads one attribute and writes three columns back onto it.
+    """
+
+    def __init__(self, laps: pd.DataFrame) -> None:
+        self.laps = laps
+
+
+def race(name: str) -> pd.DataFrame:
+    path = ROOT / "data" / "raw" / "2025" / name / "laps.parquet"
+    if not path.exists():
+        pytest.skip(f"{name} 2025 not present (curated data/raw on this machine)")
+    return pd.read_parquet(path)
+
+
+@pytest.mark.parametrize("name", ["Melbourne", "Lusail", "Monaco", "Las_Vegas"])
+@pytest.mark.parametrize("column", REPAIRED_COLUMNS)
+def test_the_replay_and_the_tower_agree(name: str, column: str) -> None:
+    """The two real paths, on the same source frame, column by column.
+
+    Parametrised per column so a failure names which one drifted rather than
+    reporting that "the frames differ".
+    """
+    raw = race(name)
+    tower, _ = repair_tyre_stints(raw.copy())
+
+    session = FakeSession(raw.copy())
+    _repair_session_stints(session)
+    replay = session.laps
+
+    both_absent = replay[column].isna() & tower[column].isna()
+    assert (both_absent | (replay[column] == tower[column])).all()
+
+
+def test_the_repair_actually_fires_on_the_race_that_needs_it() -> None:
+    """Otherwise the parity above would pass on two untouched frames.
+
+    This is the assertion that fails if the helper is never called, or returns
+    early, or writes its columns to a copy. Melbourne is the race the repair
+    exists for, so a green parity test with zero rows moved would be green about
+    nothing.
+    """
+    raw = race("Melbourne")
+    session = FakeSession(raw.copy())
+    _repair_session_stints(session)
+
+    before, after = raw["TyreLife"], session.laps["TyreLife"]
+    moved = (before != after) & ~(before.isna() & after.isna())
+    assert int(moved.sum()) == 162
+    assert int(after.isna().sum()) == 167
+
+
+@pytest.mark.parametrize("name", ["Lusail", "Monaco", "Las_Vegas"])
+def test_a_healthy_race_is_left_alone(name: str) -> None:
+    """The repair's own contract, asserted where the replay now depends on it.
+
+    It matters here beyond tidiness: an unnecessary rewrite of these columns
+    would change the pickled bytes of every cached race rather than only the
+    corrupted ones, which is the difference between one cache bump and a habit.
+    """
+    raw = race(name)
+    session = FakeSession(raw.copy())
+    _repair_session_stints(session)
+    for column in REPAIRED_COLUMNS:
+        before, after = raw[column], session.laps[column]
+        assert (after.isna() == before.isna()).all()
+        assert (after[before.notna()] == before[before.notna()]).all()
+
+
+def misplaced_boundary_race() -> pd.DataFrame:
+    """One car whose Stint column advances three laps after the stop it belongs to.
+
+    Every race on this machine exercises only the NULLING half of the repair, so
+    `Stint` and `Compound` move zero rows on all four and a write-back that
+    dropped them stayed green. That is a guard passing about the empty set, and
+    it is what a gate found in the first version of this file.
+
+    The boundary-correction half is what writes those two columns
+    (`tyre_stint_repair.py:443-444`), and it needs a shape none of the fixtures
+    has: a `PitInTime` on lap 10 whose stint boundary does not land until 13.
+    """
+    n = 20
+    return pd.DataFrame(
+        {
+            "Driver": ["NOR"] * n,
+            "LapNumber": [float(i) for i in range(1, n + 1)],
+            "Stint": [1.0] * 12 + [2.0] * 8,
+            "TyreLife": [float(i) for i in range(1, 13)] + [float(i) for i in range(1, 9)],
+            "Compound": ["MEDIUM"] * 12 + ["HARD"] * 8,
+            "PitInTime": [pd.NaT] * 9 + [pd.Timedelta(seconds=1)] + [pd.NaT] * 10,
+        }
+    )
+
+
+@pytest.mark.parametrize("column", REPAIRED_COLUMNS)
+def test_all_three_repaired_columns_reach_the_replay(column: str) -> None:
+    """The write-back is complete, on a frame where all three actually move.
+
+    Measured on this fixture: TyreLife moves 10 rows, Stint 2 and Compound 2.
+    Dropping either of the last two from the loop is invisible on every real
+    race here and fails immediately on this one.
+    """
+    raw = misplaced_boundary_race()
+    tower, report = repair_tyre_stints(raw.copy())
+    assert report.boundaries_corrected == 1, "the fixture stopped exercising the boundary path"
+
+    session = FakeSession(raw.copy())
+    _repair_session_stints(session)
+    replay = session.laps
+
+    moved = (raw[column] != tower[column]) & ~(raw[column].isna() & tower[column].isna())
+    assert int(moved.sum()) > 0, f"{column} does not move on this fixture, so it proves nothing"
+    both_absent = replay[column].isna() & tower[column].isna()
+    assert (both_absent | (replay[column] == tower[column])).all()
+
+
+def test_the_laps_object_survives_the_repair() -> None:
+    """The replay needs FastF1's `Laps` methods after this runs.
+
+    Replacing `session.laps` with the repair's plain DataFrame would strip
+    `pick_drivers`, which the per-driver extraction calls, and `pick_fastest`,
+    which the reference lap needs. Writing columns back preserves the object,
+    and this is what fails if someone simplifies the loop into an assignment.
+    """
+
+    class Marked(pd.DataFrame):
+        """Stands in for the `Laps` subclass: a type that must not be replaced."""
+
+        @property
+        def _constructor(self):
+            return Marked
+
+    session = FakeSession(Marked(race("Melbourne")))
+    _repair_session_stints(session)
+    assert isinstance(session.laps, Marked)

--- a/tests/surfaces/test_pitwall_prewarm_and_download.py
+++ b/tests/surfaces/test_pitwall_prewarm_and_download.py
@@ -1,0 +1,266 @@
+"""Work the user waits on must not sit on the request they are waiting for.
+
+Two fixes, one shape. The pit-wall host loaded the race inside `_session_for` on
+the first `get_bulk`, a call the window blocks on while it paints nothing
+(#1004), and `ensure_data` ran the whole multi-gigabyte download twice, the first
+time silently under a "Resolving..." spinner (#168).
+
+Measured here, on a payload shaped the way `app.py:658` publishes it:
+
+    old start(), connect only    first get_bulk   300.1 ms
+    new start(), pre-warmed      first get_bulk     0.3 ms
+
+The pre-warm reads the race from `payload["arcade"]`, which is where `get_bulk`
+and `get_live_lap` read it from. The first version of this read the top level
+instead: against the real producer it would have found nothing, polled for the
+full 30 s timeout and warmed nothing at all, while a test with a flattened
+fixture stayed green. `test_a_flattened_payload_is_not_the_real_shape` is that
+mistake, kept as an assertion.
+"""
+
+from __future__ import annotations
+
+import ast
+import time
+from pathlib import Path
+
+import pytest
+
+from src.pitwall.host import PitwallHost
+
+ROOT = Path(__file__).resolve().parents[2]
+CACHE_SOURCE = ROOT / "src" / "f1_strat_manager" / "data_cache.py"
+
+RACE = {
+    "year": 2025,
+    "location": "Melbourne",
+    "lap": 20,
+    "total_laps": 57,
+    "frame_index": 0,
+    "global_t_min": 0.0,
+    "drivers": {"NOR": {"laps_completed": 20}},
+    "driver_colors": {},
+}
+TICK = {"seq": 1, "arcade": RACE, "playback": {"speed": 1, "paused": False}}
+
+
+class FakeClient:
+    """Publishes one tick as soon as it is started, like a producer already up."""
+
+    def __init__(self, payload: dict | None = TICK) -> None:
+        self.started = False
+        self._payload = payload
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:
+        self.started = False
+
+    @property
+    def latest(self) -> dict | None:
+        return self._payload if self.started else None
+
+    @property
+    def connected(self) -> bool:
+        return self.started
+
+    def snapshot(self):
+        return (self._payload if self.started else None), ()
+
+
+@pytest.fixture
+def loaded(monkeypatch: pytest.MonkeyPatch) -> list[tuple]:
+    """Record every race the host loads, without touching the disk."""
+    calls: list[tuple] = []
+
+    class Stub:
+        @staticmethod
+        def load(root, year, location):
+            calls.append((year, location))
+            return None
+
+    import src.pitwall.host as host_module
+
+    monkeypatch.setattr(host_module.SessionLaps, "load", Stub.load)
+    monkeypatch.setattr(host_module.RadioCorpus, "load", Stub.load)
+    return calls
+
+
+def test_start_warms_the_race_off_the_request_path(loaded: list[tuple]) -> None:
+    """The whole point: the load happens before any window asks."""
+    host = PitwallHost(client=FakeClient(), window_count=2)
+    host.start()
+    host._warm_thread.join(10)
+
+    assert loaded == [(2025, "Melbourne"), (2025, "Melbourne")], (
+        "the pre-warm did not load the laps and the radio corpus"
+    )
+
+
+def test_the_first_get_bulk_finds_the_cache_warm(loaded: list[tuple]) -> None:
+    """After the warm-up, the request does no loading of its own.
+
+    Asserted by counting loads rather than by timing, because a wall-clock
+    threshold on a shared runner is a flake waiting to happen. The count is the
+    property; the milliseconds are in the module docstring.
+    """
+    host = PitwallHost(client=FakeClient(), window_count=2)
+    host.start()
+    host._warm_thread.join(10)
+    before = len(loaded)
+
+    host.get_bulk(-1)
+    assert len(loaded) == before, "get_bulk loaded the race again"
+
+
+def test_a_flattened_payload_is_not_the_real_shape(loaded: list[tuple]) -> None:
+    """The bug the first version shipped, stated as its own test.
+
+    `app.py:658` nests the race under `arcade`. A pre-warm reading `year` and
+    `location` off the top level finds them only in a hand-written fixture, so it
+    would warm nothing in production and every test would still pass. Here the
+    flattened payload must warm NOTHING, which is what proves the reader is
+    looking in the right place rather than in both.
+    """
+    host = PitwallHost(client=FakeClient(payload={"seq": 1, **RACE}), window_count=2)
+    host.start()
+    host._warm_thread.join(2)
+    assert loaded == [], "the pre-warm read the race off the top level"
+
+
+def test_the_warm_thread_is_a_daemon(loaded: list[tuple]) -> None:
+    """It waits up to 30 s for a race, so it must never hold the process open."""
+    host = PitwallHost(client=FakeClient(payload=None), window_count=2)
+    host.start()
+    assert host._warm_thread.daemon
+
+
+def test_the_warm_up_gives_up_rather_than_spinning(loaded: list[tuple]) -> None:
+    """A producer that never names a race is a real state, not an error.
+
+    The arcade may still be building telemetry, or may never have been started,
+    and both windows already have a waiting screen for it.
+    """
+    host = PitwallHost(client=FakeClient(payload=None), window_count=2)
+    started = time.perf_counter()
+    host._warm_session(timeout_s=0.2, poll_s=0.02)
+    assert 0.15 < time.perf_counter() - started < 3.0
+    assert loaded == []
+
+
+def _ensure_setup_ast() -> ast.FunctionDef:
+    tree = ast.parse(CACHE_SOURCE.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "ensure_setup":
+            return node
+    raise AssertionError("ensure_setup is gone from data_cache.py")
+
+
+def test_the_first_run_downloads_once() -> None:
+    """`ensure_setup` calls `_snapshot_download` exactly once (#168).
+
+    It used to call it twice: once with progress off inside the spinner, which
+    downloaded everything silently, and once with progress on, which then found
+    every file present and returned at once. A first-time user watched a spinner
+    for the whole 7-8 GB and then a progress bar that completed instantly.
+
+    Counted structurally rather than by running a download, for the obvious
+    reason. The comment on the old first call claimed it "warms the HTTP client
+    and validates credentials", which is a real thing to want and not what a full
+    download is; `_resolve_repo` does it in one metadata call, measured at 965 ms
+    against the real Hub with no bytes fetched.
+    """
+    calls = [
+        node.lineno
+        for node in ast.walk(_ensure_setup_ast())
+        if isinstance(node, ast.Call) and getattr(node.func, "id", None) == "_snapshot_download"
+    ]
+    assert len(calls) == 1, f"ensure_setup downloads {len(calls)} times, at lines {calls}"
+
+
+def test_the_spinner_waits_on_the_probe_not_on_the_download() -> None:
+    """The "Resolving..." spinner has to cover the resolve, not the transfer.
+
+    If the download moves back inside the `console.status` block the progress
+    bars are hidden again, which is the visible half of the defect: the bytes
+    are the part the user wants to watch.
+    """
+    inside = [
+        getattr(call.func, "id", None)
+        for node in ast.walk(_ensure_setup_ast())
+        if isinstance(node, ast.With)
+        for call in ast.walk(node)
+        if isinstance(call, ast.Call)
+    ]
+    assert "_resolve_repo" in inside, "the spinner does not wrap the reachability probe"
+    assert "_snapshot_download" not in inside, (
+        "the download is back inside the spinner, so its progress bars are hidden"
+    )
+
+
+DOCS_CSS = ROOT / "docs" / "styles" / "docs.css"
+ROADMAP = ROOT / "docs" / "pages" / "roadmap.md"
+
+# `--fg-4` is rgba(255,255,255,0.32), which measures 2.78-2.91 against the
+# grounds the docs site paints on, against AA's 4.5 for normal text. These two
+# are the only uses that are not text a reader is meant to read.
+DECORATIVE = {".search-icon", ".breadcrumb-sep"}
+
+
+def test_only_decoration_uses_the_sub_aa_token() -> None:
+    """Ten small labels used a token the site's own comment calls "disabled".
+
+    Measured in the browser at 1440x900, compositing each element's own
+    translucent backgrounds down to an opaque ground: `.sidebar-section-title`
+    2.78, `.toc-title` 2.78, `.breadcrumb` 2.78, `.search-kbd` 2.87,
+    `.page-footer-label` 2.90, `.docs-footer-col-title` 2.83,
+    `.docs-footer-legal` 2.83, `.rl-date` 2.91. On `--fg-3` the same eight
+    measure 5.53 to 5.70.
+
+    The token stays where it is rather than being raised, because raising it to
+    clear 4.5 needs alpha 0.48 and `--fg-3` is 0.52: the four-step ramp would
+    collapse into three to keep a role its own comment says is decorative.
+    """
+    offenders = []
+    for path in (DOCS_CSS, ROADMAP):
+        lines = path.read_text(encoding="utf-8").splitlines()
+        for i, line in enumerate(lines):
+            if "var(--fg-4)" not in line:
+                continue
+            selector = "?"
+            for j in range(i, max(-1, i - 14), -1):
+                if "{" in lines[j]:
+                    selector = lines[j].split("{")[0].strip()
+                    break
+            if selector not in DECORATIVE:
+                offenders.append(f"{path.name}:{i + 1} {selector}")
+    assert not offenders, f"read text back on the sub-AA token: {offenders}"
+
+
+BESTS_PANEL = ROOT / "src" / "pitwall" / "ui" / "src" / "features" / "data" / "BestsPanel.tsx"
+
+
+def test_the_bests_observer_outlives_a_fit_decision() -> None:
+    """#1083: the observer was rebuilt on every decision, so a resize could land
+    with nothing watching and the panel kept the previous height's answer.
+
+    Two check-runs on one SHA four seconds apart, one green one red, and it never
+    reproduced locally: `BESTS at h=593: room 69, floor card 113, rendered ranked
+    11`, eleven being the depth of the h=833 client the sweep starts from.
+
+    A text assertion on a dependency array, and it says so. The property IS the
+    array: React re-runs the effect when any entry changes identity, and `fit` is
+    a `useCallback` over the fit state, so listing it there is the defect. There
+    is no Python parser for TSX in this repo, and the alternative, counting
+    `ResizeObserver` constructions in a real browser, needs a populated bulk that
+    only `scripts/smoke-data.mjs` knows how to build.
+    """
+    source = BESTS_PANEL.read_text(encoding="utf-8")
+    assert "const observer = new ResizeObserver(() => fitRef.current());" in source, (
+        "the observer no longer calls through the ref, so its effect depends on `fit` again"
+    )
+    assert "}, [card, content]);" in source, (
+        "the observer effect's dependency array changed; if `fit` is back in it, every "
+        "fit decision tears the observer down and reinstalls it"
+    )


### PR DESCRIPTION
Closes #832, closes #1008, closes #951, closes #1004, closes #1083, closes #168, closes #1124.

## What

Six issues from the pre-2.6 sweep. Each was verified by running the code, not by a passing test.

## Why, and how each was measured

**#832 / #1008, the sentinel that was also a reading.** `_tyre_life_in` returned `1` for an absent
`TyreLife`, arguing a missing age means the set is fresh. A tyre on the first lap of a stint reads 1,
so the sentinel and the measurement were the same number and nothing downstream could tell them
apart. `race_state_builder` had ruled 1 out in writing, for that reason, and this consumer used it
anyway. It fires on 451 rows, 1.98% of the 2025 featured parquet, feeding the model that predicts
stop duration.

It now serves `UNKNOWN_TYRE_LIFE`. That value sits below the envelope's floor of 1, so the call is
logged as an extrapolation rather than passing silently. The warning text changed too: `min()` clips
the top only, so "the value is clipped to 50" was false for anything below the floor, and nothing
could reach below it until this change made it possible.

**The twin, found by an adversarial gate over that fix.** `pace_agent.run_from_state` did
`d.get("tyre_life") or 1`. `or` is false for 0, which is exactly what `race_state_builder` publishes
for an unknown, so the sentinel was destroyed one hop after being chosen, by a line three above the
comment explaining why the same `or` had been removed for `position` (#628). `laps_since_pit` carried
the same chain, and the first version of this fix kept it. Measured on the shipped N06 booster:
`tyre_life` 0, 1 and 2 all predict 86.712000 on a real Lusail row (12 predicts 86.654000), so
passing the unknown through changes no served number.

**#951, two windows and one tyre.** `repair_tyre_stints` ran on the way into the models and into
PITWALL's timing tower, and not on the way into the pyglet replay. Both come up from one
`f1-arcade --strategy`, so on a corrupted race the compound pill and the TYRE column sat on screen
together disagreeing. Measured on the four 2025 races here: Melbourne moves 162 laps across 5
drivers and its unknown ages go 5 to 167; Lusail, Monaco and Las Vegas come back byte-untouched.
`CACHE_VERSION` v15 to v16, because the bytes change for the races the fix exists for, which is the
same reason v15 moved.

**#1004, a load on the call the window is blocked on.** The laps and the radio corpus loaded inside
`_session_for` on the first `get_bulk`. `start()` now warms them on a daemon thread as soon as the
producer names a race. Measured on a payload shaped the way `app.py:658` publishes it:

| | first `get_bulk` |
|---|---:|
| old `start()`, connect only | 300.1 ms |
| new `start()`, pre-warmed | **0.3 ms** |

Same 20-driver view both ways.

**#1083, an observer that kept being rebuilt.** The effect installing the `ResizeObserver` depended
on `fit`, a `useCallback` over the fit state, so every decision disconnected the observer and built a
new one. A resize landing in that window had nothing watching it and the panel kept the previous
height's answer, which is the CI flake: two check-runs on one SHA four seconds apart, one green one
red, never reproducible locally. The callback now lives in a ref and the effect depends on
`[card, content]`.

**#168, the download that ran twice.** `ensure_setup` called `_snapshot_download` with progress off
inside a "Resolving..." spinner, which fetched the whole 7-8 GB silently, then again with progress
on, which found every file present and returned at once. One download now, with a real reachability
probe in front of it: `HfApi().repo_info` measured at 965 ms against the real Hub, no bytes fetched.

**#1124, a disabled-text token under ten read labels.** `--fg-4` is `rgba(255,255,255,0.32)`.
Measured in the browser at 1440x900, compositing each element's own translucent backgrounds down to
an opaque ground:

| selector | px | before | after |
|---|---:|---:|---:|
| `.sidebar-section-title` | 10.5 | 2.78 | 5.65 |
| `.toc-title` | 10.5 | 2.78 | 5.65 |
| `.breadcrumb` | 11.5 | 2.78 | 5.65 |
| `.search-kbd` | 11 | 2.87 | 5.70 |
| `.page-footer-label` | 11 | 2.90 | 5.55 |
| `.docs-footer-col-title` | 11 | 2.83 | 5.69 |
| `.docs-footer-legal` | 11.5 | 2.83 | 5.69 |
| `.rl-date` | 12 | 2.91 | 5.53 |

AA is 4.5. The token keeps its documented decorative role on `.search-icon` and `.breadcrumb-sep`.
Raising it instead would need alpha 0.48 against `--fg-3`'s 0.52, collapsing a four-step ramp into
three to preserve a role its own comment calls disabled.

## Not done, and why

**#1075** and **#838** each say so in their own bodies. #1075: *"nothing is visibly broken today"*
and *"not worth doing on its own"* — it is a decision record blocking a motion item that is not in
this release. #838: *"Not fixed in place because regenerating needs the full `data/raw` tree"*, and
it warns that running the tier on the curated set would publish a one-race report as the headline.
Both were on the shortlist because a sweep sized them SMALL; the size of a fix and whether it should
be done are different questions.

**#974** was already fixed on `dev`. `decision.py:312` says so and documents the chain end to end.
The sweep checked whether `guardrail_reason` exists on the Pydantic model, which is the mechanism,
where the defect was a rendered line.

## Also changed

`test_n15_envelope`'s NaN assertion encoded the old value in its own name
(`..._is_still_read_as_a_fresh_set`), and two comments in `tyre_stint_repair.py` still taught the
behaviour #832 removed.

## Checks

- `tests/agents surfaces cli mc inference engine simulation rag infra`: **1183 passed, 22 skipped**.
- `tests/audit eval fixtures` plus the root file: **129 passed**, and the same nine failures that
  fail identically on `dev`, all needing the full `data/raw` tree this machine does not have.
- `uvx ruff@0.15.22 check .` and `format --check .` clean on 203 files. `mypy src/rag/` clean.
- **13 mutants watched RED one at a time.** Two survived the first version of these guards and are
  worth naming: dropping `Stint`/`Compound` from the repair write-back stayed green because those
  columns move zero rows on every race here, so the parity test was green about the empty set (fixed
  with a synthetic frame where all three move); and `if False:` in front of the repair call passed
  the AST guard, which asserted presence and order but not reachability.
- Real paths, not tests. `f1-sim Lusail NOR McLaren --laps 1-20 --no-llm` through the real radio
  corpus: `STAY_OUT·17 PIT_NOW·3`, 7 radio alerts, best lap 85.615 s, identical to before.
  `f1-arcade --viewer --year 2025 --round 1` boots the rebuilt v16 Melbourne, 20 drivers, 154,173
  frames. `node scripts/smoke-data.mjs` 373 checks, five consecutive runs.

## One thing that is not verified

The #1083 flake itself. The issue records that it never reproduced locally in six runs, and it did
not here either, so what is confirmed is the mechanism and its removal, not the disappearance of the
symptom. The adversarial gate for this half of the work ran out of session budget before reporting.
