### PR TITLE
fix(eval): make the download guards actually guard, and publish the alert corpus

### DIFF
--- a/tests/eval/test_alert_llm_golden.py
+++ b/tests/eval/test_alert_llm_golden.py
@@ -12,8 +12,22 @@ from pathlib import Path
 
 import pytest
 
-ROOT = Path(__file__).parent.parent.parent
-_HAS_CORPUS = (ROOT / "data" / "processed" / "radio_nlp" / "radios_raw.csv").exists()
+
+def _radio_nlp(name: str) -> Path:
+    """A corpus file at the path the stage reads, not at the repo's copy of it.
+
+    `alert_llm.py` reads `get_data_root()`, which `F1_STRAT_DATA_ROOT` moves. A probe
+    anchored on the repo does not follow it, and a probe that HITS while the code
+    misses turns this skip into a hard failure.
+    """
+    from src.f1_strat_manager.data_cache import get_data_root
+
+    return get_data_root() / "processed" / "radio_nlp" / name
+
+
+_HAS_CORPUS = (
+    _radio_nlp("radios_raw.csv").exists() and _radio_nlp("intent_labeled_data.csv").exists()
+)
 
 
 def test_render_leads_with_proxy_caveat():
@@ -35,7 +49,7 @@ def test_render_handles_missing_precision():
 
 
 @pytest.mark.data
-@pytest.mark.skipif(not _HAS_CORPUS, reason="radio corpus absent (CI runner without data)")
+@pytest.mark.skipif(not _HAS_CORPUS, reason="radio corpus not downloaded")
 def test_unlabeled_radios_excludes_the_labeled_set():
     """The sample is drawn only from radios absent from the hand-labeled intent set."""
     import pandas as pd
@@ -44,9 +58,5 @@ def test_unlabeled_radios_excludes_the_labeled_set():
 
     sample = _unlabeled_radios(30)
     assert sample is not None and len(sample) == 30
-    labeled = set(
-        pd.read_csv(ROOT / "data" / "processed" / "radio_nlp" / "intent_labeled_data.csv")[
-            "message"
-        ].astype(str)
-    )
+    labeled = set(pd.read_csv(_radio_nlp("intent_labeled_data.csv"))["message"].astype(str))
     assert all(text not in labeled for text in sample)

--- a/tests/eval/test_nlp_golden.py
+++ b/tests/eval/test_nlp_golden.py
@@ -21,27 +21,40 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).parent.parent.parent
-_INTENT_DIR = ROOT / "data" / "models" / "nlp" / "intent_setfit_modernbert_v1"
-_HAS_INTENT_HEAD = (_INTENT_DIR / "model_head.pkl").exists()
-_HAS_NER_CFG = (ROOT / "data" / "models" / "nlp" / "ner_v1" / "model_config.json").exists()
-_HAS_NER_MODEL = (
-    ROOT / "data" / "models" / "nlp" / "ner_v1" / "bert_bio_v1" / "bert_bio_state_dict.pt"
-).exists()
-_HAS_RCM_CORPUS = bool(list((ROOT / "data" / "processed").glob("race_radios/2025/*/rcm.parquet")))
+
+
+def _models_file(*parts: str) -> Path:
+    """A model artefact at the path the stage reads.
+
+    Every probe in this module goes through `get_data_root()` / `get_models_root()`
+    rather than `ROOT / "data"`, because `F1_STRAT_DATA_ROOT` moves what the code
+    reads and a probe anchored on the repo does not follow it. A probe that MISSES
+    while the code hits degrades to a skip, which is harmless; a probe that HITS
+    while the code misses turns a skip into a hard failure, and that is what a
+    repo-anchored probe produced under the override (three failures, none of them a
+    real defect).
+    """
+    from src.f1_strat_manager.data_cache import get_models_root
+
+    return get_models_root().joinpath(*parts)
+
+
+def _processed_dir() -> Path:
+    """``<data root>/processed``, for the same reason as above."""
+    from src.f1_strat_manager.data_cache import get_data_root
+
+    return get_data_root() / "processed"
 
 
 def _label_file(name: str) -> Path:
-    """A label file at the path the stage reads, which is not always under the repo.
+    """A label file at the path the stage reads, for the same reason as above."""
+    return _processed_dir() / "radio_nlp" / name
 
-    The probes above use `ROOT / "data"`; `src/strategy/eval/nlp.py` uses
-    `get_data_root()`, and `F1_STRAT_DATA_ROOT` moves that elsewhere. For the
-    weights the difference is harmless (a probe that misses degrades to a skip),
-    but these two decide between a skip and a failure, so they read what the code
-    reads.
-    """
-    from src.f1_strat_manager.data_cache import get_data_root
 
-    return get_data_root() / "processed" / "radio_nlp" / name
+_HAS_INTENT_HEAD = _models_file("nlp", "intent_setfit_modernbert_v1", "model_head.pkl").exists()
+_HAS_NER_CFG = _models_file("nlp", "ner_v1", "model_config.json").exists()
+_HAS_NER_MODEL = _models_file("nlp", "ner_v1", "bert_bio_v1", "bert_bio_state_dict.pt").exists()
+_HAS_RCM_CORPUS = bool(list(_processed_dir().glob("race_radios/2025/*/rcm.parquet")))
 
 
 # The label sets the intent and NER stages score against. Both are on the Hub
