### PR TITLE
fix(data): pull the NLP label sets and the NER config the eval tier reads

### DIFF
--- a/src/f1_strat_manager/data_cache.py
+++ b/src/f1_strat_manager/data_cache.py
@@ -100,6 +100,13 @@ _DEFAULT_MODEL_PATTERNS: tuple[str, ...] = (
     "data/models/nlp/sentiment_classifier_v1/**",
     "data/models/nlp/intent_setfit_modernbert_v1/**",
     "data/models/nlp/ner_v1/bert_bio_v1/**",
+    # The NER training eval, one level ABOVE the weights, so the pattern that
+    # pulls `bert_bio_v1/**` misses it. `dead_ner_classes` reads its per-class
+    # B-F1 to flag entity types the model never gets right, and returns a
+    # `pending` row rather than raising when it is absent, so `f1-eval nlp`
+    # shipped one measurement short and said nothing (#1146). Same shape as the
+    # undercut gap in #798 and the two import-time artefacts in #837.
+    "data/models/nlp/ner_v1/model_config.json",
     "data/models/nlp/rcm_parser_v1/**",
     # The RoBERTa sentiment weights, read at MODULE IMPORT by
     # `radio_agent.py` (a bare `torch.load`, not a lazy accessor). Without
@@ -148,6 +155,11 @@ _DEFAULT_MODEL_PATTERNS: tuple[str, ...] = (
     # (~80 MB); :func:`ensure_radio_corpus` downloads it lazily per GP
     # only when the simulation actually targets that race.
     "data/processed/race_radios/**",
+    # The intent and NER label sets the #304 eval tier scores against. Neither
+    # was published, so three golden tests skipped on any machine that HAD the
+    # weights, and the NLP report carried `pending` rows where measurements
+    # belong (#1130). 313 KB for the pair.
+    "data/processed/radio_nlp/**",
     # The two holdouts the calibration tier scores on. Neither is used at
     # inference, so their absence is not a broken install, and that is exactly
     # why they went unnoticed: `f1-eval calibration` degrades each missing one to

--- a/tests/eval/test_nlp_golden.py
+++ b/tests/eval/test_nlp_golden.py
@@ -7,8 +7,11 @@ locally and skip on CI without ``data/models/``.
 Three of them need a LABEL SET as well as the weights, and the skips have to say
 so separately. Scoring intent or NER against nothing returns a ``pending`` row,
 which these tests read as a failure; gating them on the weights alone made them
-fail on any machine that had the weights and not the labels, and neither label
-file is published (#1130).
+fail on any machine that had the weights and not the labels.
+
+Both label files are on the Hub since #1130 and both are covered by
+``_DEFAULT_MODEL_PATTERNS``, so a skip here now means the download did not run
+rather than that the file does not exist.
 """
 
 from __future__ import annotations
@@ -41,9 +44,11 @@ def _label_file(name: str) -> Path:
     return get_data_root() / "processed" / "radio_nlp" / name
 
 
-# The label sets the intent and NER stages score against. Neither is on the Hub
-# (#1130), so a machine WITH the weights and without these fails three tests it
-# has no way to pass; CI never saw it because there the weights are absent too.
+# The label sets the intent and NER stages score against. Both are on the Hub
+# under `data/processed/radio_nlp/` (#1130). The probes stay because CI runs
+# without `data/` at all, and because a machine can hold the weights and not the
+# labels: before they were published that combination failed three tests it had
+# no way to pass, and CI never saw it because there the weights are absent too.
 _HAS_INTENT_LABELS = _label_file("intent_labeled_data.csv").exists()
 _HAS_NER_ANNOTATIONS = _label_file("f1_radio_entity_annotations.json").exists()
 
@@ -96,7 +101,7 @@ def test_intent_predict_proba_order_is_aligned():
 
 @pytest.mark.data
 @pytest.mark.skipif(not _HAS_INTENT_HEAD, reason="intent model absent (CI runner without weights)")
-@pytest.mark.skipif(not _HAS_INTENT_LABELS, reason="intent_labeled_data.csv absent (#1130)")
+@pytest.mark.skipif(not _HAS_INTENT_LABELS, reason="intent_labeled_data.csv not downloaded")
 def test_intent_reproduction_is_sane():
     """Setfit-free reproduction runs and beats chance on the labeled set."""
     from src.strategy.eval.nlp import reproduce_intent
@@ -109,7 +114,7 @@ def test_intent_reproduction_is_sane():
 
 @pytest.mark.data
 @pytest.mark.skipif(not _HAS_INTENT_HEAD, reason="intent model absent (CI runner without weights)")
-@pytest.mark.skipif(not _HAS_INTENT_LABELS, reason="intent_labeled_data.csv absent (#1130)")
+@pytest.mark.skipif(not _HAS_INTENT_LABELS, reason="intent_labeled_data.csv not downloaded")
 def test_alert_precision_from_gold_is_high():
     """Alert precision (intent PROBLEM/WARNING) is real (gold-derived) and clears 0.8."""
     from src.strategy.eval.nlp import reproduce_alert_precision
@@ -120,7 +125,7 @@ def test_alert_precision_from_gold_is_high():
 
 
 @pytest.mark.data
-@pytest.mark.skipif(not _HAS_NER_CFG, reason="ner model_config absent (CI runner without weights)")
+@pytest.mark.skipif(not _HAS_NER_CFG, reason="ner model_config not downloaded")
 def test_dead_ner_classes_flags_zero_f1_types():
     """NR-07: entity types with ~0 frozen-eval B-F1 are flagged untrustworthy."""
     from src.strategy.eval.nlp import dead_ner_classes
@@ -134,7 +139,7 @@ def test_dead_ner_classes_flags_zero_f1_types():
 @pytest.mark.data
 @pytest.mark.skipif(not _HAS_NER_MODEL, reason="ner weights absent (CI runner without weights)")
 @pytest.mark.skipif(
-    not _HAS_NER_ANNOTATIONS, reason="f1_radio_entity_annotations.json absent (#1130)"
+    not _HAS_NER_ANNOTATIONS, reason="f1_radio_entity_annotations.json not downloaded"
 )
 def test_ner_entity_f1_reproduces_headline():
     """Entity micro-F1 reproduces the frozen 0.4151 headline within tolerance (full-set optimistic)."""

--- a/tests/test_construction_artefacts_are_downloadable.py
+++ b/tests/test_construction_artefacts_are_downloadable.py
@@ -8,6 +8,11 @@ reaches it raised FileNotFoundError.
 It stayed invisible for two reasons worth naming, because both are how this class of gap
 survives: every machine that had run the notebook already had the file, and the one
 `f1-sim` run people reach for happens not to trigger the pit agent.
+
+The EVAL tier is the same gap with a quieter failure and it is guarded here too (#1130,
+#1146). A stage that cannot find its label set returns a `pending` row instead of
+raising, so the report ships a measurement short and says nothing, and the golden test
+that would have caught it skips with a reason naming the weights.
 """
 
 from __future__ import annotations
@@ -36,6 +41,22 @@ _CONSTRUCTION_READS = {
     "pit_strategy_agent.py": "data/processed/undercut_labeled/undercut_clean.parquet",
     "race_situation_agent.py": "data/processed/sc_labeled/sc_labeled_2023_2025.parquet",
     "radio_agent.py": "data/models/nlp/bert_sentiment_v1/best_roberta_sentiment_model.pt",
+}
+
+
+# Label sets and configs the #304 eval stages score against, keyed by the file in
+# `src/strategy/eval/` that reads them. A miss here does NOT raise: the stage returns a
+# `pending` row and the golden test skips, so the report loses a measurement silently.
+# That is why they need a guard of their own rather than being caught by a failing run.
+#
+# `ner_v1/model_config.json` sits one level ABOVE the weights, so the pattern that pulls
+# `ner_v1/bert_bio_v1/**` misses it and every clean install lost NR-07 (#1146).
+_EVAL_READS = {
+    "nlp.py": (
+        "data/processed/radio_nlp/intent_labeled_data.csv",
+        "data/processed/radio_nlp/f1_radio_entity_annotations.json",
+        "data/models/nlp/ner_v1/model_config.json",
+    ),
 }
 
 
@@ -78,6 +99,38 @@ def test_the_module_still_reads_the_artefact_this_test_claims(module, artefact):
     assert filename in source, (
         f"{module} no longer mentions {filename}: either the read moved and this entry "
         f"is stale, or the artefact list needs updating for whatever replaced it."
+    )
+
+
+@pytest.mark.parametrize(
+    ("module", "artefact"),
+    sorted((mod, art) for mod, arts in _EVAL_READS.items() for art in arts),
+)
+def test_an_eval_label_set_is_pulled_by_the_downloader(module, artefact):
+    """The download list must cover what the eval stages read, or the report loses a row."""
+    patterns = _patterns()
+    assert _covers(patterns, artefact), (
+        f"src/strategy/eval/{module} scores against {artefact}, but no pattern in "
+        f"_DEFAULT_MODEL_PATTERNS pulls it. A clean install will report a `pending` row "
+        f"instead of the measurement, and the golden test will skip rather than fail."
+    )
+
+
+@pytest.mark.parametrize(
+    ("module", "artefact"),
+    sorted((mod, art) for mod, arts in _EVAL_READS.items() for art in arts),
+)
+def test_the_eval_module_still_reads_the_artefact_this_test_claims(module, artefact):
+    """Same staleness guard as the construction list above, for the same reason."""
+    source = (ROOT / "src" / "strategy" / "eval" / module).read_text(encoding="utf-8")
+    filename = artefact.rsplit("/", 1)[-1]
+    stem = filename.rsplit(".", 1)[0]
+    # `model_config.json` is built from a directory constant plus the bare filename, so
+    # the path never appears whole in the source and the parent directory is the claim.
+    needle = filename if filename != "model_config.json" else artefact.split("/")[-2]
+    assert needle in source, (
+        f"src/strategy/eval/{module} no longer mentions {needle} (for {stem}): either the "
+        f"read moved and this entry is stale, or the list needs whatever replaced it."
     )
 
 


### PR DESCRIPTION
## What

Two lines in `_DEFAULT_MODEL_PATTERNS`, plus the two label files published to the dataset repo.

## Why

Three stages of the #304 NLP eval score against files no download pattern asked for. A missing label set does not raise: the stage returns a `pending` row, so `f1-eval nlp` ships a measurement short and says nothing, and the golden test skips with a reason that names the weights.

| file | where it was | why it was missed |
|---|---|---|
| `intent_labeled_data.csv` | git-tracked at `legacy/radio_label/2023/`, 529 rows | never copied to the processed tree or the Hub |
| `f1_radio_entity_annotations.json` | not in the repo, not on the Hub | the manual `spacy_annotator` output the legacy N04 notebook produced |
| `ner_v1/model_config.json` | on the Hub already, 2,387 bytes | sits one level above the weights, so `ner_v1/bert_bio_v1/**` misses it (#1146) |

## The premise in #1130 does not survive

It says the label files are unpublishable. Neither is.

`intent_labeled_data.csv` was in the repo the whole time, at the exact row count the eval's own docstring quotes. `f1_radio_entity_annotations.json` exists as a manual annotation of the same 529 messages, and **it reproduces the frozen 0.4151 entity micro-F1**, which is what identifies it as the right file rather than a file with the right name.

All 529 annotated messages are already public in `legacy/radio_label/2023/`, so publishing the annotations adds the entity labels and no new radio content.

## How

- Published both files to `VforVitorio/f1-strategy-dataset` under `data/processed/radio_nlp/`, one commit, two new files, nothing overwritten. Verified by re-fetching from the Hub and comparing sha256 against the local copies.
- `data/processed/radio_nlp/**` and `data/models/nlp/ner_v1/model_config.json` added to `_DEFAULT_MODEL_PATTERNS`.
- `tests/eval/test_nlp_golden.py`: the skip reasons said the files do not exist. They now say the download did not run, which is the state a skip actually reports.

## Guard

`tests/test_construction_artefacts_are_downloadable.py` already exists for this defect class (#798, #837) and its own comment calls it the repo's dominant defect. It was scoped to construction-time agent reads, which is why it did not see this one. Extended with an `_EVAL_READS` section and the same pair of tests: the pattern list must cover each path, and the eval module must still read it, so the list cannot go stale in the harmless-looking direction.

## Checks

- `tests/eval` 101 passed / 5 skipped, to **105 passed / 1 skipped**. The survivor is the alert-llm radio corpus, a different gate.
- `tests/test_construction_artefacts_are_downloadable.py` 13 passed.
- Both new assertions watched RED against a mutant that removed the two patterns, confirmed applied by grepping its marker, then restored.
- The real download path exercised, not just the glob matcher: `snapshot_download` with the two new patterns fetched all three files to the exact paths the code reads, 315,196 bytes.

Closes #1130
Closes #1146
