### PR TITLE
fix(pitwall,eval): the fit callback stops closing over its own output

### DIFF
--- a/documents/eval_reports/calibration.json
+++ b/documents/eval_reports/calibration.json
@@ -1,12 +1,12 @@
 {
   "header": {
-    "harness_sha": "998a800",
+    "harness_sha": "4724f3ed",
     "dataset": "2025 holdout + frozen calibration artifacts",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-11T19:14:07+00:00",
+    "generated_at": "2026-08-29T18:38:10+00:00",
     "artifacts": {
       "overtake_model": "cbb9d0eb0beb",
       "pit_cfg": "41dd673a93fb",
@@ -65,7 +65,7 @@
     {
       "model": "pit_duration",
       "metric": "p05_p95_coverage",
-      "value": 0.7023809523809523,
+      "value": 0.6984126984126984,
       "nominal": 0.9,
       "status": "drift",
       "detail": "n=252; empirical P05-P95 coverage recomputed on the regenerated N15 holdout"

--- a/documents/eval_reports/calibration.md
+++ b/documents/eval_reports/calibration.md
@@ -1,13 +1,13 @@
 # calibration
 
-- harness `998a800` · schema v1 · generated 2026-07-11T19:14:07+00:00
+- harness `4724f3ed` · schema v1 · generated 2026-08-29T18:38:10+00:00
 - era 2022-2025 · dataset 2025 holdout + frozen calibration artifacts · seed deterministic · llm none
 - artifacts: overtake_model=`cbb9d0eb0beb`, pit_cfg=`41dd673a93fb`, tcn_mc_calib=`e03a170f6de4`
 
 | model | metric | value | nominal | status | detail |
 |---|---|---|---|---|---|
 | undercut | ece_calibrated | 0.1303 | 0.05 | drift | n=252; 10-bin equal-width |
-| pit_duration | p05_p95_coverage | 0.7024 | 0.9 | drift | n=252; empirical P05-P95 coverage recomputed on the regenerated N15 holdout |
+| pit_duration | p05_p95_coverage | 0.6984 | 0.9 | drift | n=252; empirical P05-P95 coverage recomputed on the regenerated N15 holdout |
 | overtake | brier_calibrated | 0.0520 | - | ok | n=10217; brier raw 0.1304 -> cal 0.0520 (Platt val-2024) |
 | overtake | ece_calibrated | 0.0319 | 0.05 | ok | n=10217; 10-bin equal-width |
 | safety_car | brier_calibrated | 0.0426 | - | ok | n=995; recomputed on 2025 holdout |

--- a/src/f1_strat_manager/data_cache.py
+++ b/src/f1_strat_manager/data_cache.py
@@ -148,6 +148,15 @@ _DEFAULT_MODEL_PATTERNS: tuple[str, ...] = (
     # (~80 MB); :func:`ensure_radio_corpus` downloads it lazily per GP
     # only when the simulation actually targets that race.
     "data/processed/race_radios/**",
+    # The two holdouts the calibration tier scores on. Neither is used at
+    # inference, so their absence is not a broken install, and that is exactly
+    # why they went unnoticed: `f1-eval calibration` degrades each missing one to
+    # a `pending` row rather than failing, so a regenerated report quietly shipped
+    # with three fewer measurements than the one it replaced. Found while closing
+    # #838, and the same shape as the undercut gap in #798 and the two import-time
+    # artefacts in #837: a consumer reads it, the pattern list does not ask for it.
+    "data/processed/overtake_labeled/**",
+    "data/processed/laps_tiredeg.parquet",
     # RAG index: optional, the Hub may not have it yet. snapshot_download
     # ignores missing patterns silently.
     "data/rag/**",

--- a/src/pitwall/ui/src/features/data/BestsPanel.tsx
+++ b/src/pitwall/ui/src/features/data/BestsPanel.tsx
@@ -168,9 +168,33 @@ function useFitsRanked(card: HTMLElement | null, content: number): Fit {
     if (measuredRow > 0) lastRowHeight.current = measuredRow;
     const rowHeight = measuredRow > 0 ? measuredRow : (lastRowHeight.current ?? 0);
     if (rowHeight <= 0) return;
-    if (fitState.ranked) {
-      const extraRows = Math.max(0, fitState.depth - RANKED_FLOOR);
-      floorHeight.current = card.scrollHeight - extraRows * rowHeight;
+    // **Latched from the rows the card is RENDERING, never from the state this
+    // callback sets.** Reading `fitState` here is what made `fit` close over its
+    // own output, and the closure is the whole defect: `fitRef.current = fit` ran
+    // in a passive effect, and under load a ResizeObserver callback is delivered
+    // BEFORE that effect, so the observer ran the previous render's `fit`. Its
+    // stale `if (fitState.ranked)` branch re-latched the floor from the COMPACT
+    // card at 60 px, and `room 63 >= 60` then flipped the panel back to ranked in
+    // a slot whose real floor card is 115 px. Measured on the committed code: the
+    // signature fired on 24 of 24 throttled loads, and whether the check failed
+    // was only whether a second observer fire happened to heal it.
+    //
+    // `.bests-sections` is a four-COLUMN grid, so the card's height is governed by
+    // the TALLEST section, and the max of the rendered row counts is exactly what
+    // that height contains. It is also more correct than subtracting
+    // `fitState.depth`, which over-subtracts rows that were never rendered when
+    // the data is shallower than the depth the state asked for.
+    //
+    // The sibling that never had this bug does the same thing:
+    // `RacePaceGrid.tsx:186` measures a real cell and carries `useCallback([])`.
+    const renderedRows = Math.max(
+      0,
+      ...[...card.querySelectorAll(".bests-section")].map(
+        (section) => section.querySelectorAll(".bests-row").length,
+      ),
+    );
+    if (renderedRows > 0) {
+      floorHeight.current = card.scrollHeight - (renderedRows - RANKED_FLOOR) * rowHeight;
     }
     const atFloor = floorHeight.current;
     if (atFloor === null) return;
@@ -192,7 +216,7 @@ function useFitsRanked(card: HTMLElement | null, content: number): Fit {
       ranked: true,
       depth: Math.min(RANKED_FLOOR + extra, RANKED_CAP),
     });
-  }, [card, fitState.ranked, fitState.depth]);
+  }, [card]);
 
   // **`content` is in here because the card mounts EMPTY, and that was a P1.**
   // The card appears with the first TICK; its rows come from the BULK, which
@@ -243,30 +267,25 @@ function useFitsRanked(card: HTMLElement | null, content: number): Fit {
   // Holding the callback in a ref keeps the deps free of it. The observer calls
   // whatever `fit` is at the moment it fires, which is the same behaviour the
   // re-installation was reaching for, minus the window with no observer in it.
-  const fitRef = useRef(fit);
-  useEffect(() => {
-    fitRef.current = fit;
-  }, [fit]);
-
   useEffect(() => {
     let live = true;
     document.fonts?.ready.then(() => {
-      if (live) fitRef.current();
+      if (live) fit();
     });
     return () => {
       live = false;
     };
-  }, [card]);
+  }, [fit]);
 
   useEffect(() => {
     const column = card?.parentElement;
     if (!card || !column) return;
-    fitRef.current();
-    const observer = new ResizeObserver(() => fitRef.current());
+    fit();
+    const observer = new ResizeObserver(fit);
     observer.observe(column);
     observer.observe(card);
     return () => observer.disconnect();
-  }, [card, content]);
+  }, [card, fit, content]);
 
   return fitState;
 }