@@ -89,7 +102,7 @@ def test_gold_bio_tags_align_to_split_words():
 
 
 @pytest.mark.data
-@pytest.mark.skipif(not _HAS_INTENT_HEAD, reason="intent head absent (CI runner without weights)")
+@pytest.mark.skipif(not _HAS_INTENT_HEAD, reason="intent head not downloaded")
 def test_intent_predict_proba_order_is_aligned():
     """NR-08: the production predict_proba decode reads the correct class (no swap)."""
     from src.strategy.eval.nlp import verify_intent_column_order
@@ -100,7 +113,7 @@ def test_intent_predict_proba_order_is_aligned():
 
 
 @pytest.mark.data
-@pytest.mark.skipif(not _HAS_INTENT_HEAD, reason="intent model absent (CI runner without weights)")
+@pytest.mark.skipif(not _HAS_INTENT_HEAD, reason="intent model not downloaded")
 @pytest.mark.skipif(not _HAS_INTENT_LABELS, reason="intent_labeled_data.csv not downloaded")
 def test_intent_reproduction_is_sane():
     """Setfit-free reproduction runs and beats chance on the labeled set."""
@@ -113,7 +126,7 @@ def test_intent_reproduction_is_sane():
 
 
 @pytest.mark.data
-@pytest.mark.skipif(not _HAS_INTENT_HEAD, reason="intent model absent (CI runner without weights)")
+@pytest.mark.skipif(not _HAS_INTENT_HEAD, reason="intent model not downloaded")
 @pytest.mark.skipif(not _HAS_INTENT_LABELS, reason="intent_labeled_data.csv not downloaded")
 def test_alert_precision_from_gold_is_high():
     """Alert precision (intent PROBLEM/WARNING) is real (gold-derived) and clears 0.8."""
@@ -137,7 +150,7 @@ def test_dead_ner_classes_flags_zero_f1_types():
 
 
 @pytest.mark.data
-@pytest.mark.skipif(not _HAS_NER_MODEL, reason="ner weights absent (CI runner without weights)")
+@pytest.mark.skipif(not _HAS_NER_MODEL, reason="ner weights not downloaded")
 @pytest.mark.skipif(
     not _HAS_NER_ANNOTATIONS, reason="f1_radio_entity_annotations.json not downloaded"
 )
@@ -151,7 +164,7 @@ def test_ner_entity_f1_reproduces_headline():
 
 
 @pytest.mark.data
-@pytest.mark.skipif(not _HAS_RCM_CORPUS, reason="2025 rcm corpus absent (CI runner without data)")
+@pytest.mark.skipif(not _HAS_RCM_CORPUS, reason="2025 rcm corpus not downloaded")
 def test_rcm_coverage_is_high():
     """The ported parser leaves few OTHER events; overall coverage clears 0.9."""
     from src.strategy.eval.nlp import reproduce_rcm

--- a/tests/test_construction_artefacts_are_downloadable.py
+++ b/tests/test_construction_artefacts_are_downloadable.py
@@ -51,11 +51,25 @@ _CONSTRUCTION_READS = {
 #
 # `ner_v1/model_config.json` sits one level ABOVE the weights, so the pattern that pulls
 # `ner_v1/bert_bio_v1/**` misses it and every clean install lost NR-07 (#1146).
+#
+# The value is the artefact path; the needle is what proves the module still reads it.
+# A bare filename works when the filename is distinctive. It is NOT enough for
+# `model_config.json`, which appears five times in `nlp.py` for five different models, and
+# the parent directory is worse: `_NER_DIR = "ner_v1"` at nlp.py:54 survives deleting the
+# read entirely, so that needle could not fail. Verified by relocating the read to another
+# path in a scratch worktree, which compiled and left the guard green.
 _EVAL_READS = {
     "nlp.py": (
-        "data/processed/radio_nlp/intent_labeled_data.csv",
-        "data/processed/radio_nlp/f1_radio_entity_annotations.json",
-        "data/models/nlp/ner_v1/model_config.json",
+        ("data/processed/radio_nlp/intent_labeled_data.csv", "intent_labeled_data.csv"),
+        (
+            "data/processed/radio_nlp/f1_radio_entity_annotations.json",
+            "f1_radio_entity_annotations.json",
+        ),
+        ("data/models/nlp/ner_v1/model_config.json", '_NER_DIR / "model_config.json"'),
+    ),
+    "alert_llm.py": (
+        ("data/processed/radio_nlp/radios_raw.csv", "radios_raw.csv"),
+        ("data/processed/radio_nlp/intent_labeled_data.csv", "intent_labeled_data.csv"),
     ),
 }
 
@@ -102,11 +116,13 @@ def test_the_module_still_reads_the_artefact_this_test_claims(module, artefact):
     )
 
 
