### PR TITLE
docs(roadmap): v2.6.0 ships, so it moves out of the planned tables

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -645,16 +645,21 @@ letting the roadmap contradict the CHANGELOG.
 
 | Version | Milestone | What it adds |
 |---|---|---|
-| **v2.6.0** | Arcade, modernized | A trackside frontend built in **web technology** for part of the live Arcade experience, running **alongside** the pyglet 2D replay rather than replacing it. **Desktop windows, not a web app**: the strategy and telemetry surfaces move to React hosted in the platform webview, reusing the React app's tab and URL-contract machinery from v2.0.0. They open as OS windows and need no browser and no server. The `lap_state` contract and the agents stay unchanged. |
 | **v2.8.0** | Rival Agent | A new, additive LangGraph node that predicts each nearby rival's next strategic move (pit window, compound, undercut/overcut) and feeds it to the orchestrator. Recommendations move from reactive to anticipatory. The six existing agents are untouched. |
 | **v3.0.0** | Live race inference | Real-time ingestion over the OpenF1 WebSocket (the `lap_state` contract is unchanged, so agents and orchestrator don't change), plus adaptation to the 2026 technical/sporting regulation (re-cluster, re-label compounds, drift monitoring). |
 
-Why that order: v2.6.0 is *same data, better face*. It carries low risk, and it reuses what v2.0.0
-already built. v3.0.0 is *new data, in real time*, which depends on a live source and its
-reliability. Polishing the modern surface before plugging in the live feed means there is
+Why that order: the surface came first because it is *same data, better face*, which carries low
+risk and reuses what v2.0.0 already built. v3.0.0 is *new data, in real time*, and depends on a live
+source and its reliability. Polishing the surface before plugging in the live feed means there is
 somewhere good to render the data once it arrives.
 
 Superseded: "Modern frontend" was planned here as v1.6.0 and **shipped as v2.0.0** on 2026-07-21.
+
+Shipped: "Arcade, modernized" was planned here as v2.6.0 and **shipped on 2026-08-29**, as PITWALL:
+two desktop windows in React hosted in a platform webview, running alongside the pyglet replay. What
+shipped is narrower than the row promised in one respect and wider in another. It is not a web app
+and never opens a browser, and it also carried a design pass over the replay, every one of the 70
+rounds of 2023 to 2025 loading from the menu, and a round of startup and per-lap cost work.
 
 ### Rival Agent: the anticipatory turn (v2.8.0)
 
@@ -678,5 +683,5 @@ These map to the eight future-work lines in the thesis ([`documents/thesis/`](do
 
 ---
 
-**Last Updated:** July 28, 2026
-**Version:** 1.13 (renumbered the planned milestones to v2.6.0/v2.8.0/v3.0.0 after the release train overtook them; brought the wording in line with the docs-site roadmap)
+**Last Updated:** August 29, 2026
+**Version:** 1.14 (v2.6.0 shipped, so its row moves out of the planned table; the remaining planned milestones are v2.8.0 and v3.0.0)

--- a/docs/pages/roadmap.md
+++ b/docs/pages/roadmap.md
@@ -464,23 +464,25 @@
   </div>
 </li>
 
+<li class="rl-item">
+  <div class="rl-dot done"></div>
+  <div class="rl-card">
+    <div class="rl-header">
+      <span class="rl-version"><span class="sr-only">Version: </span>v2.6.0</span>
+      <span class="rl-date"><span class="sr-only">Date: </span>2026-08-29</span>
+      <span class="rl-badge done-badge"><span class="sr-only">Status: </span>Shipped</span>
+    </div>
+    <p class="rl-title">PITWALL, a designed Arcade, and a startup that stops making you wait</p>
+    <p class="rl-summary">The trackside surface is now <strong>PITWALL</strong>: two desktop windows built in React and hosted in a platform webview, a DATA window with the timing tower, the bests panel, the race-pace grid, the track ring and the radio feed, and an AGENTS window that shows the decision and the six consoles behind it. They run alongside the pyglet replay rather than replacing it, and the <code>lap_state</code> contract and the agents are unchanged. The replay itself got a design pass over the launch menu and the circuit layout, and every one of the 70 rounds of 2023 to 2025 now loads from the menu where only one did.</p>
+    <p class="rl-summary">Startup and per-lap cost came down with it. <code>f1-sim --help</code> went from 12.6 s to 3.6 s and a five-lap offline run from 15.6 s to 5.5 s, because importing an agent no longer drags the LLM stack in behind it; N25's confidence interval went from 660 ms to 5.9 ms a lap by scoring one perturbed block instead of two hundred single rows, returning the same numbers; a warm session load went from 7.2 s to 3.8 s, and the pit-wall windows no longer pay 300 ms for the race on the first request they block on. Full detail in the <a href="https://github.com/VforVitorio/F1-StratLab/blob/main/CHANGELOG.md" target="_blank" rel="noopener noreferrer">changelog</a>.</p>
+  </div>
+</li>
+
 </ul>
 
 <p class="rl-section-label">Planned milestones</p>
 
 <ul class="rl-wrap">
-
-<li class="rl-item">
-  <div class="rl-dot planned"></div>
-  <div class="rl-card planned">
-    <div class="rl-header">
-      <span class="rl-version"><span class="sr-only">Version: </span>v2.6.0</span>
-      <span class="rl-badge planned-badge"><span class="sr-only">Status: </span>Planned</span>
-    </div>
-    <p class="rl-title">Arcade, modernized: a trackside frontend in web technology</p>
-    <p class="rl-summary">Bring the web app's modern frontend to part of the live Arcade experience, running alongside the pyglet 2D replay rather than replacing it. The strategy and telemetry surfaces move to React hosted in the platform webview - desktop windows, not a web app; the <code>lap_state</code> contract and the agents stay unchanged.</p>
-  </div>
-</li>
 
 <li class="rl-item">
   <div class="rl-dot planned"></div>


### PR DESCRIPTION
Both roadmaps still listed v2.6.0 as planned, under a title promising a web-technology frontend.

## What shipped, against what the row promised

PITWALL is two desktop windows built in React and hosted in a platform webview, running alongside the pyglet replay. It never opens a browser and needs no server, which is narrower than "a trackside frontend in web technology" reads.

It is also wider than the row in three ways the planned text did not mention: a design pass over the replay and the launch menu, all 70 rounds of 2023 to 2025 loading from the menu where only one did, and a round of startup and per-lap cost work.

## The numbers the shipped card carries

| | before | after |
|---|---:|---:|
| `f1-sim --help` | 12.6 s | 3.6 s |
| five-lap offline run | 15.6 s | 5.5 s |
| N25's confidence interval, per lap | 660 ms | 5.9 ms |
| warm session load | 7.2 s | 3.8 s |
| first pit-wall `get_bulk` | 300 ms | 0.3 ms |

## Changes

`docs/pages/roadmap.md` gains a shipped card and loses the planned one. `ROADMAP.md` drops the row from the planned table and records what shipped under the heading that already carries the v2.0.0 supersession, so the gap between plan and outcome stays readable rather than being quietly overwritten.

The ordering rationale below the table said "v2.6.0 is same data, better face" in the present tense about a milestone that has now shipped; reworded.