### PR TITLE
fix(pitwall): stop the pre-warm thread when the host is torn down

### DIFF
--- a/src/pitwall/host.py
+++ b/src/pitwall/host.py
@@ -142,6 +142,10 @@ class PitwallHost:
         # first bulk and the warm-up could load the same race twice.
         self._session_lock = threading.Lock()
         self._warm_thread: threading.Thread | None = None
+        # Set by `shutdown()` and by the last `release_window()`. The pre-warm
+        # below waits up to 30 s for a race, so without it a host that is torn
+        # down two seconds in keeps a thread looking for work nobody will read.
+        self._stopped = threading.Event()
         # The LIVE channel's state, masked by the clock rather than by
         # completed laps. `_live_view` is the last block SERVED, so the
         # revision moves exactly when the screen would change and not ten
@@ -184,9 +188,17 @@ class PitwallHost:
         thread would poll for the full timeout and warm nothing while every test
         with a flattened fixture went on passing. That is what the first version
         of this did.
+
+        **It also stops when the host does.** It used to watch only its deadline,
+        so a host torn down two seconds into the wait left a thread that went on
+        to load a race for windows that had closed. Waiting on `_stopped` rather
+        than sleeping is what makes it leave within one poll instead of thirty
+        seconds. The host asks itself rather than asking the client, because a
+        client whose `latest` survives its own `stop()` is exactly the shape this
+        used to depend on.
         """
         deadline = time.monotonic() + timeout_s
-        while time.monotonic() < deadline:
+        while time.monotonic() < deadline and not self._stopped.is_set():
             payload = self._client.latest
             arcade = (payload or {}).get("arcade") or {}
             if arcade.get("location"):
@@ -197,7 +209,10 @@ class PitwallHost:
                     (time.monotonic() - started) * 1000,
                 )
                 return
-            time.sleep(poll_s)
+            self._stopped.wait(poll_s)
+        if self._stopped.is_set():
+            logger.info("Pit-wall pre-warm stopped: the host was torn down before a race arrived")
+            return
         logger.info("Pit-wall pre-warm gave up after %.0fs: the producer named no race", timeout_s)
 
     def get_tick(self, since_seq: int = -1) -> dict | None:
@@ -527,10 +542,12 @@ class PitwallHost:
         self._windows_open = max(0, self._windows_open - 1)
         if self._windows_open == 0:
             logger.info("Last Pitwall window closed - stopping the stream client")
+            self._stopped.set()
             self._client.stop()
         return self._windows_open
 
     def shutdown(self) -> None:
         """Unconditional teardown, for the process exiting rather than a window closing."""
         self._windows_open = 0
+        self._stopped.set()
         self._client.stop()

--- a/tests/surfaces/test_pitwall_prewarm_and_download.py
+++ b/tests/surfaces/test_pitwall_prewarm_and_download.py
@@ -352,3 +352,70 @@ def test_a_second_thread_waits_out_the_load_instead_of_reading_it_half_done(
         "the second thread read the session while the first was still loading it, "
         f"and was served {served['second']!r} - the lock is not serialising the swap"
     )
+
+
+class StillTalkingClient(FakeClient):
+    """A client whose `latest` outlives its own `stop()`, which is the real one.
+
+    `ArcadeStreamClient` keeps the slot on purpose: `_close_socket` says a frozen
+    board is still useful and the windows dim it rather than blanking it. So a
+    stopped client goes on naming a race, and `FakeClient` above does NOT model
+    that, it answers None once stopped. A pre-warm guard written against the
+    optimistic fixture passes without exercising anything, which is the same
+    fixture-fidelity gap the first version of #1004 already paid for once.
+    """
+
+    @property
+    def latest(self) -> dict | None:
+        return self._payload
+
+
+def test_the_warm_up_stops_when_the_host_does(loaded: list[tuple]) -> None:
+    """A host that is torn down mid-wait must not load a race for windows that closed.
+
+    The thread waits up to 30 s for the producer to name a race and used to watch
+    only that deadline. Nothing told it the windows were gone, and the client it
+    asks keeps answering after `stop()`, so a host shut down two seconds in went
+    on to load the laps and the corpus and populate `_session_key` on a torn-down
+    host. Bounded (a daemon reading parquet) and still work nobody will read.
+
+    Driven synchronously rather than through the thread, because a thread race
+    decided by a sleep is a flake; this calls the loop the thread runs.
+    """
+    torn_down = PitwallHost(client=StillTalkingClient(), window_count=2)
+    torn_down._client.start()
+    torn_down.shutdown()
+    torn_down._warm_session(timeout_s=1.0, poll_s=0.02)
+
+    assert loaded == [], f"the pre-warm loaded a race after shutdown(): {loaded}"
+    assert torn_down._session_key is None, (
+        f"a torn-down host came out with a session loaded: {torn_down._session_key}"
+    )
+
+    # And the same client still warms a host nobody shut down, so the assertions
+    # above are about the teardown and not about a fixture that names no race.
+    running = PitwallHost(client=StillTalkingClient(), window_count=2)
+    running._client.start()
+    running._warm_session(timeout_s=1.0, poll_s=0.02)
+    assert loaded == [(2025, "Melbourne"), (2025, "Melbourne")], (
+        f"the client never named a race, so the teardown assertions prove nothing: {loaded}"
+    )
+
+
+def test_the_last_window_closing_stops_the_warm_up_too(loaded: list[tuple]) -> None:
+    """`release_window` tears the client down at the last close, so it ends this too.
+
+    Two teardown paths reach the same state and only one of them is `shutdown()`.
+    Fixing the one the gate happened to execute would leave its twin open, which
+    is the defect this repo pays for most.
+    """
+    host = PitwallHost(client=StillTalkingClient(), window_count=2)
+    host._client.start()
+
+    assert host.release_window() == 1, "closing one of two windows tore the host down"
+    assert not host._stopped.is_set(), "one window closing already stopped the pre-warm"
+
+    assert host.release_window() == 0
+    loaded.clear()
+    host._warm_session(timeout_s=1.0, poll_s=0.02)
+    assert loaded == [], f"the pre-warm loaded a race after the last window closed: {loaded}"


### PR DESCRIPTION
## What

The pre-warm thread now ends when the host is torn down, instead of running out its own 30 s deadline and loading a race for windows that have closed.

## Why

`_warm_session` watched only its deadline. Nothing told it the windows were gone, and the client it polls **keeps answering `latest` after `stop()` on purpose** (`stream_client.py:230-235`: a frozen board is still operationally useful and the windows render it dimmed). So a host shut down two seconds into the wait went on to load the laps and the corpus and populate `_session_key` on a torn-down host.

Found by the batch B/C gate on #1126 (A-3, LOW). Bounded before and after: a daemon thread reading parquet, so the cost is wasted IO at process exit, not corruption or a wrong answer.

## How

A `_stopped` event on the host, set by `shutdown()` and by the last `release_window()`, ends the loop. Waiting on it instead of `time.sleep` is what makes the thread leave within a poll rather than at the deadline.

The host asks itself rather than asking the client, so the property does not depend on any client's `latest` semantics. `stream_client.py` is deliberately untouched: keeping the slot after a disconnect is a documented decision and the frozen-board behaviour is not this PR's to trade away.

## Checks

Two guards, one per teardown path, both driven synchronously (a thread race decided by a sleep is a flake, so these call the loop the thread runs).

- **Mutant A**, the loop back on its deadline alone: kills **both** guards.
- **Mutant B**, only `shutdown()` setting the flag with `release_window` left alone: kills the twin-path guard and leaves the other green. That is the twin this repo pays for most, so it gets its own assertion rather than sharing one.
- **The fixture is load-bearing.** The guards use a client whose `latest` outlives its own `stop()`, which is what the real one does; the file's existing `FakeClient` answers `None` once stopped. Swapping it in makes the first guard **pass with mutant A applied**, so a guard written against the optimistic fixture would have asserted nothing. Same fixture-fidelity gap the first version of #1004 already paid for.
- `uv run pytest tests/surfaces tests/cli -q`: **536 passed**, with `dev` (and therefore #1132's change to the same file) merged in.
- **Real path**, real `ArcadeStreamClient`, real host:
  - against the live producer the pre-warm still does its job: `session_key=(2025, 'Melbourne')`, radio loaded, `get_bulk` 20 drivers;
  - against a port with no producer, the thread leaves **0.001 s** after the flag with 28 s of its deadline still to run. The 1.01 s that follows is `client.stop()` joining its socket reader, unchanged here.
  - #1132's pair check re-run on the merged tree: table and radio from the same race (42 events, both kinds), and the clearing branch takes both down together.
- `uvx ruff@0.15.22 check .` and `format --check .`: clean on 203 files.
