### PR TITLE
docs(eval): name the sample behind the decision-tier figures

### DIFF
--- a/docs/pages/multi-agent.md
+++ b/docs/pages/multi-agent.md
@@ -196,7 +196,7 @@ The compounding effect is what made the old values worth changing rather than me
 
 Measured as a **single-variable comparison**: both columns run on the product's real race state, so only the bounds differ:
 
-| decision-agreement tier, 2025, 178 eligible stops | old bounds (8 / 12 / 15, wet 10) | shipped bounds (2 / 7 / 8, wet 6) |
+| decision-agreement tier, the retired six-race 2025 subset, 178 eligible stops | old bounds (8 / 12 / 15, wet 10) | shipped bounds (2 / 7 / 8, wet 6) |
 |---|---|---|
 | `min_stint` exclusion bucket | 17 stops | **5** |
 | scored sample | 54 | **66** |
@@ -204,6 +204,8 @@ Measured as a **single-variable comparison**: both columns run on the product's 
 | within one lap | 40.7% | 37.9% |
 | within two laps | 46.3% | **51.5%** |
 | mean signed error | -2.20 laps | -1.97 |
+
+Both columns are the six races the tier sampled when the comparison was made, so the shipped-bounds column is not the system's current rate. On the whole 2025 season, 573 eligible stops, the shipped bounds score 204, exact 18.6%, within one 34.3%, within two 50.0%, mean signed -2.21 laps. `documents/eval_reports/decision_modes.md` is the current artefact. The table survives its own sample because comparing two sets of constants needs both arms measured on one sample, and only the shipped arm was re-run wider.
 
 **The recalibration buys sample, not accuracy, and the honest reading is that the twelve stops it admits are harder than the ones already there.** Exact and within-one fall; within-two and the mean error improve. A bound that excludes a case is not scoring it well, it is refusing to be graded on it, so a lower rate over a wider sample is the more informative number, though calling that an accuracy improvement would be the same flattery the bound itself was performing.
 

--- a/src/strategy/eval/llm_decision.py
+++ b/src/strategy/eval/llm_decision.py
@@ -21,8 +21,8 @@ because these definitions are literally the same objects.
 WHAT IS DIFFERENT, AND HAS TO BE SAID EVERY TIME
 ------------------------------------------------
 1. **The sample is smaller and it is chosen, not enumerated.** The
-   deterministic tier can afford to sweep every green-flag stop of six races at
-   0.51 s/lap. This path costs 15.93 s/lap, so it runs over named windows. A
+   deterministic tier can afford to sweep every green-flag stop of the whole 2025
+   season at 0.213 s/lap. This path costs 15.93 s/lap, so it runs over named windows. A
    figure from here describes those windows and nothing wider.
 2. **It is not deterministic.** The orchestrator requests ``temperature=0`` and
    ``gpt-5.4-mini`` discards it. A single pass is one sample of a distribution,

--- a/src/strategy/inference/guard_rails.py
+++ b/src/strategy/inference/guard_rails.py
@@ -72,11 +72,13 @@ _NO_PIT_BEFORE_LAP = 5
 # is unrecoverable BY REGULATION. That article does not reach a green-flag lap,
 # where the bound rests on the ~22-25 s cost instead, and on this measurement.
 #
-# This is also the bound behind the four excluded stops in the six-race
-# `decision-modes` subset (Monaco VER, Lusail STR and HAD, Monza OCO). #716's issue
-# body attributes four stops to the early-race bound as well; measured on that
-# subset the early-race bound excludes NONE, and `decision_modes.md` carries no
-# `opening_laps` row at all.
+# This is also the bound behind the `closing_laps` stops in the `decision-modes`
+# sweep (Monaco VER, Lusail STR and HAD, Monza OCO), still exactly those four now
+# that the sweep covers all 24 races of 2025. #716's issue body attributes four
+# stops to the early-race bound as well; on the retired six-race subset that bound
+# excluded none, so `decision_modes.md` carried no `opening_laps` row, and over the
+# full season it excludes four different stops (Imola OCO, Mexico_City LAW,
+# Shanghai ALO and Shanghai BOR).
 _NO_PIT_LAST_N_LAPS = 3
 
 _CLIFF_P10_SAFE = 2

--- a/tests/mc/test_tyre_wear_term.py
+++ b/tests/mc/test_tyre_wear_term.py
@@ -4,8 +4,8 @@ Until now the Monte Carlo's only tyre signal was the cliff, a discrete event tha
 falls inside the 5-lap window on 4 of 110 measured laps. A set 0.4 s off the pace but
 ten laps from the cliff scored identically to a fresh one, which is most of why the
 decision layer declines to call a large share of real stops. The level is deliberately
-not quoted here: it was 46%, then 65%, and is 72 of 178 (40.4%) on the post-#829
-inputs. `documents/eval_reports/decision_modes.md` regenerates it; a copy in a test
+not quoted here, because it moves with every harness revision and every widening of the
+sample. `documents/eval_reports/decision_modes.md` regenerates it, and a copy in a test
 docstring only ever goes stale.
 
 WHAT IS BEING REPLACED, AND WHY IT IS A REPLACEMENT


### PR DESCRIPTION
## What

PR #1143 widened the decision tier from a six-race 2025 subset to all 24 races of 2025. Four places still describe the old sample.

## Why

The shipped-bounds column of the table in `docs/pages/multi-agent.md` reads 66 scored, exact 21.2%, within one 37.9%, within two 51.5%, mean signed -1.97. Those are the six-race figures. The committed report now says 204 scored of 573, exact 18.6%, within one 34.3%, within two 50.0%, mean signed -2.21, and a reader takes the table's numbers as the system's rate.

## How

| file | was | now |
|---|---|---|
| `docs/pages/multi-agent.md:199` | "2025, 178 eligible stops" | "the retired six-race 2025 subset, 178 eligible stops", plus the full-season figures in the paragraph below |
| `tests/mc/test_tyre_wear_term.py:7` | says the level is deliberately not quoted, then quotes 46%, 65% and 72 of 178 | the reason kept, the levels dropped |
| `src/strategy/eval/llm_decision.py:24` | "every green-flag stop of six races at 0.51 s/lap" | "the whole 2025 season at 0.213 s/lap" |
| `src/strategy/inference/guard_rails.py:74` | "`decision_modes.md` carries no `opening_laps` row at all" | it carries four (Imola OCO, Mexico_City LAW, Shanghai ALO and BOR) |

The old-bounds comparison stays. Isolating the effect of the four constants needs both arms measured on one sample, and only the shipped arm was re-run wider.

The four `closing_laps` stops the guard-rail comment names (Monaco VER, Lusail STR and HAD, Monza OCO) are still exactly those four on the full season, read off `decision_modes.json`.

## Out of scope

Re-running the old-bounds arm on all 24 races, which would cost about an hour and re-measure constants that no longer ship.

## Checks

- `tests/mc` + `tests/eval` 262 passed, 5 skipped, 0 failed.
- `tests/surfaces/test_docs_site_links.py` + `test_diagrams_no_retired_surface.py` 24 passed.
- `uvx ruff@0.15.22 check .` clean, `format --check .` 203 files.
- Bucket counts and the named drivers read from `documents/eval_reports/decision_modes.json` at HEAD, not from prose.