### PR TITLE
fix(eval): gate the NLP golden tests on their label files, not just the weights

### DIFF
--- a/tests/eval/test_nlp_golden.py
+++ b/tests/eval/test_nlp_golden.py
@@ -3,6 +3,12 @@
 The gated-stage contract is hermetic (authored data). The intent reproduction +
 NR-08 column-order verdict are data-tier: they load pickled weights, so they run
 locally and skip on CI without ``data/models/``.
+
+Three of them need a LABEL SET as well as the weights, and the skips have to say
+so separately. Scoring intent or NER against nothing returns a ``pending`` row,
+which these tests read as a failure; gating them on the weights alone made them
+fail on any machine that had the weights and not the labels, and neither label
+file is published (#1130).
 """
 
 from __future__ import annotations
@@ -19,6 +25,27 @@ _HAS_NER_MODEL = (
     ROOT / "data" / "models" / "nlp" / "ner_v1" / "bert_bio_v1" / "bert_bio_state_dict.pt"
 ).exists()
 _HAS_RCM_CORPUS = bool(list((ROOT / "data" / "processed").glob("race_radios/2025/*/rcm.parquet")))
+
+
+def _label_file(name: str) -> Path:
+    """A label file at the path the stage reads, which is not always under the repo.
+
+    The probes above use `ROOT / "data"`; `src/strategy/eval/nlp.py` uses
+    `get_data_root()`, and `F1_STRAT_DATA_ROOT` moves that elsewhere. For the
+    weights the difference is harmless (a probe that misses degrades to a skip),
+    but these two decide between a skip and a failure, so they read what the code
+    reads.
+    """
+    from src.f1_strat_manager.data_cache import get_data_root
+
+    return get_data_root() / "processed" / "radio_nlp" / name
+
+
+# The label sets the intent and NER stages score against. Neither is on the Hub
+# (#1130), so a machine WITH the weights and without these fails three tests it
+# has no way to pass; CI never saw it because there the weights are absent too.
+_HAS_INTENT_LABELS = _label_file("intent_labeled_data.csv").exists()
+_HAS_NER_ANNOTATIONS = _label_file("f1_radio_entity_annotations.json").exists()
 
 
 def test_no_nlp_stage_is_gated_after_304():
@@ -69,6 +96,7 @@ def test_intent_predict_proba_order_is_aligned():
 
 @pytest.mark.data
 @pytest.mark.skipif(not _HAS_INTENT_HEAD, reason="intent model absent (CI runner without weights)")
+@pytest.mark.skipif(not _HAS_INTENT_LABELS, reason="intent_labeled_data.csv absent (#1130)")
 def test_intent_reproduction_is_sane():
     """Setfit-free reproduction runs and beats chance on the labeled set."""
     from src.strategy.eval.nlp import reproduce_intent
@@ -81,6 +109,7 @@ def test_intent_reproduction_is_sane():
 
 @pytest.mark.data
 @pytest.mark.skipif(not _HAS_INTENT_HEAD, reason="intent model absent (CI runner without weights)")
+@pytest.mark.skipif(not _HAS_INTENT_LABELS, reason="intent_labeled_data.csv absent (#1130)")
 def test_alert_precision_from_gold_is_high():
     """Alert precision (intent PROBLEM/WARNING) is real (gold-derived) and clears 0.8."""
     from src.strategy.eval.nlp import reproduce_alert_precision
@@ -104,6 +133,9 @@ def test_dead_ner_classes_flags_zero_f1_types():
 
 @pytest.mark.data
 @pytest.mark.skipif(not _HAS_NER_MODEL, reason="ner weights absent (CI runner without weights)")
+@pytest.mark.skipif(
+    not _HAS_NER_ANNOTATIONS, reason="f1_radio_entity_annotations.json absent (#1130)"
+)
 def test_ner_entity_f1_reproduces_headline():
     """Entity micro-F1 reproduces the frozen 0.4151 headline within tolerance (full-set optimistic)."""
     from src.strategy.eval.nlp import reproduce_ner


### PR DESCRIPTION
## What

Adds the missing half of the `skipif` on three tests in `tests/eval/test_nlp_golden.py`, so they skip for the reason that is true instead of failing.

Part 1 of #1130. The issue stays open for part 2.

## Why

Each of the three asserts a stage reports `reproduced`, and each was gated only on the **model weights**. The stages read a **label set** as well, and return a `pending` row when it is absent, which the tests read as a failure:

| test | gated on | also reads |
|---|---|---|
| `test_intent_reproduction_is_sane` | `intent_setfit_modernbert_v1/model_head.pkl` | `radio_nlp/intent_labeled_data.csv` (`nlp.py:221`) |
| `test_alert_precision_from_gold_is_high` | the same head | the same CSV |
| `test_ner_entity_f1_reproduces_headline` | `ner_v1/bert_bio_v1/bert_bio_state_dict.pt` | `radio_nlp/f1_radio_entity_annotations.json` (`nlp.py:518`) |

So they skip on CI, where there is no `data/` at all, and fail on exactly the machine that has the weights and not the labels. That is every install, because neither label file is downloadable: `find --path "*radio_nlp*"`, `--name "*annotations*"` and `--name "*intent_labeled*"` against `VforVitorio/f1-strategy-dataset` all return zero entries.

They were the last three of the nine local failures on `dev`.

## How

Two probes, read through `get_data_root()` rather than `ROOT / "data"`. The other five probes in the file use `ROOT / "data"`; with `F1_STRAT_DATA_ROOT` set those degrade to a false skip, which is harmless, while these two decide between a skip and a failure, so they read what the code reads.

The module docstring said the data-tier tests need `data/models/`. It now says three of them need a label set too.

## What this does NOT fix

`intent_labeled_data.csv` is not actually missing: it is in git at `legacy/radio_label/2023/`, 56.4 KB, columns `message,intent`, **529 rows**, the exact count `_intent_predictions`' docstring quotes. Copying it to `data/processed/radio_nlp/` makes both intent tests pass in 11.7 s (executed). Publishing it to the dataset repo and adding it to the processed-tree patterns turns two of these three skips back into real measurements, and that is part 2 of #1130. Same shape as #798 and #837.

`f1_radio_entity_annotations.json` exists nowhere: not on the Hub, and a repo-wide search for `*annotation*` outside `.venv` finds nothing. That one needs a decision, not a publish.

## Checks

- `uv run pytest tests/eval tests/surfaces tests/cli -q`: **621 passed, 5 skipped, 0 failed**. The same three failed before this change.
- **The gate is conditional, not a blanket skip**: with the legacy CSV copied into `data/processed/radio_nlp/`, the file runs **7 passed / 2 skipped** instead of 5/4, and the two intent tests measure rather than skip. Removed again afterwards.
- Skip reasons now read `intent_labeled_data.csv absent (#1130)` and `f1_radio_entity_annotations.json absent (#1130)`.
- `uvx ruff@0.15.22 check .` and `format --check .`: clean on 203 files.