-@pytest.mark.parametrize(
-    ("module", "artefact"),
-    sorted((mod, art) for mod, arts in _EVAL_READS.items() for art in arts),
+_EVAL_CASES = sorted(
+    (mod, art, needle) for mod, reads in _EVAL_READS.items() for art, needle in reads
 )
-def test_an_eval_label_set_is_pulled_by_the_downloader(module, artefact):
+
+
+@pytest.mark.parametrize(("module", "artefact", "needle"), _EVAL_CASES)
+def test_an_eval_artefact_is_pulled_by_the_downloader(module, artefact, needle):
     """The download list must cover what the eval stages read, or the report loses a row."""
     patterns = _patterns()
     assert _covers(patterns, artefact), (
@@ -116,21 +132,14 @@ def test_an_eval_label_set_is_pulled_by_the_downloader(module, artefact):
     )
 
 
-@pytest.mark.parametrize(
-    ("module", "artefact"),
-    sorted((mod, art) for mod, arts in _EVAL_READS.items() for art in arts),
-)
-def test_the_eval_module_still_reads_the_artefact_this_test_claims(module, artefact):
+@pytest.mark.parametrize(("module", "artefact", "needle"), _EVAL_CASES)
+def test_the_eval_module_still_reads_the_artefact_this_test_claims(module, artefact, needle):
     """Same staleness guard as the construction list above, for the same reason."""
     source = (ROOT / "src" / "strategy" / "eval" / module).read_text(encoding="utf-8")
-    filename = artefact.rsplit("/", 1)[-1]
-    stem = filename.rsplit(".", 1)[0]
-    # `model_config.json` is built from a directory constant plus the bare filename, so
-    # the path never appears whole in the source and the parent directory is the claim.
-    needle = filename if filename != "model_config.json" else artefact.split("/")[-2]
     assert needle in source, (
-        f"src/strategy/eval/{module} no longer mentions {needle} (for {stem}): either the "
-        f"read moved and this entry is stale, or the list needs whatever replaced it."
+        f"src/strategy/eval/{module} no longer contains {needle!r}, the expression that "
+        f"reads {artefact}: either the read moved and this entry is stale, or the list "
+        f"needs whatever replaced it."
     )
 
 


### PR DESCRIPTION
## What

An adversarial gate over the guards #1148 added found two of them asserting nothing, and a third artefact of the same class still unpublished.

## The three defects

**1. `radios_raw.csv` was never published.** `src/strategy/eval/alert_llm.py:86` reads it, and like every member of this class (#798, #837, #1146) the miss does not raise: `run_alert_precision_llm` returns `AlertLLMResult(..., None, "intent set or radios_raw.csv absent")`. So `f1-eval alert-llm` returned a degraded row on every install, and the last skip in the suite fired with the reason `radio corpus absent (CI runner without data)` on a machine that has data.

Published under `data/processed/radio_nlp/`, 684 rows, `driver`/`text`/`duration`. `filename` and `file_path` were dropped: nothing reads them and they carry a relative path into an `f1-strategy/data/audio` tree no repo has any more. `text` preserved verbatim, verified by re-fetching from the Hub and comparing sha256 (`ceb1a181ceaa5044`). The pattern list already pulls the directory, so no pattern change was needed.

The test this un-skips does not spend LLM. It exercises the corpus selection; the judge is reachable only through `f1-eval alert-llm`, which stays out of `f1-eval all`.

**2. The `model_config.json` staleness needle could not fail.** It asserted the string `ner_v1`, which survives via `_NER_DIR` at `nlp.py:54` whether or not the guarded read exists. Each `_EVAL_READS` entry now carries the expression that performs its read (`_NER_DIR / "model_config.json"`), and `alert_llm.py`'s two reads were added, so the table names both modules rather than one.

**3. Five probes were anchored on the repo while the code reads `get_data_root()`.** `_HAS_INTENT_HEAD`, `_HAS_NER_CFG`, `_HAS_NER_MODEL` and `_HAS_RCM_CORPUS` in `test_nlp_golden.py`, plus `_HAS_CORPUS` and one `pd.read_csv` in `test_alert_llm_golden.py`. Under `F1_STRAT_DATA_ROOT` the probes hit while the code missed, so three tests FAILED where they should have skipped.

The docstring #1148 added said the difference was "harmless (a probe that misses degrades to a skip)". That is true in the direction that does not happen. A probe that hits while the code misses turns a skip into a hard failure, and it guarded the very test whose skip reason the same commit reworded.

## Checks

| | before | after |
|---|---|---|
| `tests/eval` + the download guard | 115 passed, 5 skipped | **120 passed, 0 skipped** |
| the same, under an empty `F1_STRAT_DATA_ROOT` | 3 failed, 3 passed, 3 skipped | **5 passed, 7 skipped, 0 failed** |

- The repaired needle watched RED against the mutant that defeated the old one: the `dead_ner_classes` read relocated to another path, confirmed applied by grepping its marker, confirmed to still compile with `ast.parse`, and `_NER_DIR` still present three times. The old needle passed that mutant; the new one fails on it. Restored afterwards.
- `uvx ruff@0.15.22 check .` clean, `format --check .` 204 files.
- Skip reasons across both files now say what a skip actually reports, which is that the artefact was not downloaded, rather than naming a runner.
