### PR TITLE
fix(pitwall): budget the whole radio line, not just its message

### DIFF
--- a/src/pitwall/agent_formatters.py
+++ b/src/pitwall/agent_formatters.py
@@ -52,6 +52,35 @@ STATUS_WATCH: str = "WATCH"
 STATUS_ALERT: str = "ALERT"
 STATUS_IDLE: str = "IDLE"
 
+# The body's width budget, in characters of the 11 px line font.
+#
+# `_truncate`'s 70 bounds the MESSAGE and nothing else, and it was written
+# against a 280-340 px Qt label. Every body line also carries a prefix built
+# from wire text (`RCM L23 {label}: `, `{driver} {intent}: "`), and none of it
+# was ever counted, so the rendered line had no bound at all.
+#
+# The narrowest client this window opens at is 1226 px, from a 1280x720 screen;
+# `.agent-card-body.has-below` in `agents.css` is keyed to that same
+# measurement. A third of the grid leaves the body 373 px there, and realistic
+# transcript text measures about 5.0 px per character at 11 px, so the whole
+# LINE gets 74. `.agent-line` carries `overflow-wrap: anywhere` over a
+# content-sized grid row, so a line over budget does not truncate: it wraps,
+# grows the row, and takes the height out of the charts above it.
+#
+# The full message is never lost. `radio_tooltip` returns every message
+# uncapped, which is the division this window already uses: the ticker on the
+# glass, the record one hover away.
+BODY_LINE_LIMIT: int = 74
+
+# A flag token or an intent, not a sentence. `flag`, `event_type` and the N21
+# intent are all free wire text, and a label longer than this arrived in the
+# wrong field.
+LABEL_LIMIT: int = 22
+
+# What the message keeps even when the prefix has taken its share, so a long
+# label cannot render a line that is all prefix and an ellipsis.
+MESSAGE_FLOOR: int = 24
+
 # Type alias for readability only.
 Line = tuple[str, tuple[int, int, int]]
 Formatted = tuple[str, tuple[int, int, int], list[Line], str]
@@ -122,6 +151,16 @@ def _truncate(text: str | None, limit: int = 70) -> str:
     if len(s) <= limit:
         return s
     return s[: max(limit - 3, 0)].rstrip() + "..."
+
+
+def _message_room(prefix: str) -> int:
+    """Characters the message may use once ``prefix`` has taken its share of the line.
+
+    The prefix is bounded by its own callers (`_rcm_label`, `_radio_driver` and
+    `_radio_intent` each cap what they return), so the floor is a guard against
+    a prefix at its limit rather than against an unbounded one.
+    """
+    return max(MESSAGE_FLOOR, BODY_LINE_LIMIT - len(prefix))
 
 
 # --- N25 Pace -----------------------------------------------------------
@@ -311,8 +350,15 @@ def _rcm_label(event: dict[str, Any]) -> str:
     investigations) and finally to the literal ``RCM`` so the line never
     renders an empty bracket. Pulled into its own helper so both the body
     ticker and the tooltip render the same label for the same event.
+
+    Both wire fields are free text and neither was bounded, so a long
+    ``event_type`` rendered a body line with no width limit at all. Capped
+    here rather than at the call site because the tooltip reads the same
+    helper, and a label is a label on both surfaces. That does not reopen the
+    tooltip's uncapped-message rule: this bounds the LABEL, and the message
+    still arrives whole.
     """
-    return str(event.get("flag") or event.get("event_type") or "RCM")
+    return _truncate(str(event.get("flag") or event.get("event_type") or "RCM"), LABEL_LIMIT)
 
 
 def _radio_driver(event: dict[str, Any]) -> str:
@@ -324,8 +370,11 @@ def _radio_driver(event: dict[str, Any]) -> str:
     every entry depending on serialisation. ``UNKNOWN`` matches the same
     fallback string used in the agent itself, so the dashboard never
     invents a driver code that does not exist.
+
+    Capped like the other two label helpers: the field is wire text, and a
+    driver code longer than a label is malformed rather than long.
     """
-    return str(event.get("driver") or "UNKNOWN")
+    return _truncate(str(event.get("driver") or "UNKNOWN"), LABEL_LIMIT)
 
 
 def _radio_intent(event: dict[str, Any]) -> str:
@@ -335,8 +384,11 @@ def _radio_intent(event: dict[str, Any]) -> str:
     line still renders an intent column. Trusting the dict shape produced
     by ``run_pipeline`` (``analysis.intent``); only the boundary against
     missing keys is guarded, per the project's no-defensive-checks rule.