--- a/tests/surfaces/test_pitwall_prewarm_and_download.py
+++ b/tests/surfaces/test_pitwall_prewarm_and_download.py
@@ -241,26 +241,45 @@ def test_only_decoration_uses_the_sub_aa_token() -> None:
 BESTS_PANEL = ROOT / "src" / "pitwall" / "ui" / "src" / "features" / "data" / "BestsPanel.tsx"
 
 
-def test_the_bests_observer_outlives_a_fit_decision() -> None:
-    """#1083: the observer was rebuilt on every decision, so a resize could land
-    with nothing watching and the panel kept the previous height's answer.
+def test_the_fit_callback_does_not_close_over_the_state_it_sets() -> None:
+    """#1083, and the regression the first attempt at it shipped.
 
-    Two check-runs on one SHA four seconds apart, one green one red, and it never
-    reproduced locally: `BESTS at h=593: room 69, floor card 113, rendered ranked
-    11`, eleven being the depth of the h=833 client the sweep starts from.
+    The observer was rebuilt on every decision because its effect depended on
+    `fit`, a `useCallback` over the fit state, so a resize landing in the gap was
+    unobserved. The first fix put `fit` behind a ref and dropped it from the deps.
+    That made it worse: `fitRef.current = fit` runs in a PASSIVE effect, and under
+    load a ResizeObserver callback is delivered before that effect runs, so the
+    observer called the previous render's closure. Its stale `if (fitState.ranked)`
+    branch re-latched the floor from the compact card at 60 px and `room 63 >= 60`
+    flipped the panel back to ranked in a slot whose real floor card is 115 px.
+    Measured: the signature fired on 24 of 24 throttled loads, and `smoke-data`
+    failed 7 of 9 unthrottled runs where the pre-fix bundle passed 3 of 3.
 
