### PR TITLE
docs(pitwall): describe the AGENTS window as it ships

### DIFF
--- a/docs/pages/pitwall.md
+++ b/docs/pages/pitwall.md
@@ -102,13 +102,53 @@ moment, not an error in either.
 
 ### PITWALL · AGENTS
 
-A 1:1 port of the Qt strategy window: header, the orchestrator card, scenario
-bars, the six-tab reasoning panel, and the 3x2 grid of sub-agent cards with
-their embedded charts.
+Four strata, top to bottom: header, the decision band, the agent grid, status
+bar. The band answers one question per module across the line the eye lands on
+anyway, left to right in the order a reader asks them, which is what the
+orchestrator is doing, why, on what evidence, and what happens next.
 
-It is 1:1 **by construction** rather than by inspection. The host calls the Qt
-window's own formatters and hands the React side an already-formatted view, so
-the two surfaces cannot describe the same lap differently.
+**The Qt lineage ends at the layout, and only at the layout.** Every string,
+colour and glyph still comes out of `src/pitwall/agents_view/`, which is the Qt
+window's own code, so the two surfaces cannot describe the same lap
+differently. What the port inherited and then dropped is the geometry: a header
+strip over a 540 / 740 horizontal split, decision in the left column and a 3x2
+card grid in the right. That split made the decision a peer of the agent grid,
+two territories with no reading order, and put the most important content on the
+window in the same column as a reasoning panel measured at 1.9% ink.
+
+The grid places its cards by name rather than in reading order, because three of
+the six want a shape reading order does not give them:
+
+```
+pace   tire   side
+radio  exit   rag
+```
+
+**PIT EXIT is the one output with no Qt counterpart.** It answers the question a
+pit wall asks before every stop: box on this lap, and what position does the car
+rejoin in, with which cars either side. It reads `P1 → P3` under an *if we box
+now* header, the car ahead and the car behind named with the gap to each. The
+number is the one the projection layer is graded on, 86.1% within one position
+over 552 real green-flag stops of 2025, because the card computes at the same
+two-lap horizon the ground truth measures rather than at the five-lap one the
+strategy scoring uses.
+
+The card is a hypothetical and says so in its own header, which is what keeps it
+readable on a STAY_OUT lap. Suppressing it there was designed and rejected: it
+would idle the card on exactly the laps somebody is asking whether to box, which
+is when the readout earns its space. It carries no identity colour either. The
+live call wears ACCENT one card up, and a branch that is not happening must not.
+
+RADIO gave up the second of its two columns to make room, so the bottom row runs
+three cards wide. That is not cosmetic. At one column a radio transcript no
+longer fits on one line and the body wraps rather than clips, so the height comes
+out of the charts above it, which is why `agent_formatters.BODY_LINE_LIMIT`
+budgets the lines.
+
+Before the first view arrives the window renders what the Qt window shows at
+startup rather than a spinner. The scenario scores are the one field that no
+longer follows Qt: they read `--` where it painted `0%`, because before the first
+tick nothing has been simulated and 0% is a measurement.
 
 ## How it is wired
 


### PR DESCRIPTION
## What

The PITWALL AGENTS section of the docs site described the window the port started from, not the one 2.6 ships.

## Why

It read:

> A 1:1 port of the Qt strategy window: header, the orchestrator card, scenario bars, the six-tab reasoning panel, and the 3x2 grid of sub-agent cards with their embedded charts.

`AgentsWindow.tsx:9` says the opposite in its own docstring: **"The Qt lineage ends here for the LAYOUT, and only for the layout."** The 540 / 740 horizontal split became four strata (header, decision band, agent grid, status bar), and the grid places cards by name rather than in reading order:

```
pace   tire   side
radio  exit   rag
```

The section also did not mention **PIT EXIT** at all, which is the release's one new model output on the glass and the only card with no Qt counterpart. The roadmap page carries it; the page that documents the surface did not.

## How

Rewritten from the source:

- the four strata, and what the decision band answers left to right
- what is still 1:1, which is every string, colour and glyph, because they come out of `src/pitwall/agents_view/`
- PIT EXIT: the `P1 → P3` headline under the `if we box now` qualifier, the named neighbours with their gaps, and why it computes at the two-lap horizon `REJOIN_CONFIG` declares rather than the five-lap one the strategy scoring uses
- why suppressing the card on STAY_OUT laps was designed and rejected, and why it carries no identity colour
- RADIO giving up its second column, and the wrap that `agent_formatters.BODY_LINE_LIMIT` budgets for

## Checks

Every claim resolved against the file that owns it, not against a sibling document:

| claim | source |
|---|---|
| four strata, the 540 / 740 split it replaced, the 1.9% ink figure | `AgentsWindow.tsx:1-30` |
| grid areas | `styles/agents.css:291-293` |
| the RADIO column and the wrap | `styles/agents.css:300-303`, `agent_formatters.py:73` |
| `P{origin} → P{slot}`, `if we box now`, ahead/behind rows | `agents_view/decision.py:598-613` |
| two-lap horizon, one shared config | `position_projection.py:849-874` |
| 86.1% within one position, 552 stops, 2025 | `documents/eval_reports/projection.md` |

- `tests/surfaces/test_docs_site_links.py` + `test_diagrams_no_retired_surface.py` 24 passed.
- Zero em dashes and zero second person in the page.