+
+    Capped for the same reason as ``_rcm_label``: the classifier's label is
+    free text on the wire and it rides in the body line's prefix.
     """
-    return str((event.get("analysis") or {}).get("intent") or "INFO")
+    return _truncate(str((event.get("analysis") or {}).get("intent") or "INFO"), LABEL_LIMIT)
 
 
 def _correction_row(entry: dict[str, Any]) -> dict[str, str]:
@@ -589,21 +641,26 @@ def format_radio(r: dict[str, Any] | None) -> Formatted:
     body: list[Line] = [
         (f"{n_radios} radios · {n_rcms} rcm", TEXT_SECONDARY),
     ]
+    # Both lines are budgeted as a WHOLE, prefix included. Capping only the
+    # message left the prefix free to run the rendered line past the card, and
+    # `.agent-line` wraps rather than clips, so the overflow came out of the
+    # charts above rather than out of the transcript.
     if rcm_events:
         last_rcm = rcm_events[-1]
+        prefix = f"RCM L{last_rcm.get('lap', '?')} {_rcm_label(last_rcm)}: "
         body.append(
             (
-                f"RCM L{last_rcm.get('lap', '?')} "
-                f"{html.escape(_rcm_label(last_rcm))}: {_escaped(last_rcm.get('message'))}",
+                f"{html.escape(prefix)}{_escaped(last_rcm.get('message'), _message_room(prefix))}",
                 TEXT_SECONDARY,
             )
         )
     for event in _radios_worth_the_room(radio_events, alerts):
+        prefix = f"{_radio_driver(event)} {_radio_intent(event)}: "
+        # The two quotes are part of the rendered line and so part of its budget.
+        room = _message_room(prefix) - 2
         body.append(
             (
-                f"{html.escape(_radio_driver(event))} "
-                f"{html.escape(_radio_intent(event))}: "
-                f'"{_escaped(event.get("message"))}"',
+                f'{html.escape(prefix)}"{_escaped(event.get("message"), room)}"',
                 TEXT_TERTIARY,
             )
         )

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -2240,3 +2240,56 @@ def test_the_routing_roster_is_the_routers_own_conditional_agents():
     assert {agent_id for agent_id, _ in ROUTING_LANES} == added, (
         f"the roster and the router disagree: {ROUTING_LANES} vs {sorted(added)}"
     )
+
+
+def test_no_radio_body_line_can_outgrow_the_card():
+    """A body line is budgeted whole, prefix included, or it wraps into the charts.
+
+    The 70-character cap bounds the MESSAGE. Every line also carries a prefix
+    built from wire text (`RCM L23 {label}: `, `{driver} {intent}: "`), and
+    `_rcm_label` reads `flag` or `event_type` straight off the feed with no
+    bound at all. At two grid columns the slack hid it; at one column the
+    rendered line runs past the card, and `.agent-line` carries
+    `overflow-wrap: anywhere` over a content-sized grid row, so the overflow
+    comes out of the PACE and TIRE charts rather than out of the transcript.
+
+    The hostile strings here are the shape the wire can actually produce: an
+    `event_type` is a structured token nobody bounds, and the N21 intent is a
+    classifier label.
+    """
+    from src.pitwall.agent_formatters import BODY_LINE_LIMIT, format_radio
+
+    block = {
+        "rcm_events": [
+            {
+                "lap": 23,
+                "event_type": "INVESTIGATION_AFTER_THE_RACE_FOR_A_PROCEDURAL_BREACH" * 3,
+                "message": "M" * 400,
+            }
+        ],
+        "radio_events": [
+            {
+                "driver": "UNKNOWN_DRIVER_IDENTIFIER" * 2,
+                "analysis": {"intent": "INSTRUCTION_WITH_A_VERY_LONG_CLASSIFIER_LABEL"},
+                "message": "W" * 400,
+            }
+        ],
+        "alerts": [],
+    }
+
+    import html
+
+    lines = [html.unescape(text) for text, _ in format_radio(block)[2]]
+    transcript = [line for line in lines if ":" in line and "radios" not in line]
+
+    assert len(transcript) == 2, f"both the RCM line and the radio line render: {lines}"
+    for line in transcript:
+        assert len(line) <= BODY_LINE_LIMIT, (
+            f"{len(line)} visible characters against a {BODY_LINE_LIMIT} budget: {line!r}"
+        )
+
+    # And the budget is spent on the message, not eaten by the prefix: a line
+    # that is all label and an ellipsis carries no transcript at all.
+    for line in transcript:
+        _, _, tail = line.partition(": ")
+        assert len(tail.strip('"')) >= 20, f"the message keeps its floor: {line!r}"


### PR DESCRIPTION
## What

The RADIO card's body lines are now budgeted as a whole, prefix included, at 74 characters.

## Why

`_truncate`'s 70-character cap bounds the **message** and nothing else. Every body line also carries a prefix built from wire text, and none of it was ever counted:

- `RCM L23 {label}: ` where `_rcm_label` returns `flag` or `event_type` straight off the feed, truncated by nothing
- `{driver} {intent}: "` where both come off the NLP pipeline

At two grid columns the slack hid it. Measured at Segoe UI 11px:

| line | width |
|---|---|
| bare 70-char message | 350 px |
| typical `VER INFO: "..."` | 401 px |
| worst in-contract `UNKNOWN INSTRUCTION: "..."` | 483 px |
| RCM with a long `event_type` | 1026 px |

Budgets: 459 px at the 1486 px client, **373 px** at the 1226 px client from a 1280x720 screen, which is the measurement `.agent-card-body.has-below` in `agents.css` is already keyed to. The typical line already exceeds the narrow one.

`.agent-line` carries `overflow-wrap: anywhere` over a content-sized grid row, so a line over budget does not clip. It wraps, grows row 2, and takes the height out of the PACE and TIRE charts above.

## How

- `BODY_LINE_LIMIT = 74`, derived from the 373 px budget at ~5.0 px per character, with the derivation in the comment.
- `_message_room(prefix)` gives the message whatever the prefix leaves, with a floor so a long label cannot render a line that is all prefix.
- `_rcm_label`, `_radio_driver` and `_radio_intent` capped at 22. Capped in the helpers rather than at the call site because the tooltip reads the same ones and a label is a label on both surfaces. This does not reopen the tooltip's uncapped-message rule; the message still arrives whole there.

## Out of scope

The layout change that makes this urgent is in `feat/pit-exit-card`, which takes one of RADIO's two columns. This lands first so that one does not ship a regression.

## Checks

`tests/surfaces` and `tests/mc`, 709 passed. ruff and mypy clean.

The guard feeds `format_radio` an RCM with a 200-character `event_type` and a radio with a long intent, then asserts every body line is inside the budget with its message above the floor. Watched RED against two compiling mutants: dropping the `_rcm_label` truncation, and returning a fixed 70 from `_message_room`.

Rendered in the real window at 1485x913 and 1226x593; every RADIO line sets on one line at both.