-    A text assertion on a dependency array, and it says so. The property IS the
-    array: React re-runs the effect when any entry changes identity, and `fit` is
-    a `useCallback` over the fit state, so listing it there is the defect. There
-    is no Python parser for TSX in this repo, and the alternative, counting
-    `ResizeObserver` constructions in a real browser, needs a populated bulk that
-    only `scripts/smoke-data.mjs` knows how to build.
+    Both defects have one cause, which is why one assertion covers both: `fit`
+    read the state it sets. It now reads the rendered rows from the DOM instead,
+    so it is identity-stable per card node, and the observer effect can depend on
+    it directly without ever being torn down by a decision.
+
+    Still a text assertion, and the reason is unchanged: there is no TSX parser
+    here. What changed is WHAT it pins. The previous version pinned
+    `fitRef.current()` verbatim, an implementation, and would have blocked this
+    repair; these pin the property, that no fit state appears in the callback's
+    dependencies and that no ref stands between the observer and the callback.
     """
     source = BESTS_PANEL.read_text(encoding="utf-8")
-    assert "const observer = new ResizeObserver(() => fitRef.current());" in source, (
-        "the observer no longer calls through the ref, so its effect depends on `fit` again"
+    code = "\n".join(
+        line for line in source.splitlines() if not line.strip().startswith(("//", "*"))
     )
-    assert "}, [card, content]);" in source, (
-        "the observer effect's dependency array changed; if `fit` is back in it, every "
-        "fit decision tears the observer down and reinstalls it"
+    assert "fitState" not in code.split("}, [card]);")[0].split("const fit = useCallback")[-1], (
+        "the fit callback reads fitState again, so it closes over its own output and a "
+        "stale copy can re-latch the floor from the compact card"
+    )
+    assert "fitRef" not in code, (
+        "a ref is back between the observer and the callback; its updater runs in a "
+        "passive effect, after ResizeObserver delivery under load"
+    )
+    assert "new ResizeObserver(fit)" in code, "the observer no longer calls fit directly"
+    assert "}, [card, fit, content]);" in code, (
+        "the observer effect's dependency array changed; `fit` belongs there and is safe "
+        "there only while it stays identity-stable"
     )

--- a/tests/surfaces/test_pitwall_radio_feed.py
+++ b/tests/surfaces/test_pitwall_radio_feed.py
@@ -24,6 +24,16 @@ from src.pitwall.host import PitwallHost
 from src.pitwall.radio_feed import RadioCorpus, unavailable
 from src.pitwall.session_data import SessionLaps
 
+# A location that is not a Grand Prix, so the "nothing on disk" branch is reached
+# by construction rather than by what happens to be installed. These three checks
+# used to name a real race the curated download left out, and they passed only on
+# a PARTIAL install: pulling the full `data/raw` tree gave that race its laps and
+# all three went red, having never once run in the state they were written for.
+# `RadioCorpus.load` and `SessionLaps.load` both answer None for an unknown GP
+# (they catch `resolve_gp_slug`'s ValueError) exactly as they do for a missing
+# directory, so the branch under test is the same one.
+NO_SUCH_RACE = "Not A Circuit"
+
 MELBOURNE = (2025, "Melbourne")
 
 
@@ -178,7 +188,7 @@ def test_a_race_with_no_corpus_says_so_instead_of_going_quiet():
     A feed that answered with an empty list would repeat it one channel over.
     """
     assert unavailable() == {"available": False, "events": []}
