### PR TITLE
fix(engine): open the draw capture on the no-LLM profile too

### DIFF
--- a/src/strategy/inference/no_llm.py
+++ b/src/strategy/inference/no_llm.py
@@ -49,6 +49,7 @@ from src.agents.strategy_orchestrator import (
 from src.agents.tire_agent import TireAgent, _compound_name_to_id
 from src.strategy.inference.engine import (
     _assemble_agent_outputs,
+    _rejoin_from,
     _build_default_lap_state,
     _StageTimer,
 )
@@ -285,6 +286,11 @@ def run_no_llm_lap(
 
     with _StageTimer(timings, "mc"):
         _ctx = race_context_from_lap_state(lap_state, race_state)
+        # Same capture the rich profile takes, for the same reason. Without it
+        # the PIT EXIT card renders its "no rejoin geometry" idle on laps where
+        # the projection DID run, which is worse than an absent card: the copy
+        # claims there is nothing to compute when there is.
+        mc_draws: dict[str, Any] = {}
         mc_results = _run_mc_simulation(
             pace_out=pace_out,
             tire_out=tire_out,
@@ -295,6 +301,7 @@ def run_no_llm_lap(
             position=_ctx.get("position"),
             laps_remaining=_ctx.get("laps_remaining"),
             pit_context=_ctx.get("pit_context"),
+            capture=mc_draws,
         )
         best_mc = best_mc_candidate(mc_results)
 
@@ -326,6 +333,7 @@ def run_no_llm_lap(
     agent_outputs = None
     if return_agent_outputs:
         agent_outputs = _assemble_agent_outputs(
+            rejoin=_rejoin_from(mc_draws),
             pace_out=pace_out,
             tire_out=tire_out,
             situation_out=situation_out,

--- a/tests/engine/test_engine_threads_every_argument.py
+++ b/tests/engine/test_engine_threads_every_argument.py
@@ -117,3 +117,37 @@ def test_the_docstring_does_not_name_a_test_that_does_not_exist():
         assert (ROOT / name).exists(), (
             f"the engine docstring names {name} as an anti-drift guard, but it does not exist"
         )
+
+
+def test_both_profiles_open_the_draw_capture_and_forward_the_rejoin():
+    """The rich profile and the no-LLM one must agree about the PIT EXIT readout.
+
+    The capture kwarg landed on the rich profile alone. The no-LLM one still ran
+    the same projection and still deposited nothing, so `_rejoin_from` saw an
+    empty dict and the card rendered its "no rejoin geometry" idle on laps where
+    the projection HAD run. That is worse than an absent card: the copy claims
+    there is nothing to compute while the geometry is sitting one call away.
+
+    This is the same drift the rest of this file guards, one layer down. The
+    engine imports the orchestrator's functions so their BODIES cannot diverge,
+    and then re-drives the sequence twice, once per profile, by hand.
+
+    Static, like its siblings: the question is about the call site, and calling
+    either profile for real needs the weights and a race state.
+    """
+    from src.strategy.inference import engine, no_llm
+
+    for name, func in (("rich", engine._run_rich), ("no_llm", no_llm.run_no_llm_lap)):
+        mc_kwargs = kwargs_passed_by(func, "_run_mc_simulation")
+        assert mc_kwargs, f"{name} no longer calls _run_mc_simulation; this guard is dead"
+        assert "capture" in mc_kwargs, (
+            f"the {name} profile scores the candidates without opening the draw "
+            f"capture, so the rejoin readout has nothing to price the stop with"
+        )
+
+        outputs_kwargs = kwargs_passed_by(func, "_assemble_agent_outputs")
+        assert outputs_kwargs, f"{name} no longer calls _assemble_agent_outputs"
+        assert "rejoin" in outputs_kwargs, (
+            f"the {name} profile captured the draws and then dropped the readout "
+            f"on the floor before the surfaces could see it"
+        )


### PR DESCRIPTION
## What

The no-LLM profile now opens the same draw capture the rich one does, so the PIT EXIT card works there.

## Why

#1135 added the capture to `engine._run_rich` and stopped. `no_llm.run_no_llm_lap` runs the same `_run_mc_simulation` over the same rivals and deposited nothing, so `_rejoin_from` received an empty dict and the card fell to its idle branch.

That branch prints a reason, and the reason was **false**: it says "no rejoin geometry" while the geometry is one call away. An absent card would have been better.

## How

Three lines, mirroring the rich profile: a `mc_draws` dict, `capture=mc_draws` on the call, and `rejoin=_rejoin_from(mc_draws)` into `_assemble_agent_outputs`.

## Checks

Verified on the real path, not a fixture. Melbourne 2025 lap 23 for NOR through `run_no_llm_lap`, no LLM spend:

```
action: STAY_OUT
rivals on the lap: 16
pit_exit: slot=3 from_position=1 band=0
          ahead=VER -7.003s  behind=RUS +1.828s
```

Leading, and boxing there drops to P3 between the two. The published action is `STAY_OUT`, which is exactly the lap the card exists for and the reason it is framed rather than suppressed.

The guard joins the two anti-drift checks already in `tests/engine/test_engine_threads_every_argument.py`, which exist for this precise failure: the engine imports the orchestrator's layer functions so their bodies cannot diverge, then re-drives the sequence by hand, once per profile, and that is where an argument goes missing. Static like its siblings, so it needs neither weights nor a race state.

Watched RED against both halves of the bug: dropping `capture=`, and capturing the draws then not forwarding the readout.