### PR TITLE
fix(pitwall): take the laps and the radio as one snapshot, not two reads

### DIFF
--- a/src/pitwall/host.py
+++ b/src/pitwall/host.py
@@ -394,7 +394,7 @@ class PitwallHost:
         if payload is None:
             return None
         arcade = payload.get("arcade") or {}
-        session = self._session_for(arcade)
+        session, _ = self._session_for(arcade)
         if session is None:
             # The twin `get_bulk` has always had this branch and this one did
             # not. Plain None means "keep what you have", so pointing the
@@ -448,8 +448,8 @@ class PitwallHost:
             for code, state in (arcade.get("drivers") or {}).items()
         }
 
-    def _session_for(self, arcade: dict) -> SessionLaps | None:
-        """The loaded race for this tick, or None when it is not on disk.
+    def _session_for(self, arcade: dict) -> tuple[SessionLaps | None, RadioCorpus | None]:
+        """The loaded race AND its radio for this tick, or a pair of Nones.
 
         Cached on (year, location) so pointing the arcade at another race
         replaces the laps instead of serving the previous one's - the
@@ -469,6 +469,16 @@ class PitwallHost:
         beside it had already given up on. Not reachable from today's producer,
         which always publishes an int year and a str location, and fixed anyway
         because the branch exists to be defensive and was not.
+
+        **Both come back from here rather than the caller reading `self._radio`.**
+        Loading them under one lock only settles who WRITES them; the reader was
+        still unlocked, so `_masked_view` could take the table from one race and
+        then, after the swap, read the radio of another - or the radio the
+        clearing branch above had just withdrawn. The interleaving served a table
+        with one driver's laps beside `{"available": False, "events": []}`, which
+        is precisely what the comment on the lock says cannot happen. Returning
+        the pair hands the caller one consistent snapshot and leaves nothing for
+        it to re-read.
         """
         year, location = arcade.get("year"), arcade.get("location")
         # The whole body is under the lock, the clearing branch included. Leaving
@@ -480,12 +490,12 @@ class PitwallHost:
                 self._session_key = None
                 self._session = None
                 self._radio = None
-                return None
+                return None, None
             if self._session_key != (year, location):
                 self._session_key = (year, location)
                 self._session = SessionLaps.load(get_data_root(), year, location)
                 self._radio = RadioCorpus.load(get_data_root(), year, location)
-            return self._session
+            return self._session, self._radio
 
     def _masked_view(self, arcade: dict, reveal: dict[str, int]) -> dict:
         """Load the race once, then slice it; or say it is not on disk.