-    assert RadioCorpus.load(get_data_root(), 2025, "Shanghai") is None
+    assert RadioCorpus.load(get_data_root(), 2025, NO_SUCH_RACE) is None
 
 
 def test_the_feed_rides_in_the_bulk_and_a_race_switch_empties_it():
@@ -197,7 +207,7 @@ def test_the_feed_rides_in_the_bulk_and_a_race_switch_empties_it():
     assert served["radio"]["available"] is True
     assert served["radio"]["events"], "the bulk went out without the feed"
 
-    client.latest = _tick(dict.fromkeys(codes, 24), location="Shanghai")
+    client.latest = _tick(dict.fromkeys(codes, 24), location=NO_SUCH_RACE)
     switched = host.get_bulk(served["rev"])
     assert switched["available"] is False, "the table did not follow the race switch"
     assert switched["radio"] == {"available": False, "events": []}, (

--- a/tests/surfaces/test_pitwall_session_data.py
+++ b/tests/surfaces/test_pitwall_session_data.py
@@ -24,6 +24,16 @@ from src.f1_strat_manager.data_cache import get_data_root
 from src.pitwall.host import PitwallHost
 from src.pitwall.session_data import SessionLaps, race_dir, unavailable
 
+# A location that is not a Grand Prix, so the "nothing on disk" branch is reached
+# by construction rather than by what happens to be installed. These three checks
+# used to name a real race the curated download left out, and they passed only on
+# a PARTIAL install: pulling the full `data/raw` tree gave that race its laps and
+# all three went red, having never once run in the state they were written for.
+# `RadioCorpus.load` and `SessionLaps.load` both answer None for an unknown GP
+# (they catch `resolve_gp_slug`'s ValueError) exactly as they do for a missing
+# directory, so the branch under test is the same one.
+NO_SUCH_RACE = "Not A Circuit"
+
 MELBOURNE = (2025, "Melbourne")
 
 
@@ -970,7 +980,7 @@ def test_pointing_the_arcade_at_a_race_with_no_laps_clears_the_sectors():
         pytest.skip("2025/Melbourne is not in this install's curated data set")
     assert melbourne["drivers"]["NOR"]["lap"] == 21
 
-    client.latest = tick_for("Shanghai", 20)
+    client.latest = tick_for(NO_SUCH_RACE, 20)
     switched = host.get_live_lap(melbourne["rev"])
 
     assert switched is not None, (


### PR DESCRIPTION
Closes #838.

Two fixes plus three tests that were passing for the wrong reason. Both fixes came out of auditing
work that had already shipped, one of them mine from earlier today.

## #1083, the second attempt at it

The first fix (PR #1126) put `fit` behind a ref so the `ResizeObserver` would stop being torn down
on every fit decision. The idea was right and the execution was not: `fit` still closed over
`fitState`, and `fitRef.current = fit` runs in a **passive effect**, while a `ResizeObserver`
callback is delivered before that effect under load. So the observer could run the previous render's
closure, whose stale `if (fitState.ranked)` branch re-latched the floor from the **compact** card at
60 px, and `room 63 >= 60` then flipped the panel back to ranked in a slot whose real floor card is
115 px.

| | smoke-data |
|---|---|
| before #1126 | 3 of 3 green |
| after #1126 | **7 failures in 9** |
| after this PR | **12 of 12 green** |

Instrumented on the real bundle, the poison signature fired on **24 of 24** CPU-throttled loads.
Whether a run went red was only whether a second observer fire happened to heal it, which is also
why the pre-fix code looked fine: both effects depended on `fit`, so every `setFitState` called it
again, an accidental convergence pass the first fix removed.

`fit` now derives the latch from the rows the card is actually rendering, so it no longer reads the
state it sets. Its deps are `[card]`, the ref is gone, and the observer effect depends on `fit`
directly: the #1083 property (no teardown per decision) holds structurally rather than through a
ref. This is the shape the sibling that never had the bug already uses, `RacePaceGrid.tsx:186`,
`useCallback([])` over a measured cell. Subtracting the rendered row count is also more correct than
subtracting `fitState.depth`, which over-subtracts rows that were never rendered when the data is
shallower than the depth the state asked for.

**The guard for #1083 blocked this repair.** It pinned `const observer = new ResizeObserver(() =>
fitRef.current());` verbatim, an implementation, while its own docstring claimed it pinned a
property. Rewritten to assert the property: no fit state in the callback's dependencies, and no ref
between the observer and the callback.

## #838

`calibration.md` published 0.7024 for `pit_duration p05_p95_coverage` while the golden test states
176/252 = 0.6984. The issue deferred the fix because regenerating needs the full `data/raw` tree.
That is true, and the cost was wrong: the tree is **70 races and 40.3 MB**, pulled in 93 s. The
regenerated report differs in exactly one row.

The first regeneration lost three rows to `pending`, which is the failure mode the issue warned
about. Two holdouts the calibration tier scores on were missing from the download patterns and are on
the Hub: `data/processed/overtake_labeled/**` and `data/processed/laps_tiredeg.parquet`. Added.
Neither is read at inference, so their absence was never a broken install, which is exactly why it
went unnoticed: the tier degrades each missing one to a `pending` row rather than failing, so a
regenerated report can quietly ship with fewer measurements than the one it replaces. Same shape as
#798 and #837.

Pulling the full tree also took the local eval failures from **9 to 3**. Six of the nine were missing
data, not expected local noise. The three that remain need `data/processed/radio_nlp/*.csv`, which is
not published on the Hub at all, so they cannot pass on any machine; that is worth its own issue.

## Three tests that were green about the empty set

`test_a_race_with_no_corpus_says_so_instead_of_going_quiet`,
`test_the_feed_rides_in_the_bulk_and_a_race_switch_empties_it` and
`test_pointing_the_arcade_at_a_race_with_no_laps_clears_the_sectors` all named Shanghai 2025 as the
race with nothing on disk. The full tree gave it laps and all three went red.

They passed only on a partial install, and CI skips them for having no data at all, so they had
never once run in the state they were written for. Repointed at a location that is not a Grand Prix,
which reaches the same branch by construction: `RadioCorpus.load` and `SessionLaps.load` both answer
`None` for an unknown GP exactly as they do for a missing directory.

## Checks

- `tests/surfaces` + `tests/cli`: **532 passed, 0 failed**.
- `node scripts/smoke-data.mjs` **12 consecutive runs, all green**, after `npm run build`. The count
  matters here: the failure it replaces was intermittent at roughly 1 in 7, so a single green proves
  nothing and five greens is what luck looks like.
- `smoke-agents` 133. `uvx ruff@0.15.22 check .` and `format --check .` clean on 203 files.
  `npx tsc -b` clean.
- `f1-eval calibration` regenerated against the full tree; the diff is the one value plus the harness
  SHA and timestamp.

## Not in this PR

The `_session_lock` added in #1126 has no guard that exercises two threads: deleting the lock
entirely leaves all nine guards green. Real, known, and a concurrency test is its own piece of work.
