### PR TITLE
test(eval): score the decision tier on every 2025 race instead of six

### DIFF
--- a/documents/eval_reports/decision_modes.json
+++ b/documents/eval_reports/decision_modes.json
@@ -1,12 +1,12 @@
 {
   "header": {
-    "harness_sha": "ea9c319",
-    "dataset": "data/raw laps, stratified 6-race subset (RAW, not featured)",
+    "harness_sha": "8d43342d",
+    "dataset": "data/raw laps, every 2025 race (RAW, not featured)",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-08-06T18:57:01+00:00",
+    "generated_at": "2026-08-30T16:34:12+00:00",
     "artifacts": {}
   },
   "status": "masked",
@@ -14,19 +14,31 @@
   "sampled_races": [
     {
       "year": 2025,
+      "race": "Austin"
+    },
+    {
+      "year": 2025,
+      "race": "Baku"
+    },
+    {
+      "year": 2025,
       "race": "Barcelona"
     },
     {
       "year": 2025,
-      "race": "Monaco"
+      "race": "Budapest"
     },
     {
       "year": 2025,
-      "race": "Silverstone"
+      "race": "Imola"
     },
     {
       "year": 2025,
-      "race": "Marina_Bay"
+      "race": "Jeddah"
+    },
+    {
+      "year": 2025,
+      "race": "Las_Vegas"
     },
     {
       "year": 2025,
@@ -34,28 +46,431 @@
     },
     {
       "year": 2025,
+      "race": "Marina_Bay"
+    },
+    {
+      "year": 2025,
+      "race": "Melbourne"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City"
+    },
+    {
+      "year": 2025,
+      "race": "Miami_Gardens"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal"
+    },
+    {
+      "year": 2025,
       "race": "Monza"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir"
+    },
+    {
+      "year": 2025,
+      "race": "Shanghai"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone"
+    },
+    {
+      "year": 2025,
+      "race": "Spa-Francorchamps"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg"
+    },
+    {
+      "year": 2025,
+      "race": "Suzuka"
+    },
+    {
+      "year": 2025,
+      "race": "São_Paulo"
+    },
+    {
+      "year": 2025,
+      "race": "Yas_Island"
+    },
+    {
+      "year": 2025,
+      "race": "Zandvoort"
     }
   ],
   "agreement": {
-    "sample_size": 66,
-    "eligible": 178,
-    "scored_share": 0.3707865168539326,
-    "races": 6,
-    "exact": 0.21212121212121213,
-    "within_one": 0.3787878787878788,
-    "within_two": 0.5151515151515151,
-    "mean_signed_error": -1.9696969696969697,
-    "mean_absolute_error": 2.4242424242424243
+    "sample_size": 204,
+    "eligible": 573,
+    "scored_share": 0.35602094240837695,
+    "races": 24,
+    "exact": 0.18627450980392157,
+    "within_one": 0.3431372549019608,
+    "within_two": 0.5,
+    "mean_signed_error": -2.2058823529411766,
+    "mean_absolute_error": 2.480392156862745
   },
   "buckets": {
     "closing_laps": 4,
-    "min_stint": 5,
-    "no_boundary_in_window": 31,
-    "no_call_in_window": 72,
-    "scored": 66
+    "min_stint": 16,
+    "no_boundary_in_window": 121,
+    "no_call_in_window": 224,
+    "opening_laps": 4,
+    "scored": 204
   },
   "verdicts": [
+    {
+      "year": 2025,
+      "race": "Austin",
+      "driver": "VER",
+      "actual_lap": 33,
+      "chosen_lap": 32,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Austin",
+      "driver": "GAS",
+      "actual_lap": 27,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Austin",
+      "driver": "ANT",
+      "actual_lap": 31,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Austin",
+      "driver": "ALO",
+      "actual_lap": 30,
+      "chosen_lap": 27,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Austin",
+      "driver": "LEC",
+      "actual_lap": 22,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Austin",
+      "driver": "STR",
+      "actual_lap": 28,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Austin",
+      "driver": "TSU",
+      "actual_lap": 29,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Austin",
+      "driver": "ALB",
+      "actual_lap": 36,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Austin",
+      "driver": "HUL",
+      "actual_lap": 33,
+      "chosen_lap": 32,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Austin",
+      "driver": "LAW",
+      "actual_lap": 30,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Austin",
+      "driver": "OCO",
+      "actual_lap": 24,
+      "chosen_lap": 20,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Austin",
+      "driver": "NOR",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Austin",
+      "driver": "COL",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Austin",
+      "driver": "HAM",
+      "actual_lap": 31,
+      "chosen_lap": 29,
+      "offset_laps": -2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Austin",
+      "driver": "BOR",
+      "actual_lap": 14,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Austin",
+      "driver": "BOR",
+      "actual_lap": 36,
+      "chosen_lap": 39,
+      "offset_laps": 3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Austin",
+      "driver": "HAD",
+      "actual_lap": 28,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Austin",
+      "driver": "RUS",
+      "actual_lap": 33,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Austin",
+      "driver": "PIA",
+      "actual_lap": 30,
+      "chosen_lap": 30,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Austin",
+      "driver": "BEA",
+      "actual_lap": 30,
+      "chosen_lap": 25,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Baku",
+      "driver": "VER",
+      "actual_lap": 40,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Baku",
+      "driver": "GAS",
+      "actual_lap": 35,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Baku",
+      "driver": "ANT",
+      "actual_lap": 18,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Baku",
+      "driver": "ALO",
+      "actual_lap": 21,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Baku",
+      "driver": "LEC",
+      "actual_lap": 19,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Baku",
+      "driver": "STR",
+      "actual_lap": 37,
+      "chosen_lap": 35,
+      "offset_laps": -2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Baku",
+      "driver": "TSU",
+      "actual_lap": 38,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Baku",
+      "driver": "ALB",
+      "actual_lap": 15,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Baku",
+      "driver": "HUL",
+      "actual_lap": 36,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Baku",
+      "driver": "LAW",
+      "actual_lap": 20,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Baku",
+      "driver": "NOR",
+      "actual_lap": 37,
+      "chosen_lap": 35,
+      "offset_laps": -2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Baku",
+      "driver": "COL",
+      "actual_lap": 16,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Baku",
+      "driver": "HAM",
+      "actual_lap": 36,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Baku",
+      "driver": "BOR",
+      "actual_lap": 26,
+      "chosen_lap": 21,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Baku",
+      "driver": "SAI",
+      "actual_lap": 27,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Baku",
+      "driver": "HAD",
+      "actual_lap": 29,
+      "chosen_lap": 28,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Baku",
+      "driver": "RUS",
+      "actual_lap": 39,
+      "chosen_lap": 39,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Baku",
+      "driver": "BEA",
+      "actual_lap": 28,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
     {
       "year": 2025,
       "race": "Barcelona",
@@ -427,6 +842,1554 @@
     },
     {
       "year": 2025,
+      "race": "Budapest",
+      "driver": "VER",
+      "actual_lap": 17,
+      "chosen_lap": 16,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "VER",
+      "actual_lap": 48,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "GAS",
+      "actual_lap": 32,
+      "chosen_lap": 31,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "ANT",
+      "actual_lap": 21,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "ALO",
+      "actual_lap": 39,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "LEC",
+      "actual_lap": 19,
+      "chosen_lap": 19,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "LEC",
+      "actual_lap": 40,
+      "chosen_lap": 40,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "STR",
+      "actual_lap": 36,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "TSU",
+      "actual_lap": 20,
+      "chosen_lap": 18,
+      "offset_laps": -2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "TSU",
+      "actual_lap": 37,
+      "chosen_lap": 34,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "ALB",
+      "actual_lap": 14,
+      "chosen_lap": 11,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "ALB",
+      "actual_lap": 38,
+      "chosen_lap": 34,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "HUL",
+      "actual_lap": 5,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "HUL",
+      "actual_lap": 41,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "LAW",
+      "actual_lap": 40,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "OCO",
+      "actual_lap": 14,
+      "chosen_lap": 11,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "NOR",
+      "actual_lap": 31,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "COL",
+      "actual_lap": 13,
+      "chosen_lap": 8,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "COL",
+      "actual_lap": 35,
+      "chosen_lap": 33,
+      "offset_laps": -2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "HAM",
+      "actual_lap": 42,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "BOR",
+      "actual_lap": 40,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "SAI",
+      "actual_lap": 15,
+      "chosen_lap": 12,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "SAI",
+      "actual_lap": 51,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "HAD",
+      "actual_lap": 33,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "RUS",
+      "actual_lap": 19,
+      "chosen_lap": 15,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "RUS",
+      "actual_lap": 43,
+      "chosen_lap": 43,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "PIA",
+      "actual_lap": 18,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "PIA",
+      "actual_lap": 45,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "BEA",
+      "actual_lap": 30,
+      "chosen_lap": 28,
+      "offset_laps": -2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Budapest",
+      "driver": "BEA",
+      "actual_lap": 48,
+      "chosen_lap": 48,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Imola",
+      "driver": "GAS",
+      "actual_lap": 9,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Imola",
+      "driver": "ALO",
+      "actual_lap": 12,
+      "chosen_lap": 12,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Imola",
+      "driver": "LEC",
+      "actual_lap": 10,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Imola",
+      "driver": "STR",
+      "actual_lap": 14,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Imola",
+      "driver": "LAW",
+      "actual_lap": 10,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Imola",
+      "driver": "OCO",
+      "actual_lap": 1,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "opening_laps"
+    },
+    {
+      "year": 2025,
+      "race": "Imola",
+      "driver": "COL",
+      "actual_lap": 22,
+      "chosen_lap": 18,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Imola",
+      "driver": "BOR",
+      "actual_lap": 12,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Imola",
+      "driver": "SAI",
+      "actual_lap": 11,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Imola",
+      "driver": "RUS",
+      "actual_lap": 11,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Imola",
+      "driver": "PIA",
+      "actual_lap": 13,
+      "chosen_lap": 10,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Jeddah",
+      "driver": "VER",
+      "actual_lap": 21,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Jeddah",
+      "driver": "ANT",
+      "actual_lap": 19,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Jeddah",
+      "driver": "ALO",
+      "actual_lap": 19,
+      "chosen_lap": 18,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Jeddah",
+      "driver": "LEC",
+      "actual_lap": 29,
+      "chosen_lap": 24,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Jeddah",
+      "driver": "STR",
+      "actual_lap": 39,
+      "chosen_lap": 35,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Jeddah",
+      "driver": "ALB",
+      "actual_lap": 22,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Jeddah",
+      "driver": "HUL",
+      "actual_lap": 33,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Jeddah",
+      "driver": "LAW",
+      "actual_lap": 20,
+      "chosen_lap": 19,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Jeddah",
+      "driver": "NOR",
+      "actual_lap": 34,
+      "chosen_lap": 30,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Jeddah",
+      "driver": "HAM",
+      "actual_lap": 23,
+      "chosen_lap": 19,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Jeddah",
+      "driver": "SAI",
+      "actual_lap": 21,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Jeddah",
+      "driver": "HAD",
+      "actual_lap": 34,
+      "chosen_lap": 30,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Jeddah",
+      "driver": "RUS",
+      "actual_lap": 20,
+      "chosen_lap": 20,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Jeddah",
+      "driver": "DOO",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Jeddah",
+      "driver": "PIA",
+      "actual_lap": 19,
+      "chosen_lap": 14,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Jeddah",
+      "driver": "BEA",
+      "actual_lap": 18,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Las_Vegas",
+      "driver": "VER",
+      "actual_lap": 25,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Las_Vegas",
+      "driver": "LEC",
+      "actual_lap": 24,
+      "chosen_lap": 21,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Las_Vegas",
+      "driver": "TSU",
+      "actual_lap": 27,
+      "chosen_lap": 25,
+      "offset_laps": -2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Las_Vegas",
+      "driver": "ALB",
+      "actual_lap": 13,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Las_Vegas",
+      "driver": "ALB",
+      "actual_lap": 34,
+      "chosen_lap": 29,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Las_Vegas",
+      "driver": "ALB",
+      "actual_lap": 35,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Las_Vegas",
+      "driver": "HUL",
+      "actual_lap": 30,
+      "chosen_lap": 28,
+      "offset_laps": -2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Las_Vegas",
+      "driver": "LAW",
+      "actual_lap": 28,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Las_Vegas",
+      "driver": "OCO",
+      "actual_lap": 27,
+      "chosen_lap": 22,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Las_Vegas",
+      "driver": "NOR",
+      "actual_lap": 22,
+      "chosen_lap": 21,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Las_Vegas",
+      "driver": "COL",
+      "actual_lap": 25,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Las_Vegas",
+      "driver": "HAM",
+      "actual_lap": 29,
+      "chosen_lap": 24,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Las_Vegas",
+      "driver": "SAI",
+      "actual_lap": 22,
+      "chosen_lap": 21,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Las_Vegas",
+      "driver": "HAD",
+      "actual_lap": 20,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Las_Vegas",
+      "driver": "RUS",
+      "actual_lap": 17,
+      "chosen_lap": 17,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Las_Vegas",
+      "driver": "PIA",
+      "actual_lap": 21,
+      "chosen_lap": 20,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Las_Vegas",
+      "driver": "BEA",
+      "actual_lap": 17,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "VER",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "GAS",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "ANT",
+      "actual_lap": 32,
+      "chosen_lap": 30,
+      "offset_laps": -2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "ALO",
+      "actual_lap": 32,
+      "chosen_lap": 32,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "LEC",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "STR",
+      "actual_lap": 24,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "STR",
+      "actual_lap": 49,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "STR",
+      "actual_lap": 55,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "closing_laps"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "TSU",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "ALB",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "LAW",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "OCO",
+      "actual_lap": 34,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "NOR",
+      "actual_lap": 25,
+      "chosen_lap": 25,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "NOR",
+      "actual_lap": 44,
+      "chosen_lap": 44,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "COL",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "HAM",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "BOR",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "SAI",
+      "actual_lap": 32,
+      "chosen_lap": 32,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "HAD",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "HAD",
+      "actual_lap": 55,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "closing_laps"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "RUS",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "PIA",
+      "actual_lap": 24,
+      "chosen_lap": 24,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "PIA",
+      "actual_lap": 42,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "BEA",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "BEA",
+      "actual_lap": 40,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "BEA",
+      "actual_lap": 41,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "VER",
+      "actual_lap": 19,
+      "chosen_lap": 19,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "GAS",
+      "actual_lap": 24,
+      "chosen_lap": 19,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "GAS",
+      "actual_lap": 51,
+      "chosen_lap": 53,
+      "offset_laps": 2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "ANT",
+      "actual_lap": 25,
+      "chosen_lap": 25,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "ALO",
+      "actual_lap": 27,
+      "chosen_lap": 26,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "LEC",
+      "actual_lap": 21,
+      "chosen_lap": 16,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "STR",
+      "actual_lap": 38,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "TSU",
+      "actual_lap": 13,
+      "chosen_lap": 13,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "ALB",
+      "actual_lap": 42,
+      "chosen_lap": 45,
+      "offset_laps": 3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "HUL",
+      "actual_lap": 25,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "HUL",
+      "actual_lap": 44,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "LAW",
+      "actual_lap": 48,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "OCO",
+      "actual_lap": 30,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "NOR",
+      "actual_lap": 26,
+      "chosen_lap": 22,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "COL",
+      "actual_lap": 14,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "HAM",
+      "actual_lap": 24,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "HAM",
+      "actual_lap": 46,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "BOR",
+      "actual_lap": 13,
+      "chosen_lap": 12,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "SAI",
+      "actual_lap": 50,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "HAD",
+      "actual_lap": 20,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "RUS",
+      "actual_lap": 25,
+      "chosen_lap": 20,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "PIA",
+      "actual_lap": 27,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "BEA",
+      "actual_lap": 23,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Melbourne",
+      "driver": "ANT",
+      "actual_lap": 44,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Melbourne",
+      "driver": "STR",
+      "actual_lap": 44,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Melbourne",
+      "driver": "ALB",
+      "actual_lap": 44,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Melbourne",
+      "driver": "HUL",
+      "actual_lap": 44,
+      "chosen_lap": 40,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Melbourne",
+      "driver": "NOR",
+      "actual_lap": 44,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Melbourne",
+      "driver": "BOR",
+      "actual_lap": 44,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Melbourne",
+      "driver": "RUS",
+      "actual_lap": 44,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Melbourne",
+      "driver": "PIA",
+      "actual_lap": 44,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Melbourne",
+      "driver": "BEA",
+      "actual_lap": 44,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "VER",
+      "actual_lap": 37,
+      "chosen_lap": 33,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "GAS",
+      "actual_lap": 33,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "ANT",
+      "actual_lap": 22,
+      "chosen_lap": 22,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "ANT",
+      "actual_lap": 47,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "ALO",
+      "actual_lap": 20,
+      "chosen_lap": 16,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "ALO",
+      "actual_lap": 34,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "LEC",
+      "actual_lap": 31,
+      "chosen_lap": 29,
+      "offset_laps": -2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "STR",
+      "actual_lap": 26,
+      "chosen_lap": 25,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "STR",
+      "actual_lap": 43,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "TSU",
+      "actual_lap": 36,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "ALB",
+      "actual_lap": 41,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "HUL",
+      "actual_lap": 25,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "LAW",
+      "actual_lap": 2,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "opening_laps"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "LAW",
+      "actual_lap": 5,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "OCO",
+      "actual_lap": 27,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "NOR",
+      "actual_lap": 34,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "COL",
+      "actual_lap": 48,
+      "chosen_lap": 43,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "HAM",
+      "actual_lap": 23,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "HAM",
+      "actual_lap": 47,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "BOR",
+      "actual_lap": 37,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "SAI",
+      "actual_lap": 17,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "SAI",
+      "actual_lap": 46,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "SAI",
+      "actual_lap": 56,
+      "chosen_lap": 61,
+      "offset_laps": 5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "HAD",
+      "actual_lap": 34,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "RUS",
+      "actual_lap": 25,
+      "chosen_lap": 21,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "RUS",
+      "actual_lap": 48,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "PIA",
+      "actual_lap": 24,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "PIA",
+      "actual_lap": 47,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "BEA",
+      "actual_lap": 24,
+      "chosen_lap": 24,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Mexico_City",
+      "driver": "BEA",
+      "actual_lap": 48,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Miami_Gardens",
+      "driver": "VER",
+      "actual_lap": 26,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Miami_Gardens",
+      "driver": "ANT",
+      "actual_lap": 25,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Miami_Gardens",
+      "driver": "STR",
+      "actual_lap": 20,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Miami_Gardens",
+      "driver": "ALB",
+      "actual_lap": 26,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Miami_Gardens",
+      "driver": "HUL",
+      "actual_lap": 36,
+      "chosen_lap": 33,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Miami_Gardens",
+      "driver": "LAW",
+      "actual_lap": 36,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Miami_Gardens",
+      "driver": "OCO",
+      "actual_lap": 23,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Miami_Gardens",
+      "driver": "BOR",
+      "actual_lap": 19,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Miami_Gardens",
+      "driver": "SAI",
+      "actual_lap": 25,
+      "chosen_lap": 25,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Miami_Gardens",
+      "driver": "HAD",
+      "actual_lap": 22,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
       "race": "Monaco",
       "driver": "VER",
       "actual_lap": 28,
@@ -760,6 +2723,951 @@
     },
     {
       "year": 2025,
+      "race": "Montréal",
+      "driver": "VER",
+      "actual_lap": 12,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "VER",
+      "actual_lap": 37,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "GAS",
+      "actual_lap": 53,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "ANT",
+      "actual_lap": 14,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "ANT",
+      "actual_lap": 38,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "ALO",
+      "actual_lap": 15,
+      "chosen_lap": 11,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "ALO",
+      "actual_lap": 50,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "LEC",
+      "actual_lap": 28,
+      "chosen_lap": 24,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "LEC",
+      "actual_lap": 53,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "STR",
+      "actual_lap": 24,
+      "chosen_lap": 23,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "STR",
+      "actual_lap": 51,
+      "chosen_lap": 47,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "TSU",
+      "actual_lap": 56,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "ALB",
+      "actual_lap": 23,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "HUL",
+      "actual_lap": 19,
+      "chosen_lap": 18,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "LAW",
+      "actual_lap": 38,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "LAW",
+      "actual_lap": 54,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "OCO",
+      "actual_lap": 57,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "NOR",
+      "actual_lap": 29,
+      "chosen_lap": 25,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "NOR",
+      "actual_lap": 47,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "COL",
+      "actual_lap": 14,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "HAM",
+      "actual_lap": 15,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "HAM",
+      "actual_lap": 45,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "BOR",
+      "actual_lap": 49,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "SAI",
+      "actual_lap": 57,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "HAD",
+      "actual_lap": 13,
+      "chosen_lap": 12,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "RUS",
+      "actual_lap": 13,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "RUS",
+      "actual_lap": 42,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "PIA",
+      "actual_lap": 16,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "PIA",
+      "actual_lap": 45,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Montréal",
+      "driver": "BEA",
+      "actual_lap": 18,
+      "chosen_lap": 18,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "VER",
+      "actual_lap": 37,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "GAS",
+      "actual_lap": 49,
+      "chosen_lap": 45,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "ANT",
+      "actual_lap": 28,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "ALO",
+      "actual_lap": 20,
+      "chosen_lap": 15,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "ALO",
+      "actual_lap": 24,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "LEC",
+      "actual_lap": 33,
+      "chosen_lap": 33,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "STR",
+      "actual_lap": 49,
+      "chosen_lap": 51,
+      "offset_laps": 2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "TSU",
+      "actual_lap": 19,
+      "chosen_lap": 18,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "ALB",
+      "actual_lap": 41,
+      "chosen_lap": 36,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "LAW",
+      "actual_lap": 9,
+      "chosen_lap": 9,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "OCO",
+      "actual_lap": 51,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "closing_laps"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "NOR",
+      "actual_lap": 46,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "COL",
+      "actual_lap": 33,
+      "chosen_lap": 28,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "HAM",
+      "actual_lap": 38,
+      "chosen_lap": 33,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "BOR",
+      "actual_lap": 20,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "SAI",
+      "actual_lap": 30,
+      "chosen_lap": 27,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "HAD",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "RUS",
+      "actual_lap": 27,
+      "chosen_lap": 27,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "PIA",
+      "actual_lap": 45,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "BEA",
+      "actual_lap": 18,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "VER",
+      "actual_lap": 10,
+      "chosen_lap": 8,
+      "offset_laps": -2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "VER",
+      "actual_lap": 26,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "GAS",
+      "actual_lap": 10,
+      "chosen_lap": 6,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "GAS",
+      "actual_lap": 28,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "ANT",
+      "actual_lap": 12,
+      "chosen_lap": 9,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "ANT",
+      "actual_lap": 27,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "ALO",
+      "actual_lap": 16,
+      "chosen_lap": 11,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "LEC",
+      "actual_lap": 17,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "STR",
+      "actual_lap": 12,
+      "chosen_lap": 8,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "TSU",
+      "actual_lap": 11,
+      "chosen_lap": 8,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "ALB",
+      "actual_lap": 16,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "HUL",
+      "actual_lap": 5,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "HUL",
+      "actual_lap": 27,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "LAW",
+      "actual_lap": 14,
+      "chosen_lap": 11,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "OCO",
+      "actual_lap": 8,
+      "chosen_lap": 6,
+      "offset_laps": -2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "OCO",
+      "actual_lap": 27,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "NOR",
+      "actual_lap": 10,
+      "chosen_lap": 8,
+      "offset_laps": -2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "HAM",
+      "actual_lap": 17,
+      "chosen_lap": 15,
+      "offset_laps": -2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "BOR",
+      "actual_lap": 13,
+      "chosen_lap": 9,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "SAI",
+      "actual_lap": 14,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "SAI",
+      "actual_lap": 44,
+      "chosen_lap": 44,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "SAI",
+      "actual_lap": 45,
+      "chosen_lap": 44,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "HAD",
+      "actual_lap": 6,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "HAD",
+      "actual_lap": 28,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "RUS",
+      "actual_lap": 13,
+      "chosen_lap": 8,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "DOO",
+      "actual_lap": 9,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "DOO",
+      "actual_lap": 28,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "PIA",
+      "actual_lap": 14,
+      "chosen_lap": 12,
+      "offset_laps": -2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Sakhir",
+      "driver": "BEA",
+      "actual_lap": 14,
+      "chosen_lap": 9,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Shanghai",
+      "driver": "VER",
+      "actual_lap": 13,
+      "chosen_lap": 8,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Shanghai",
+      "driver": "GAS",
+      "actual_lap": 10,
+      "chosen_lap": 7,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Shanghai",
+      "driver": "ANT",
+      "actual_lap": 12,
+      "chosen_lap": 7,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Shanghai",
+      "driver": "ALO",
+      "actual_lap": 4,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "opening_laps"
+    },
+    {
+      "year": 2025,
+      "race": "Shanghai",
+      "driver": "LEC",
+      "actual_lap": 15,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Shanghai",
+      "driver": "STR",
+      "actual_lap": 36,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Shanghai",
+      "driver": "TSU",
+      "actual_lap": 11,
+      "chosen_lap": 8,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Shanghai",
+      "driver": "TSU",
+      "actual_lap": 35,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Shanghai",
+      "driver": "TSU",
+      "actual_lap": 46,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Shanghai",
+      "driver": "ALB",
+      "actual_lap": 20,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Shanghai",
+      "driver": "HUL",
+      "actual_lap": 20,
+      "chosen_lap": 18,
+      "offset_laps": -2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Shanghai",
+      "driver": "LAW",
+      "actual_lap": 18,
+      "chosen_lap": 13,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Shanghai",
+      "driver": "LAW",
+      "actual_lap": 30,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Shanghai",
+      "driver": "OCO",
+      "actual_lap": 11,
+      "chosen_lap": 8,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Shanghai",
+      "driver": "NOR",
+      "actual_lap": 15,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Shanghai",
+      "driver": "HAM",
+      "actual_lap": 13,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Shanghai",
+      "driver": "HAM",
+      "actual_lap": 37,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Shanghai",
+      "driver": "BOR",
+      "actual_lap": 1,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "opening_laps"
+    },
+    {
+      "year": 2025,
+      "race": "Shanghai",
+      "driver": "BOR",
+      "actual_lap": 26,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Shanghai",
+      "driver": "SAI",
+      "actual_lap": 17,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Shanghai",
+      "driver": "HAD",
+      "actual_lap": 12,
+      "chosen_lap": 8,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Shanghai",
+      "driver": "HAD",
+      "actual_lap": 33,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Shanghai",
+      "driver": "RUS",
+      "actual_lap": 14,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Shanghai",
+      "driver": "DOO",
+      "actual_lap": 11,
+      "chosen_lap": 7,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Shanghai",
+      "driver": "PIA",
+      "actual_lap": 14,
+      "chosen_lap": 14,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Shanghai",
+      "driver": "BEA",
+      "actual_lap": 26,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
       "race": "Silverstone",
       "driver": "VER",
       "actual_lap": 11,
@@ -1039,178 +3947,205 @@
     },
     {
       "year": 2025,
-      "race": "Marina_Bay",
+      "race": "Spa-Francorchamps",
       "driver": "VER",
-      "actual_lap": 19,
-      "chosen_lap": 19,
-      "offset_laps": 0,
-      "bucket": "scored"
-    },
-    {
-      "year": 2025,
-      "race": "Marina_Bay",
-      "driver": "GAS",
-      "actual_lap": 24,
-      "chosen_lap": 19,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2025,
-      "race": "Marina_Bay",
-      "driver": "GAS",
-      "actual_lap": 51,
-      "chosen_lap": 53,
-      "offset_laps": 2,
-      "bucket": "scored"
-    },
-    {
-      "year": 2025,
-      "race": "Marina_Bay",
-      "driver": "ANT",
-      "actual_lap": 25,
-      "chosen_lap": 25,
-      "offset_laps": 0,
-      "bucket": "scored"
-    },
-    {
-      "year": 2025,
-      "race": "Marina_Bay",
-      "driver": "ALO",
-      "actual_lap": 27,
-      "chosen_lap": 26,
-      "offset_laps": -1,
-      "bucket": "scored"
-    },
-    {
-      "year": 2025,
-      "race": "Marina_Bay",
-      "driver": "LEC",
-      "actual_lap": 21,
-      "chosen_lap": 16,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2025,
-      "race": "Marina_Bay",
-      "driver": "STR",
-      "actual_lap": 38,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_boundary_in_window"
-    },
-    {
-      "year": 2025,
-      "race": "Marina_Bay",
-      "driver": "TSU",
-      "actual_lap": 13,
-      "chosen_lap": 13,
-      "offset_laps": 0,
-      "bucket": "scored"
-    },
-    {
-      "year": 2025,
-      "race": "Marina_Bay",
-      "driver": "ALB",
-      "actual_lap": 42,
-      "chosen_lap": 45,
-      "offset_laps": 3,
-      "bucket": "scored"
-    },
-    {
-      "year": 2025,
-      "race": "Marina_Bay",
-      "driver": "HUL",
-      "actual_lap": 25,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_boundary_in_window"
-    },
-    {
-      "year": 2025,
-      "race": "Marina_Bay",
-      "driver": "HUL",
-      "actual_lap": 44,
+      "actual_lap": 12,
       "chosen_lap": null,
       "offset_laps": null,
       "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
-      "race": "Marina_Bay",
-      "driver": "LAW",
-      "actual_lap": 48,
+      "race": "Spa-Francorchamps",
+      "driver": "GAS",
+      "actual_lap": 11,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "no_boundary_in_window"
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
-      "race": "Marina_Bay",
-      "driver": "OCO",
+      "race": "Spa-Francorchamps",
+      "driver": "ANT",
+      "actual_lap": 12,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spa-Francorchamps",
+      "driver": "ANT",
       "actual_lap": 30,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "no_boundary_in_window"
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
-      "race": "Marina_Bay",
-      "driver": "NOR",
-      "actual_lap": 26,
-      "chosen_lap": 22,
-      "offset_laps": -4,
+      "race": "Spa-Francorchamps",
+      "driver": "ALO",
+      "actual_lap": 11,
+      "chosen_lap": 6,
+      "offset_laps": -5,
       "bucket": "scored"
     },
     {
       "year": 2025,
-      "race": "Marina_Bay",
-      "driver": "COL",
-      "actual_lap": 14,
+      "race": "Spa-Francorchamps",
+      "driver": "ALO",
+      "actual_lap": 29,
       "chosen_lap": null,
       "offset_laps": null,
       "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
-      "race": "Marina_Bay",
-      "driver": "HAM",
-      "actual_lap": 24,
+      "race": "Spa-Francorchamps",
+      "driver": "LEC",
+      "actual_lap": 12,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "no_boundary_in_window"
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
-      "race": "Marina_Bay",
-      "driver": "HAM",
-      "actual_lap": 46,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_boundary_in_window"
-    },
-    {
-      "year": 2025,
-      "race": "Marina_Bay",
-      "driver": "BOR",
-      "actual_lap": 13,
-      "chosen_lap": 12,
-      "offset_laps": -1,
+      "race": "Spa-Francorchamps",
+      "driver": "STR",
+      "actual_lap": 12,
+      "chosen_lap": 10,
+      "offset_laps": -2,
       "bucket": "scored"
     },
     {
       "year": 2025,
-      "race": "Marina_Bay",
-      "driver": "SAI",
-      "actual_lap": 50,
+      "race": "Spa-Francorchamps",
+      "driver": "TSU",
+      "actual_lap": 13,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "no_boundary_in_window"
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
-      "race": "Marina_Bay",
+      "race": "Spa-Francorchamps",
+      "driver": "ALB",
+      "actual_lap": 12,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spa-Francorchamps",
+      "driver": "HUL",
+      "actual_lap": 11,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spa-Francorchamps",
+      "driver": "HUL",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spa-Francorchamps",
+      "driver": "LAW",
+      "actual_lap": 12,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spa-Francorchamps",
+      "driver": "OCO",
+      "actual_lap": 13,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spa-Francorchamps",
+      "driver": "NOR",
+      "actual_lap": 13,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spa-Francorchamps",
+      "driver": "COL",
+      "actual_lap": 12,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spa-Francorchamps",
+      "driver": "COL",
+      "actual_lap": 28,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spa-Francorchamps",
+      "driver": "HAM",
+      "actual_lap": 11,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spa-Francorchamps",
+      "driver": "BOR",
+      "actual_lap": 12,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spa-Francorchamps",
+      "driver": "SAI",
+      "actual_lap": 12,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spa-Francorchamps",
+      "driver": "SAI",
+      "actual_lap": 26,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spa-Francorchamps",
+      "driver": "HAD",
+      "actual_lap": 13,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spa-Francorchamps",
       "driver": "HAD",
       "actual_lap": 20,
       "chosen_lap": null,
@@ -1219,25 +4154,502 @@
     },
     {
       "year": 2025,
-      "race": "Marina_Bay",
+      "race": "Spa-Francorchamps",
       "driver": "RUS",
+      "actual_lap": 12,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spa-Francorchamps",
+      "driver": "PIA",
+      "actual_lap": 12,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spa-Francorchamps",
+      "driver": "BEA",
+      "actual_lap": 12,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "GAS",
+      "actual_lap": 12,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "GAS",
+      "actual_lap": 38,
+      "chosen_lap": 35,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "ALO",
+      "actual_lap": 33,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "LEC",
       "actual_lap": 25,
-      "chosen_lap": 20,
+      "chosen_lap": 25,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "LEC",
+      "actual_lap": 49,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "STR",
+      "actual_lap": 26,
+      "chosen_lap": 25,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "STR",
+      "actual_lap": 53,
+      "chosen_lap": 48,
       "offset_laps": -5,
       "bucket": "scored"
     },
     {
       "year": 2025,
-      "race": "Marina_Bay",
-      "driver": "PIA",
-      "actual_lap": 27,
+      "race": "Spielberg",
+      "driver": "TSU",
+      "actual_lap": 18,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "TSU",
+      "actual_lap": 30,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "TSU",
+      "actual_lap": 60,
       "chosen_lap": null,
       "offset_laps": null,
       "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
-      "race": "Marina_Bay",
+      "race": "Spielberg",
+      "driver": "ALB",
+      "actual_lap": 13,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "ALB",
+      "actual_lap": 15,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "HUL",
+      "actual_lap": 12,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "HUL",
+      "actual_lap": 42,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "LAW",
+      "actual_lap": 32,
+      "chosen_lap": 29,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "OCO",
+      "actual_lap": 19,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "OCO",
+      "actual_lap": 50,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "NOR",
+      "actual_lap": 20,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "NOR",
+      "actual_lap": 52,
+      "chosen_lap": 52,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "COL",
+      "actual_lap": 13,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "COL",
+      "actual_lap": 39,
+      "chosen_lap": 39,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "HAM",
+      "actual_lap": 26,
+      "chosen_lap": 26,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "HAM",
+      "actual_lap": 50,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "BOR",
+      "actual_lap": 21,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "BOR",
+      "actual_lap": 49,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "HAD",
+      "actual_lap": 28,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "RUS",
+      "actual_lap": 18,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "RUS",
+      "actual_lap": 45,
+      "chosen_lap": 41,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "PIA",
+      "actual_lap": 24,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "PIA",
+      "actual_lap": 53,
+      "chosen_lap": 49,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "BEA",
+      "actual_lap": 11,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Spielberg",
+      "driver": "BEA",
+      "actual_lap": 39,
+      "chosen_lap": 39,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Suzuka",
+      "driver": "VER",
+      "actual_lap": 21,
+      "chosen_lap": 19,
+      "offset_laps": -2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Suzuka",
+      "driver": "GAS",
+      "actual_lap": 24,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Suzuka",
+      "driver": "ANT",
+      "actual_lap": 31,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Suzuka",
+      "driver": "ALO",
+      "actual_lap": 24,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Suzuka",
+      "driver": "LEC",
+      "actual_lap": 21,
+      "chosen_lap": 18,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Suzuka",
+      "driver": "STR",
+      "actual_lap": 9,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Suzuka",
+      "driver": "STR",
+      "actual_lap": 30,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Suzuka",
+      "driver": "TSU",
+      "actual_lap": 23,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Suzuka",
+      "driver": "ALB",
+      "actual_lap": 24,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Suzuka",
+      "driver": "HUL",
+      "actual_lap": 22,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Suzuka",
+      "driver": "LAW",
+      "actual_lap": 33,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Suzuka",
+      "driver": "OCO",
+      "actual_lap": 32,
+      "chosen_lap": 28,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Suzuka",
+      "driver": "NOR",
+      "actual_lap": 21,
+      "chosen_lap": 18,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Suzuka",
+      "driver": "HAM",
+      "actual_lap": 30,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Suzuka",
+      "driver": "BOR",
+      "actual_lap": 31,
+      "chosen_lap": 26,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Suzuka",
+      "driver": "SAI",
+      "actual_lap": 33,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Suzuka",
+      "driver": "HAD",
+      "actual_lap": 25,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Suzuka",
+      "driver": "RUS",
+      "actual_lap": 19,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Suzuka",
+      "driver": "DOO",
+      "actual_lap": 15,
+      "chosen_lap": 12,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Suzuka",
+      "driver": "PIA",
+      "actual_lap": 20,
+      "chosen_lap": 18,
+      "offset_laps": -2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Suzuka",
       "driver": "BEA",
       "actual_lap": 23,
       "chosen_lap": null,
@@ -1246,107 +4658,8 @@
     },
     {
       "year": 2025,
-      "race": "Lusail",
+      "race": "São_Paulo",
       "driver": "VER",
-      "actual_lap": 32,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2025,
-      "race": "Lusail",
-      "driver": "GAS",
-      "actual_lap": 32,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2025,
-      "race": "Lusail",
-      "driver": "ANT",
-      "actual_lap": 32,
-      "chosen_lap": 30,
-      "offset_laps": -2,
-      "bucket": "scored"
-    },
-    {
-      "year": 2025,
-      "race": "Lusail",
-      "driver": "ALO",
-      "actual_lap": 32,
-      "chosen_lap": 32,
-      "offset_laps": 0,
-      "bucket": "scored"
-    },
-    {
-      "year": 2025,
-      "race": "Lusail",
-      "driver": "LEC",
-      "actual_lap": 32,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2025,
-      "race": "Lusail",
-      "driver": "STR",
-      "actual_lap": 24,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_boundary_in_window"
-    },
-    {
-      "year": 2025,
-      "race": "Lusail",
-      "driver": "STR",
-      "actual_lap": 49,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_boundary_in_window"
-    },
-    {
-      "year": 2025,
-      "race": "Lusail",
-      "driver": "STR",
-      "actual_lap": 55,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "closing_laps"
-    },
-    {
-      "year": 2025,
-      "race": "Lusail",
-      "driver": "TSU",
-      "actual_lap": 32,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_boundary_in_window"
-    },
-    {
-      "year": 2025,
-      "race": "Lusail",
-      "driver": "ALB",
-      "actual_lap": 32,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2025,
-      "race": "Lusail",
-      "driver": "LAW",
-      "actual_lap": 32,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2025,
-      "race": "Lusail",
-      "driver": "OCO",
       "actual_lap": 34,
       "chosen_lap": null,
       "offset_laps": null,
@@ -1354,53 +4667,197 @@
     },
     {
       "year": 2025,
-      "race": "Lusail",
-      "driver": "NOR",
-      "actual_lap": 25,
-      "chosen_lap": 25,
-      "offset_laps": 0,
-      "bucket": "scored"
-    },
-    {
-      "year": 2025,
-      "race": "Lusail",
-      "driver": "NOR",
-      "actual_lap": 44,
-      "chosen_lap": 44,
-      "offset_laps": 0,
-      "bucket": "scored"
-    },
-    {
-      "year": 2025,
-      "race": "Lusail",
-      "driver": "COL",
-      "actual_lap": 32,
+      "race": "São_Paulo",
+      "driver": "VER",
+      "actual_lap": 54,
       "chosen_lap": null,
       "offset_laps": null,
       "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
-      "race": "Lusail",
-      "driver": "HAM",
-      "actual_lap": 32,
+      "race": "São_Paulo",
+      "driver": "GAS",
+      "actual_lap": 18,
       "chosen_lap": null,
       "offset_laps": null,
       "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
-      "race": "Lusail",
-      "driver": "BOR",
-      "actual_lap": 32,
+      "race": "São_Paulo",
+      "driver": "GAS",
+      "actual_lap": 39,
+      "chosen_lap": 41,
+      "offset_laps": 2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "São_Paulo",
+      "driver": "ANT",
+      "actual_lap": 21,
+      "chosen_lap": 18,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "São_Paulo",
+      "driver": "ANT",
+      "actual_lap": 47,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "São_Paulo",
+      "driver": "ALO",
+      "actual_lap": 28,
+      "chosen_lap": 28,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "São_Paulo",
+      "driver": "ALO",
+      "actual_lap": 46,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "São_Paulo",
+      "driver": "STR",
+      "actual_lap": 29,
+      "chosen_lap": 30,
+      "offset_laps": 1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "São_Paulo",
+      "driver": "STR",
+      "actual_lap": 54,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "São_Paulo",
+      "driver": "TSU",
+      "actual_lap": 24,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "São_Paulo",
+      "driver": "TSU",
+      "actual_lap": 47,
       "chosen_lap": null,
       "offset_laps": null,
       "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
-      "race": "Lusail",
-      "driver": "SAI",
+      "race": "São_Paulo",
+      "driver": "ALB",
+      "actual_lap": 35,
+      "chosen_lap": 30,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "São_Paulo",
+      "driver": "ALB",
+      "actual_lap": 55,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "São_Paulo",
+      "driver": "HUL",
+      "actual_lap": 36,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "São_Paulo",
+      "driver": "LAW",
+      "actual_lap": 19,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "São_Paulo",
+      "driver": "OCO",
+      "actual_lap": 47,
+      "chosen_lap": 47,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "São_Paulo",
+      "driver": "NOR",
+      "actual_lap": 30,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "São_Paulo",
+      "driver": "NOR",
+      "actual_lap": 50,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "São_Paulo",
+      "driver": "COL",
+      "actual_lap": 29,
+      "chosen_lap": 27,
+      "offset_laps": -2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "São_Paulo",
+      "driver": "COL",
+      "actual_lap": 43,
+      "chosen_lap": 42,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "São_Paulo",
+      "driver": "HAM",
+      "actual_lap": 14,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "São_Paulo",
+      "driver": "HAM",
       "actual_lap": 32,
       "chosen_lap": 32,
       "offset_laps": 0,
@@ -1408,44 +4865,98 @@
     },
     {
       "year": 2025,
-      "race": "Lusail",
-      "driver": "HAD",
-      "actual_lap": 32,
+      "race": "São_Paulo",
+      "driver": "HAM",
+      "actual_lap": 37,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "São_Paulo",
+      "driver": "SAI",
+      "actual_lap": 17,
       "chosen_lap": null,
       "offset_laps": null,
       "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
-      "race": "Lusail",
-      "driver": "HAD",
-      "actual_lap": 55,
+      "race": "São_Paulo",
+      "driver": "SAI",
+      "actual_lap": 38,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "closing_laps"
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
-      "race": "Lusail",
+      "race": "São_Paulo",
+      "driver": "HAD",
+      "actual_lap": 18,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "São_Paulo",
+      "driver": "HAD",
+      "actual_lap": 37,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "São_Paulo",
       "driver": "RUS",
-      "actual_lap": 32,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2025,
-      "race": "Lusail",
-      "driver": "PIA",
-      "actual_lap": 24,
-      "chosen_lap": 24,
-      "offset_laps": 0,
+      "actual_lap": 34,
+      "chosen_lap": 32,
+      "offset_laps": -2,
       "bucket": "scored"
     },
     {
       "year": 2025,
-      "race": "Lusail",
+      "race": "São_Paulo",
+      "driver": "RUS",
+      "actual_lap": 48,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "São_Paulo",
       "driver": "PIA",
+      "actual_lap": 38,
+      "chosen_lap": 34,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "São_Paulo",
+      "driver": "PIA",
+      "actual_lap": 51,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "São_Paulo",
+      "driver": "BEA",
+      "actual_lap": 17,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "São_Paulo",
+      "driver": "BEA",
       "actual_lap": 42,
       "chosen_lap": null,
       "offset_laps": null,
@@ -1453,17 +4964,152 @@
     },
     {
       "year": 2025,
-      "race": "Lusail",
-      "driver": "BEA",
+      "race": "Yas_Island",
+      "driver": "VER",
+      "actual_lap": 23,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Yas_Island",
+      "driver": "GAS",
+      "actual_lap": 13,
+      "chosen_lap": 8,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Yas_Island",
+      "driver": "GAS",
+      "actual_lap": 40,
+      "chosen_lap": 36,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Yas_Island",
+      "driver": "ANT",
       "actual_lap": 32,
+      "chosen_lap": 31,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Yas_Island",
+      "driver": "ALO",
+      "actual_lap": 16,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Yas_Island",
+      "driver": "LEC",
+      "actual_lap": 16,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Yas_Island",
+      "driver": "LEC",
+      "actual_lap": 39,
       "chosen_lap": null,
       "offset_laps": null,
       "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
-      "race": "Lusail",
-      "driver": "BEA",
+      "race": "Yas_Island",
+      "driver": "STR",
+      "actual_lap": 42,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Yas_Island",
+      "driver": "TSU",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Yas_Island",
+      "driver": "ALB",
+      "actual_lap": 8,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Yas_Island",
+      "driver": "ALB",
+      "actual_lap": 33,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Yas_Island",
+      "driver": "HUL",
+      "actual_lap": 7,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Yas_Island",
+      "driver": "HUL",
+      "actual_lap": 42,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Yas_Island",
+      "driver": "LAW",
+      "actual_lap": 21,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Yas_Island",
+      "driver": "OCO",
+      "actual_lap": 19,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Yas_Island",
+      "driver": "NOR",
+      "actual_lap": 16,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Yas_Island",
+      "driver": "NOR",
       "actual_lap": 40,
       "chosen_lap": null,
       "offset_laps": null,
@@ -1471,192 +5117,174 @@
     },
     {
       "year": 2025,
-      "race": "Lusail",
-      "driver": "BEA",
-      "actual_lap": 41,
+      "race": "Yas_Island",
+      "driver": "COL",
+      "actual_lap": 15,
+      "chosen_lap": 15,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Yas_Island",
+      "driver": "COL",
+      "actual_lap": 40,
+      "chosen_lap": 36,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Yas_Island",
+      "driver": "HAM",
+      "actual_lap": 8,
+      "chosen_lap": 7,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Yas_Island",
+      "driver": "HAM",
+      "actual_lap": 31,
       "chosen_lap": null,
       "offset_laps": null,
       "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
-      "race": "Monza",
-      "driver": "VER",
-      "actual_lap": 37,
+      "race": "Yas_Island",
+      "driver": "BOR",
+      "actual_lap": 15,
       "chosen_lap": null,
       "offset_laps": null,
       "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
-      "race": "Monza",
-      "driver": "GAS",
-      "actual_lap": 49,
-      "chosen_lap": 45,
-      "offset_laps": -4,
+      "race": "Yas_Island",
+      "driver": "SAI",
+      "actual_lap": 18,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Yas_Island",
+      "driver": "HAD",
+      "actual_lap": 14,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Yas_Island",
+      "driver": "RUS",
+      "actual_lap": 14,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Yas_Island",
+      "driver": "PIA",
+      "actual_lap": 41,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Yas_Island",
+      "driver": "BEA",
+      "actual_lap": 14,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Zandvoort",
+      "driver": "ALO",
+      "actual_lap": 18,
+      "chosen_lap": 16,
+      "offset_laps": -2,
       "bucket": "scored"
     },
     {
       "year": 2025,
-      "race": "Monza",
-      "driver": "ANT",
-      "actual_lap": 28,
+      "race": "Zandvoort",
+      "driver": "ALO",
+      "actual_lap": 40,
       "chosen_lap": null,
       "offset_laps": null,
       "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
-      "race": "Monza",
-      "driver": "ALO",
-      "actual_lap": 20,
-      "chosen_lap": 15,
-      "offset_laps": -5,
+      "race": "Zandvoort",
+      "driver": "STR",
+      "actual_lap": 8,
+      "chosen_lap": 7,
+      "offset_laps": -1,
       "bucket": "scored"
     },
     {
       "year": 2025,
-      "race": "Monza",
-      "driver": "ALO",
-      "actual_lap": 24,
+      "race": "Zandvoort",
+      "driver": "TSU",
+      "actual_lap": 19,
+      "chosen_lap": 16,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Zandvoort",
+      "driver": "HUL",
+      "actual_lap": 19,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Zandvoort",
+      "driver": "LAW",
+      "actual_lap": 27,
       "chosen_lap": null,
       "offset_laps": null,
       "bucket": "min_stint"
     },
     {
       "year": 2025,
-      "race": "Monza",
-      "driver": "LEC",
-      "actual_lap": 33,
-      "chosen_lap": 33,
-      "offset_laps": 0,
-      "bucket": "scored"
+      "race": "Zandvoort",
+      "driver": "COL",
+      "actual_lap": 19,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
-      "race": "Monza",
-      "driver": "STR",
-      "actual_lap": 49,
-      "chosen_lap": 51,
+      "race": "Zandvoort",
+      "driver": "BOR",
+      "actual_lap": 60,
+      "chosen_lap": 62,
       "offset_laps": 2,
       "bucket": "scored"
     },
     {
       "year": 2025,
-      "race": "Monza",
-      "driver": "TSU",
-      "actual_lap": 19,
-      "chosen_lap": 18,
-      "offset_laps": -1,
-      "bucket": "scored"
-    },
-    {
-      "year": 2025,
-      "race": "Monza",
-      "driver": "ALB",
-      "actual_lap": 41,
-      "chosen_lap": 36,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2025,
-      "race": "Monza",
-      "driver": "LAW",
-      "actual_lap": 9,
-      "chosen_lap": 9,
-      "offset_laps": 0,
-      "bucket": "scored"
-    },
-    {
-      "year": 2025,
-      "race": "Monza",
-      "driver": "OCO",
-      "actual_lap": 51,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "closing_laps"
-    },
-    {
-      "year": 2025,
-      "race": "Monza",
-      "driver": "NOR",
-      "actual_lap": 46,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_boundary_in_window"
-    },
-    {
-      "year": 2025,
-      "race": "Monza",
-      "driver": "COL",
-      "actual_lap": 33,
-      "chosen_lap": 28,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2025,
-      "race": "Monza",
-      "driver": "HAM",
-      "actual_lap": 38,
-      "chosen_lap": 33,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2025,
-      "race": "Monza",
-      "driver": "BOR",
-      "actual_lap": 20,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2025,
-      "race": "Monza",
+      "race": "Zandvoort",
       "driver": "SAI",
-      "actual_lap": 30,
-      "chosen_lap": 27,
-      "offset_laps": -3,
-      "bucket": "scored"
-    },
-    {
-      "year": 2025,
-      "race": "Monza",
-      "driver": "HAD",
-      "actual_lap": 32,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_boundary_in_window"
-    },
-    {
-      "year": 2025,
-      "race": "Monza",
-      "driver": "RUS",
       "actual_lap": 27,
-      "chosen_lap": 27,
-      "offset_laps": 0,
-      "bucket": "scored"
-    },
-    {
-      "year": 2025,
-      "race": "Monza",
-      "driver": "PIA",
-      "actual_lap": 45,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "no_boundary_in_window"
-    },
-    {
-      "year": 2025,
-      "race": "Monza",
-      "driver": "BEA",
-      "actual_lap": 18,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "bucket": "min_stint"
     }
   ]
 }

--- a/documents/eval_reports/decision_modes.md
+++ b/documents/eval_reports/decision_modes.md
@@ -1,28 +1,29 @@
 # decision_modes
 
-- harness `ea9c319` · schema v1 · generated 2026-08-06T18:57:01+00:00
-- era 2022-2025 · dataset data/raw laps, stratified 6-race subset (RAW, not featured) · seed deterministic · llm none
-- artifacts: none
+- harness `8d43342d` · schema v1 · generated 2026-08-30T16:34:12+00:00
+- era 2022-2025 · dataset data/raw laps, every 2025 race (RAW, not featured) · seed deterministic · llm none
+- artifacts: —
 
 | Metric | Value | Meaning |
 | --- | --- | --- |
-| Stops scored | 66 of 178 (37.1%) | real green-flag stops the tier could grade |
-| Exact lap | 21.2% | chose the lap the team chose |
-| Within 1 lap | 37.9% | same call, one lap either side |
-| Within 2 laps | 51.5% | same strategic window |
-| Mean signed error | -1.97 laps | negative = earlier than the team. **Do not quote as a system property**, since it still moves with `DECISION_WINDOW_LAPS` (measured -0.33 / -1.29 / -2.50 at w=3/5/10 on one race), because a wider window admits more distant, and therefore earlier, transitions |
-| Mean absolute error | 2.42 laps | magnitude, same width caveat |
+| Stops scored | 204 of 573 (35.6%) | real green-flag stops the tier could grade |
+| Exact lap | 18.6% | chose the lap the team chose |
+| Within 1 lap | 34.3% | same call, one lap either side |
+| Within 2 laps | 50.0% | same strategic window |
+| Mean signed error | -2.21 laps | negative = earlier than the team. **Do not quote as a system property** — it still moves with `DECISION_WINDOW_LAPS`, because a wider window admits more distant, and therefore earlier, transitions. The levels this caveat used to quote (-0.33 / -1.29 / -2.50 at w=3/5/10) were measured on ONE race and on the constant-fed inputs #829 retired, so they are withdrawn rather than restated; the direction is arithmetic and survives, the magnitudes are unmeasured on this input set |
+| Mean absolute error | 2.48 laps | magnitude, same width caveat |
 | Coverage verdict | **masked** | `masked` when under 60% of eligible stops were scored |
 
-## Buckets
+### Buckets
 
 | Bucket | Stops |
 | --- | --- |
 | `closing_laps` | 4 |
-| `min_stint` | 5 |
-| `no_boundary_in_window` | 31 |
-| `no_call_in_window` | 72 |
-| `scored` | 66 |
+| `min_stint` | 16 |
+| `no_boundary_in_window` | 121 |
+| `no_call_in_window` | 224 |
+| `opening_laps` | 4 |
+| `scored` | 204 |
 
 `opening_laps` / `closing_laps` / `min_stint` are stops the guard rails make
 impossible to agree with, so they are excluded from the headline rather than
@@ -39,9 +40,12 @@ as **no locatable decision**, never as a description of what the stack did.
 Three different shapes land here and they are not the same finding:
 
 - already asking when the window opened, and still asking on every lap;
-- already asking when the window opened, then **withdrawing** later - on the
-  measured 2025 Monza sample this was 4 of 4 occupants, one of them flipping to
-  STAY_OUT on the exact lap the team really stopped;
+- already asking when the window opened, then **withdrawing** later. Re-measured
+  on 2025 Monza (2026-08-06, on these inputs): this is 4 of 4 occupants, and all
+  four were STILL ASKING on the exact lap the team really stopped, flipping to
+  STAY_OUT only the lap after - VER asks laps 32-37 for a lap-37 stop, NOR 41-46
+  for 46, HAD 27-32 for 32, PIA 40-45 for 45. So this bucket is holding four
+  cases where the stack agreed with the team and the metric cannot say so;
 - a lap inside the window that was never evaluated, so the only pit ask has no
   witness for its predecessor.
 
@@ -65,18 +69,27 @@ synthesis told on every lap that the car ahead sat exactly 2.0 s away and matche
 its pace. **Figures generated before 2026-08-06 are not comparable to these.**
 
 They do not reach N27, which derives its own pair gap from ``laps_df``, nor the
-Monte Carlo, which takes the rivals list from the lap state.
+Monte Carlo, which takes the rivals list from the lap state. An earlier wording
+here said they did.
 
 ### Scope
 
-- Sampled races (6 measured): 2025 Barcelona, 2025 Monaco, 2025 Silverstone, 2025 Marina_Bay, 2025 Lusail, 2025 Monza.
-- **All six are 2025, deliberately.** 2023 and 2024 are training seasons for
+- Sampled races (24 measured): 2025 Austin, 2025 Baku, 2025 Barcelona, 2025 Budapest, 2025 Imola, 2025 Jeddah, 2025 Las_Vegas, 2025 Lusail, 2025 Marina_Bay, 2025 Melbourne, 2025 Mexico_City, 2025 Miami_Gardens, 2025 Monaco, 2025 Montréal, 2025 Monza, 2025 Sakhir, 2025 Shanghai, 2025 Silverstone, 2025 Spa-Francorchamps, 2025 Spielberg, 2025 Suzuka, 2025 São_Paulo, 2025 Yas_Island, 2025 Zandvoort.
+- **Every one is 2025, deliberately.** 2023 and 2024 are training seasons for
   every model in the stack, so a decision tier scored there is partly reading
   back its own training data.
-- A full sweep of the real-stop sample is roughly 11.5 h of wall clock at
-  0.51 s per lap through the stack, so this is a stratified subset by circuit
-  archetype and **not** full coverage. Read every figure above as conditional
-  on these races.
+- This is the whole 2025 season, not a stratified subset. It used to be six
+  races, on a runtime estimate of 11.5 h for a full sweep that assumed a
+  full-race replay per driver; the tier replays only the scoring windows, so
+  the whole season is 8,393 replayed laps at 0.213 s each, about half an hour.
+  The subset was representative for the headline, 40.4% declines against 39.1%
+  here, and not per race: decline runs from 4.8% at Suzuka to 88.9% at
+  Melbourne, only 3 of the 24 races land within three points of the season
+  figure, and the retired subset's own six spanned 13.0% to 74.2%. Read any
+  per-circuit claim off the per-race numbers, never off this headline.
+- Season coverage is **not** the same thing as the coverage verdict above. Every
+  eligible 2025 stop is now looked at; the verdict says how many of them the
+  metric could locate a decision inside.
 - Decisions come from `profile="no-llm"`: the deterministic Monte Carlo layer
   plus the guard rails, never the LLM synthesis.
 - Agreement with the real pit wall is evidence, not correctness. The team can

--- a/src/strategy/eval/decision_modes.py
+++ b/src/strategy/eval/decision_modes.py
@@ -69,8 +69,8 @@ WHERE TO CHANGE IF THINGS MOVE:
 - ``src/strategy/inference/guard_rails.py`` owns the rails and the pit-action
   set. ``guard_rail_block`` CALLS the rail rather than restating its thresholds,
   because the first version retyped one boundary and got it wrong by one lap.
-- ``SAMPLED_RACES`` is the subset and the reason it exists; see its comment
-  before widening it.
+- ``SAMPLED_RACES`` is the sample and the reason it is 2025 only; see its
+  comment before changing it.
 - ``lap_inputs`` decides which laps are answerable and is deliberately free of
   agent imports, so the two bugs that lived there stay under test on a runner
   with no model weights.
@@ -101,28 +101,54 @@ from src.strategy.inference.guard_rails import (
 # it was built to answer rather than a horizon it never considers.
 DECISION_WINDOW_LAPS = 5
 
-# A full sweep is not affordable. Measured on this machine: 0.51 s per lap through
-# the no-llm stack, 28.8 s for one (race, driver) pair, and the real-stop sample
-# spans roughly 1440 pairs — about 11.5 hours for one report. So the tier runs on a
-# named, stratified subset instead, chosen for circuit archetype rather than
-# convenience: two conventional high-degradation circuits, two street circuits where
-# track position dominates, one low-downforce low-stop circuit and one fast circuit
-# with variable weather. Widening this is a runtime decision, not a correctness one —
-# but the report must keep saying which races it used.
+# EVERY RACE OF 2025, because the stratified subset this list used to hold was
+# affordable-by-necessity and is no longer necessary. The comment here used to say a
+# full sweep cost about 11.5 hours, from 0.51 s per lap and 28.8 s for one
+# (race, driver) pair over roughly 1440 pairs. That estimate assumed a FULL-RACE
+# replay per driver; `_replay_span` replays only the union of the scoring windows.
+# Measured on this machine, 2026-08-30: 8,393 replayed laps for the whole of 2025 at
+# 0.213 s per lap, about half an hour. All three seasons on disk are 27,550 laps, so
+# roughly 1.6 hours rather than 11.5.
 #
-# ALL SIX ARE 2025, AND THAT IS THE CORRECTNESS HALF. The first version of this list
-# took four of its six races from 2023-24, which are TRAINING seasons for every model
-# in the stack. A decision tier scored there is partly reading back its own training
-# data, and the whole point of this report is what the shipped system does on the
-# season it actually infers on. The archetypes are unchanged; only the year moved, so
-# the stratification argument above still holds.
-SAMPLED_RACES: tuple[tuple[int, str], ...] = (
-    (2025, "Barcelona"),  # conventional, high degradation
-    (2025, "Monaco"),  # street, track position is everything
-    (2025, "Silverstone"),  # fast, weather-variable
-    (2025, "Marina_Bay"),  # street, high degradation
-    (2025, "Lusail"),  # high degradation, stint-limited history
-    (2025, "Monza"),  # low downforce, fewest stops
+# What widening bought, measured on the same code: the eligible sample goes 178 -> 573
+# and the decline rate moves 40.4% -> 39.1%, so the old subset was representative for
+# the headline. It was not representative per race. Decline over the 24 races runs from
+# 4.8% at Suzuka to 88.9% at Melbourne, only 3 of them land within three points of the
+# season figure, and the retired subset's own six spanned 13.0% to 74.2%. That spread is
+# why a six-race read could not be trusted for anything circuit-shaped.
+#
+# 2025 ONLY, AND THAT IS THE CORRECTNESS HALF. 2023 and 2024 are TRAINING seasons for
+# every model in the stack, so a decision tier scored there is partly reading back its
+# own training data, and the whole point of this report is what the shipped system does
+# on the season it actually infers on.
+SAMPLED_RACES: tuple[tuple[int, str], ...] = tuple(
+    (2025, race)
+    for race in (
+        "Austin",
+        "Baku",
+        "Barcelona",
+        "Budapest",
+        "Imola",
+        "Jeddah",
+        "Las_Vegas",
+        "Lusail",
+        "Marina_Bay",
+        "Melbourne",
+        "Mexico_City",
+        "Miami_Gardens",
+        "Monaco",
+        "Montréal",
+        "Monza",
+        "Sakhir",
+        "Shanghai",
+        "Silverstone",
+        "Spa-Francorchamps",
+        "Spielberg",
+        "Suzuka",
+        "São_Paulo",
+        "Yas_Island",
+        "Zandvoort",
+    )
 )
 
 # Share of eligible stops that must actually be scored before the headline
@@ -444,8 +470,10 @@ def _replay_span(stop_laps: list[int], total_laps: int) -> tuple[int, int]:
     """The laps to replay for one (race, driver), covering the union of the windows.
 
     One pass per driver rather than one per stop: two stops twenty laps apart still
-    cost one replay, which is where the runtime budget for a stratified subset comes
-    from.
+    cost one replay. This is also why a whole season is affordable at all. Over the 24
+    races of 2025 the union of the windows is 8,393 laps where a full-race replay per
+    driver would be 24,960, so assuming the second is what produced the 11.5 h estimate
+    this module used to carry. It is 2.97x too high.
 
     The span opens **one lap before** the earliest scoring window. A transition needs
     its predecessor to have been evaluated, so without that extra lap the first lap of
@@ -705,14 +733,21 @@ def _render_table(
         "### Scope",
         "",
         f"- Sampled races ({agreement.races} measured): {races}.",
-        "- **All six are 2025, deliberately.** 2023 and 2024 are training seasons for",
+        "- **Every one is 2025, deliberately.** 2023 and 2024 are training seasons for",
         "  every model in the stack, so a decision tier scored there is partly reading",
-        "  back its own training data. An earlier version of this list took four of its",
-        "  six races from those seasons; the archetypes are unchanged, only the year.",
-        "- A full sweep of the real-stop sample is roughly 11.5 h of wall clock at",
-        "  0.51 s per lap through the stack, so this is a stratified subset by circuit",
-        "  archetype and **not** full coverage. Read every figure above as conditional",
-        "  on these races.",
+        "  back its own training data.",
+        "- This is the whole 2025 season, not a stratified subset. It used to be six",
+        "  races, on a runtime estimate of 11.5 h for a full sweep that assumed a",
+        "  full-race replay per driver; the tier replays only the scoring windows, so",
+        "  the whole season is 8,393 replayed laps at 0.213 s each, about half an hour.",
+        "  The subset was representative for the headline, 40.4% declines against 39.1%",
+        "  here, and not per race: decline runs from 4.8% at Suzuka to 88.9% at",
+        "  Melbourne, only 3 of the 24 races land within three points of the season",
+        "  figure, and the retired subset's own six spanned 13.0% to 74.2%. Read any",
+        "  per-circuit claim off the per-race numbers, never off this headline.",
+        "- Season coverage is **not** the same thing as the coverage verdict above. Every",
+        "  eligible 2025 stop is now looked at; the verdict says how many of them the",
+        "  metric could locate a decision inside.",
         '- Decisions come from `profile="no-llm"`: the deterministic Monte Carlo layer',
         "  plus the guard rails, never the LLM synthesis.",
         "- Agreement with the real pit wall is evidence, not correctness. The team can",
@@ -730,7 +765,7 @@ def build_decision_modes_report() -> dict[str, Any]:
         agreement, verdicts = None, []
 
     status = coverage_verdict(agreement) if agreement is not None else "unavailable"
-    header = build_header(dataset="data/raw laps, stratified 6-race subset (RAW, not featured)")
+    header = build_header(dataset="data/raw laps, every 2025 race (RAW, not featured)")
     md_path, json_path = write_report(
         "decision_modes",
         header,

--- a/tests/eval/test_decision_modes.py
+++ b/tests/eval/test_decision_modes.py
@@ -442,15 +442,22 @@ def test_tyre_life_is_the_builders_contract_now():
 # --- the report's honesty --------------------------------------------------
 
 
-def test_render_states_the_subset_and_refuses_to_imply_full_coverage():
-    """The scope caveats are part of the artifact, not decoration."""
+def test_render_names_every_race_and_keeps_season_scope_apart_from_coverage():
+    """The scope caveats are part of the artifact, not decoration.
+
+    The sample is now the whole 2025 season, so the old "stratified subset, not full
+    coverage" wording is gone. The distinction it protected is not: covering every race
+    of a season is a different claim from the coverage verdict, which says how many of
+    those stops the metric could locate a decision inside. A reader who conflates the
+    two reads `masked` as "we only looked at some races".
+    """
     body = _render_table(
         _agreement([0, 1], guard_railed=1),
         [StopVerdict(2025, "Lusail", "NOR", 30, 30, 0, "scored")],
         "ok",
     )
-    assert "not** full coverage" in body
-    assert "stratified subset" in body
+    assert "not a stratified subset" in body
+    assert "not** the same thing as the coverage verdict" in body
     assert "no-llm" in body
     for _year, race in SAMPLED_RACES:
         assert race in body


### PR DESCRIPTION
## What

`f1-eval decision-modes` now scores every race of 2025 instead of a six-race stratified subset.
The eligible sample goes from 178 real green-flag stops to 573, and the committed report and JSON
are regenerated on it.

## Why

The subset existed for runtime, and the runtime figure it rested on was wrong. The module comment
put a full sweep at 11.5 h, derived from 28.8 s per (race, driver) pair over roughly 1440 pairs.
That assumes a full-race replay per driver, but `_replay_span` replays only the union of the
scoring windows: 8,393 laps over the 24 races of 2025 where a full-race replay would be 24,960,
so the estimate was 2.97x too high. Measured on this machine the whole season is 8,393 replayed
laps at 0.213 s each, about half an hour.

The subset was also the only sample behind a number this release quotes, and per race it is not
representative. Decline runs from 4.8% at Suzuka to 88.9% at Melbourne, only 3 of the 24 races land
within three points of the season figure, and the six races the subset used spanned 13.0% to 74.2%
among themselves.

## How

- `SAMPLED_RACES` is the 24 races of 2025. Still 2025 only, and for the unchanged reason: 2023 and
  2024 are training seasons for every model in the stack.
- The scope prose no longer says "stratified subset" or "**not** full coverage", because neither
  is true now. It says instead that season coverage and the coverage verdict are different claims,
  which is the confusion the old wording was protecting against: `masked` says how many stops the
  metric could locate a decision inside, not how many races were looked at.
- `_replay_span`'s docstring and the module docstring's "where to change" entry are corrected to
  match.
- `test_render_states_the_subset_and_refuses_to_imply_full_coverage` is renamed and re-pointed at
  the two strings that carry the claim now.

No production code is touched. `SAMPLED_RACES`, `DECISION_WINDOW_LAPS` and the report renderer are
all the eval harness's own.

## What moved in the numbers

| | 6 races (harness `ea9c319`) | 24 races (this PR) |
|---|---|---|
| eligible stops | 178 | 573 |
| scored | 66 (37.1%) | 204 (35.6%) |
| `no_call_in_window` | 72 (40.4%) | 224 (39.1%) |
| `no_boundary_in_window` | 31 | 121 |
| exact / within-1 / within-2 | 21.2% / 37.9% / 51.5% | 18.6% / 34.3% / 50.0% |
| mean signed / absolute | -1.97 / 2.42 | -2.21 / 2.48 |
| coverage verdict | masked | masked |

Widening does not lift the coverage verdict off `masked`, and it was not expected to: the verdict
is about how many stops carry a locatable decision, which the sample size does not change.

## Out of scope

- The decline rate itself. #715 stays open; its remaining work is #724's plan plus #557, and the
  measurements behind that are posted on #715.
- `- artifacts: —` in the header is what `report.py:164` emits for an empty artifact dict. It reads
  as new here only because the previous file was generated before that line changed. Fixing it
  would re-diff every report in the folder.

## Checks

- `tests/eval/test_decision_modes.py` 38 passed. The renamed guard was watched RED against two
  independent mutants, one per asserted string, each confirmed applied by grepping its marker
  before the run, and green again after restore.
- `uvx ruff@0.15.22 check .` clean, `format --check .` 203 files already formatted.
- The report is the output of `uv run python -m src.strategy.eval.cli decision-modes`, not hand
  edited. Its figures were cross-checked against an independent per-race sweep written for the
  runtime measurement, which agreed on every bucket: 4 / 16 / 121 / 224 / 4 / 204 summing to 573.
- Baseline before the change, on `dev` @`8d43342d`: `tests/surfaces` + `tests/cli` + `tests/eval`
  631 passed, 5 skipped, 0 failed. The 5 skips are #1130's open half.
