### PR TITLE
test(pitwall): drop the radio line check that could not fail

### DIFF
--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -628,19 +628,20 @@ check(
   grid.exit.left === grid.tire.left && grid.exit.right <= grid.situation.left,
   "PIT EXIT holds the second, under TIRE",
 );
-// The line budget that makes one column survivable. A radio line over budget
-// does not clip: `.agent-line` wraps over a content-sized row, so the height
-// comes out of the charts above, and the failure would look like a chart bug.
-const radioLines = await page.evaluate(() =>
-  [...document.querySelectorAll(".slot-radio .agent-line")].map((el) => {
-    const lineHeight = parseFloat(getComputedStyle(el).lineHeight) || 14;
-    return Math.round(el.getBoundingClientRect().height / lineHeight);
-  }),
-);
-check(
-  radioLines.length > 0 && radioLines.every((lines) => lines === 1),
-  `every RADIO line sets on one line at one column (${radioLines.join(",")})`,
-);
+// **The radio line budget is NOT checkable here, and a check that pretended
+// otherwise sat in this spot.** It asserted every `.slot-radio .agent-line`
+// renders on one line, and removing the formatter's cap entirely left all 137
+// checks green: this file feeds `VIEW` straight to the bundle, so the radio
+// card's body is the literal `"a body line"` above and never passes through
+// `agent_formatters` at all. The smoke tests the RENDERER; the cap is a
+// producer-side property and belongs to
+// `tests/surfaces/test_pitwall_agents_view.py::test_no_radio_body_line_can_outgrow_the_card`,
+// which was watched RED against two compiling mutants.
+//
+// There IS a renderer-side property worth having and this is not it: row 2 is
+// `auto`, so a long line grows the band and shrinks the charts, and nothing in
+// the layout stops it. The formatter cap is the only defence today. Asserting
+// that here would be asserting a design decision this sprint did not take.
 check(
   grid.rag.left === grid.situation.left && grid.rag.top >= grid.radio.top,
   "and RAG closes the corner",


### PR DESCRIPTION
## What

Removes a check added in #1137 that asserted every RADIO body line renders on one line. It could not fail.

## Why

`smoke-agents.mjs` feeds `VIEW` straight to the bundle. The radio card's body is the literal `"a body line"` fixture at the top of the file and never passes through `agent_formatters`, so the smoke cannot see the formatter's cap at all.

Demonstrated rather than reasoned: with `_rcm_label`'s truncation dropped **and** `_message_room` returning a fixed 70, both halves of the budget gone, the smoke stayed at **137 checks green**.

Two things also made it weaker than it looked. The smoke drives one client, 1486x833, while the tight budget is at the 1226 px client the stylesheet itself measures; and the fixture line is eleven characters, nowhere near any cap.

## The property is still guarded

`tests/surfaces/test_pitwall_agents_view.py::test_no_radio_body_line_can_outgrow_the_card` feeds `format_radio` an RCM with a 200-character `event_type` and a radio with a long intent, and was watched RED against those same two mutants. The cap is a producer-side property and that is where it belongs.

## What is left in its place

A comment saying what the smoke can and cannot see here, and naming the renderer-side property that genuinely is missing: grid row 2 is `auto`, so a long line grows the band and shrinks the charts, and the layout has no defence of its own. The formatter cap is the only one today. Asserting that here would be asserting a design decision this sprint did not take, so it is written down rather than smuggled in.

## Checks

`smoke OK: 136 checks` (down one, and the one removed was noise), `smoke-data OK: 373`. The two layout checks added alongside it, that RADIO holds the first column alone and PIT EXIT the second under TIRE, are unaffected and do bite: they measure boxes the smoke actually controls.