### PR TITLE
fix(eval): spell an empty artifact set as none in the report header

### DIFF
--- a/documents/eval_reports/decision_modes.json
+++ b/documents/eval_reports/decision_modes.json
@@ -1,12 +1,12 @@
 {
   "header": {
-    "harness_sha": "8d43342d",
+    "harness_sha": "83c59629",
     "dataset": "data/raw laps, every 2025 race (RAW, not featured)",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-08-30T16:34:12+00:00",
+    "generated_at": "2026-08-30T17:54:11+00:00",
     "artifacts": {}
   },
   "status": "masked",

--- a/documents/eval_reports/decision_modes.md
+++ b/documents/eval_reports/decision_modes.md
@@ -1,8 +1,8 @@
 # decision_modes
 
-- harness `8d43342d` · schema v1 · generated 2026-08-30T16:34:12+00:00
+- harness `83c59629` · schema v1 · generated 2026-08-30T17:54:11+00:00
 - era 2022-2025 · dataset data/raw laps, every 2025 race (RAW, not featured) · seed deterministic · llm none
-- artifacts: —
+- artifacts: none
 
 | Metric | Value | Meaning |
 | --- | --- | --- |

--- a/src/strategy/eval/report.py
+++ b/src/strategy/eval/report.py
@@ -161,7 +161,7 @@ def write_report(
 
 def _render_md(name: str, header: ReportHeader, table_md: str) -> str:
     """Render a report: title, provenance header block, then the table body."""
-    artifacts = ", ".join(f"{k}=`{v}`" for k, v in header.artifacts.items()) or "—"
+    artifacts = ", ".join(f"{k}=`{v}`" for k, v in header.artifacts.items()) or "none"
     lines = [
         f"# {name}",
         "",

--- a/tests/eval/test_report_header_provenance.py
+++ b/tests/eval/test_report_header_provenance.py
@@ -1,0 +1,67 @@
+"""Every committed report's provenance header is what the renderer emits today.
+
+The header is generated, so it is the one part of a report nobody should edit by
+hand. It was edited by hand: the writing pass that removed em dashes from the
+documentation tree reached into ``documents/eval_reports/`` and rewrote the
+renderer's ``artifacts`` placeholder in four reports without touching the
+renderer. The next regeneration put the em dash back in a fifth, so the tree held
+two spellings of the same empty value and neither traced to the code.
+
+These two tests close that loop from both ends: the renderer's placeholder is
+asserted directly, and every committed report is asserted to carry a placeholder
+the renderer can produce.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from src.strategy.eval.report import ReportHeader, _render_md
+
+ROOT = Path(__file__).parent.parent.parent
+REPORTS = sorted((ROOT / "documents" / "eval_reports").glob("*.md"))
+
+# What an empty artifact dict renders as. An em dash here is a prose defect in
+# generated output as well as a mismatch, so the value is asserted literally
+# rather than by "is not empty".
+EMPTY_ARTIFACTS = "none"
+
+
+def _artifacts_line(text: str) -> str:
+    """The `- artifacts: ...` line of a report, or "" when the report has none."""
+    match = re.search(r"^- artifacts: (.*)$", text, flags=re.MULTILINE)
+    return match.group(1) if match else ""
+
+
+def test_renderer_spells_an_empty_artifact_set_as_none():
+    """The placeholder is `none`, so no generated report carries an em dash."""
+    header = ReportHeader(
+        harness_sha="deadbeef",
+        dataset="probe",
+        seed_policy="deterministic",
+        llm="none",
+        artifacts={},
+    )
+    rendered = _artifacts_line(_render_md("probe", header, "| a |\n|---|\n"))
+    assert rendered == EMPTY_ARTIFACTS
+
+
+@pytest.mark.parametrize("report", REPORTS, ids=lambda p: p.stem)
+def test_committed_report_artifacts_line_matches_the_renderer(report: Path):
+    """A committed report either lists hashed artifacts or uses the placeholder.
+
+    Anything else means the line was written by something other than
+    :func:`_render_md`, which is how the two spellings appeared.
+    """
+    line = _artifacts_line(report.read_text(encoding="utf-8"))
+    assert line, f"{report.name} has no artifacts line"
+    if line == EMPTY_ARTIFACTS:
+        return
+    # A non-empty set is `name=`hash`` pairs joined by ", ".
+    for entry in line.split(", "):
+        assert re.fullmatch(r"[\w.\-]+=`[0-9a-f]+`", entry), (
+            f"{report.name} artifacts entry {entry!r} is not a rendered name=`hash` pair"
+        )


### PR DESCRIPTION
## What

`_render_md` emitted an em dash for an empty artifact dict. It now emits `none`.

## Why

The writing pass over the documentation tree (`f541ee72`) removed em dashes from four generated eval reports by editing the reports rather than the renderer. `report.py` kept emitting the em dash, so when #1143 regenerated `decision_modes` it came back with one:

| report | artifacts line |
|---|---|
| `alert_llm`, `hygiene`, `projection`, `stint_lengths` | `none` (hand-edited) |
| `decision_modes` | the em dash (what the code produces) |

Two spellings of the same empty value, neither traceable to the code, in a header that is the one part of a report nobody should be editing by hand. It is also a banned em dash in prose the harness generates.

`none` is the value that makes four of the five files correct without regenerating them.

## How

- `src/strategy/eval/report.py:164`, the placeholder.
- `documents/eval_reports/decision_modes.{md,json}` regenerated on the full 2025 season so no report is hand-maintained.
- `tests/eval/test_report_header_provenance.py`, two guards: the renderer's placeholder asserted directly, and every committed report asserted to carry an artifacts line the renderer can produce (`none`, or hashed `name=hash` pairs).

## The regeneration reproduced everything

97 lines before, 97 after, and the diff is two of them:

```
-- harness `8d43342d` · schema v1 · generated 2026-08-30T16:34:12+00:00
+- harness `83c59629` · schema v1 · generated 2026-08-30T17:54:11+00:00
-- artifacts: —
+- artifacts: none
```

Every bucket, rate and mean is unchanged: 204 scored of 573, exact 18.6%, within one 34.3%, within two 50.0%, mean signed -2.21, coverage `masked`. That is a third independent full-season run agreeing with the two before it.

## Checks

- Both guards watched RED before being trusted. The report guard failed on the real defect (`decision_modes.md artifacts entry '—' is not a rendered name/hash pair`); the renderer guard failed against a mutant confirmed applied by grepping its marker, then restored.
- `tests/eval/test_report_header_provenance.py` 10 passed.
- `uvx ruff@0.15.22 check .` clean, `format --check .` 204 files.