@@ -496,7 +506,7 @@ class PitwallHost:
         #904 already paid for once on the AGENTS history.
         """
         year, location = arcade.get("year"), arcade.get("location")
-        session = self._session_for(arcade)
+        session, radio = self._session_for(arcade)
         if session is None:
             view = unavailable(
                 year if isinstance(year, int) else None,
@@ -512,9 +522,7 @@ class PitwallHost:
         # bulk is 66,991 / 152,657 / 337,289 bytes at reveal L10 / L24 / L57 on
         # the real Melbourne payload, and the largest feed in the whole corpus
         # (Monaco, 210 events) is about 31 KB - 9%.
-        view["radio"] = (
-            radio_unavailable() if self._radio is None else self._radio.masked_view(reveal)
-        )
+        view["radio"] = radio_unavailable() if radio is None else radio.masked_view(reveal)
         return view
 
     def release_window(self) -> int:

--- a/tests/surfaces/test_pitwall_prewarm_and_download.py
+++ b/tests/surfaces/test_pitwall_prewarm_and_download.py
@@ -307,7 +307,7 @@ def test_a_second_thread_waits_out_the_load_instead_of_reading_it_half_done(
     race rather than reading the half-swapped state. `_session_for` assigns
     `_session_key` first and only then calls the two loaders, so an unlocked
     second thread finds the key already set, skips the load it would otherwise
-    have done, and returns `self._session` while it is still None - a caller
+    have done, and returns the pair while both halves are still None - a caller
     told the race is not on disk during the very load that is putting it there.
 
     Timing rather than a barrier, because a barrier inside the loader deadlocks
@@ -347,8 +347,8 @@ def test_a_second_thread_waits_out_the_load_instead_of_reading_it_half_done(
         f"the race was loaded {len(calls)} times, not once for the laps and once "
         f"for the radio: {calls}"
     )
-    assert served["first"] == "Melbourne-2025"
-    assert served["second"] == "Melbourne-2025", (
+    assert served["first"] == ("Melbourne-2025", "Melbourne-2025")
+    assert served["second"] == ("Melbourne-2025", "Melbourne-2025"), (
         "the second thread read the session while the first was still loading it, "
         f"and was served {served['second']!r} - the lock is not serialising the swap"
     )

--- a/tests/surfaces/test_pitwall_radio_feed.py
+++ b/tests/surfaces/test_pitwall_radio_feed.py
@@ -17,6 +17,8 @@ seventy, and the radio corpus is a separate artefact that can be absent on its o
 
 from __future__ import annotations
 
+import threading
+
 import pytest
 
 from src.f1_strat_manager.data_cache import get_data_root
@@ -246,3 +248,78 @@ def test_a_tick_that_names_no_race_takes_the_feed_down_with_the_table():
     assert answered["radio"] == {"available": False, "events": []}, (
         "the table went empty and the previous race's radio stayed on screen beside it"
     )
+
+
+class _BlockingSession:
+    """A race whose `masked_view` parks, so a swap can land in the middle of it."""
+
+    def __init__(self) -> None:
+        self.entered = threading.Event()
+        self.release = threading.Event()
+
+    def masked_view(self, reveal, t_min):
+        self.entered.set()
+        self.release.wait(10)
+        return {"available": True, "drivers": {"NOR": 20}}
+
+
+class _StubCorpus:
+    """A radio corpus that always has something to say, so silence means a torn read."""
+
+    @staticmethod
+    def masked_view(reveal):
+        return {"available": True, "events": [{"kind": "radio", "driver": "NOR"}]}
+
+
+def test_the_table_and_the_radio_come_from_the_same_race_under_a_concurrent_swap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The pair has to be taken once, not read again after the table is built.
+
+    `_session_for` loads the laps and the corpus under one lock, which settles
+    who WRITES them. The reader was still unlocked: `_masked_view` built the
+    table, and only then read `self._radio` off the host. A swap landing in that
+    gap serves one race's table beside another race's radio, or beside the
+    `{"available": False, "events": []}` the clearing branch had just published,
+    which is exactly what the comment on the lock says cannot happen.
+
+    Executed rather than argued. A window thread parks inside
+    `session.masked_view`; a second thread runs a tick that names no race, which
+    takes the clearing branch and nulls all three fields; the window is then let
+    go. Before the fix the payload came back as an available table beside an
+    unavailable feed.
+
+    Stubs rather than the real Melbourne corpus, because the interleaving needs a
+    `masked_view` that parks on command and the real one returns immediately.
+    `test_a_tick_that_names_no_race_takes_the_feed_down_with_the_table` is the
+    same clearing branch on real data, without the second thread.
+    """
+    import src.pitwall.host as host_module
+
+    session = _BlockingSession()
+    monkeypatch.setattr(host_module.SessionLaps, "load", lambda root, y, loc: session)
+    monkeypatch.setattr(host_module.RadioCorpus, "load", lambda root, y, loc: _StubCorpus())
+
+    host = PitwallHost(_FakeClient(), window_count=1)
+    served: dict[str, dict] = {}
+
+    def window() -> None:
+        served["view"] = host._masked_view(
+            {"year": 2025, "location": "Melbourne", "global_t_min": 0.0}, {"NOR": 20}
+        )
+
+    reader = threading.Thread(target=window, name="window")
+    reader.start()
+    assert session.entered.wait(10), "the window never reached masked_view"
+
+    host._session_for({"year": None, "location": None})
+    session.release.set()
+    reader.join(10)
+
+    view = served["view"]
+    assert view["available"] is True, "the table did not build; the case is not exercised"
+    assert view["radio"]["available"] is True, (
+        "the table was served for one race beside a radio the clearing branch had already "
+        f"withdrawn: {view['radio']}"
+    )
+    assert view["radio"]["events"], "the feed came back empty beside a populated table"


### PR DESCRIPTION
## What

`_session_for` now returns the laps and the radio corpus as one pair. `_masked_view` uses that pair instead of reading `self._radio` back off the host after it has already built the table.

## Why

The lock added in #1004 loads both under `_session_lock`, which settles who **writes** them. The reader was still unlocked: `_masked_view` took the session from `_session_for`, built the table, and only then read `self._radio` (`host.py:515`). A swap landing in that gap serves one race's table beside another race's radio, or beside the `{"available": False, "events": []}` the clearing branch had just published. That is precisely what the comment at `host.py:472-475` says cannot happen, so the comment was wrong until this.

Found by the batch B/C gate on #1126, which built the interleaving and got back a table with `drivers={'NOR': 20}` beside an unavailable feed. Rated LOW-MEDIUM there: today's producer never emits a malformed tick, a race switch mid-poll is rare, and the next poll self-corrects.

## How

`_session_for` returns `tuple[SessionLaps | None, RadioCorpus | None]`, `(None, None)` on the clearing branch. `_masked_view` unpacks both; `get_live_lap` unpacks and discards the radio; the pre-warm already discarded the whole result. Nothing else calls it.

The concurrency guard from #1129 asserts the pair now, because the return type moved.

## Checks

- New guard in `tests/surfaces/test_pitwall_radio_feed.py`, beside the non-concurrent twin of the same clearing branch: a window thread parks inside `session.masked_view`, the main thread runs a tick naming no race, then releases it.
  - Pre-fix read restored (confirmed applied at `host.py:525`): **RED 3 of 3**, `AssertionError: the table was served for one race beside a radio the clearing branch had already withdrawn: {'available': False, 'events': []}`.
  - Fix restored, `host.py` byte-identical: **green 3 of 3**.
- `uv run pytest tests/surfaces tests/cli -q`: **534 passed**.
- **Real path**, host wired as `src/pitwall/__main__.py:42` wires it, against `scripts/dev_pitwall_producer.py` on 9998: tick `2025 Melbourne lap=23`, `get_bulk` available with 20 drivers, `radio available=True` with 41 events across both `radio` and `rcm`, `get_live_lap` 17 drivers, `_session_key=(2025, 'Melbourne')`. Feeding the clearing tick to the real host takes the table and the radio down together.
- `uvx ruff@0.15.22 check .` and `format --check .`: clean on 203 files.
