### PR TITLE
docs: correct four places that describe a sample or a layout that changed

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -438,10 +438,10 @@ Wire the multi-agent system into the FastAPI backend, expose strategy tools via 
 - [X] FastMCP server mounted alongside FastAPI; `/chat/` is an MCP client ✅
 - [X] Phase 1: agent MCP tools: `predict_pace`, `predict_tire`, `predict_situation`, `predict_pit`, `analyze_radio`, `query_regulations`, `recommend_strategy` ✅
 - [X] Phase 2: telemetry MCP tools via `FastMCP.from_openapi()`: `get_lap_times`, `get_telemetry`, `compare_drivers`, `get_race_data` (HTTP fallback for chat) ✅
-- [X] **2026-04-14: inline Plotly chart rendering** for the 4 Phase 2 tools in the chat: new `chart_builders.py`, `_render_chart` dispatcher, purple-outlined bubbles matching the agent cards. Backend trim split via `_trim_for_llm` so the UI receives the full payload. Qdrant singleton fix (`@lru_cache` on `get_retriever`) ✅
-- [X] `pages/strategy.py`: Live strategy card (action badge, confidence bar, scenario scores, reasoning) ✅
+- [X] **2026-04-14: inline Plotly chart rendering** for the 4 Phase 2 tools in the chat: new `chart_builders.py` (Streamlit-era, removed with that frontend in v2.0.0), `_render_chart` dispatcher, purple-outlined bubbles matching the agent cards. Backend trim split via `_trim_for_llm` so the UI receives the full payload. Qdrant singleton fix (`@lru_cache` on `get_retriever`) ✅
+- [X] `pages/strategy.py`: Live strategy card (action badge, confidence bar, scenario scores, reasoning) ✅ (Streamlit-era; the React web app carries this surface since v2.0.0)
   - Sub-agent tabs: Pace (CI ribbon), Tyres (cliff gauge), Race Situation (overtake + SC gauges), Pit Analysis (undercut + duration)
-- [X] `pages/race_analysis.py`: 5-tab race view (Overview, Competitive, Gap Analysis, Degradation, Predictions) ✅
+- [X] `pages/race_analysis.py`: 5-tab race view (Overview, Competitive, Gap Analysis, Degradation, Predictions) ✅ (Streamlit-era; same migration as the row above)
   - Port legacy components from `legacy/app_streamlit_v1/` with N25-N31 API data sources
 
 **Step 11: CLI simulation demo (`scripts/run_simulation_cli.py`):** ✅ DONE

--- a/docs/pages/pitwall.md
+++ b/docs/pages/pitwall.md
@@ -107,10 +107,13 @@ bar. The band answers one question per module across the line the eye lands on
 anyway, left to right in the order a reader asks them, which is what the
 orchestrator is doing, why, on what evidence, and what happens next.
 
-**The Qt lineage ends at the layout, and only at the layout.** Every string,
-colour and glyph still comes out of `src/pitwall/agents_view/`, which is the Qt
-window's own code, so the two surfaces cannot describe the same lap
-differently. What the port inherited and then dropped is the geometry: a header
+**The Qt lineage ends at the layout, and only at the layout.** The host formats
+nothing on the React side: every headline, body line and colour is produced by
+`src/pitwall/agent_formatters.py`, the Qt window's own formatting code, and
+`agents_view/builder.py` states that as its first invariant. Chart colours come
+from `src/arcade/palette`, which the replay uses too. The Qt window itself is
+gone, so the rule now buys a single source for the strings rather than agreement
+between two surfaces. What the port inherited and then dropped is the geometry: a header
 strip over a 540 / 740 horizontal split, decision in the left column and a 3x2
 card grid in the right. That split made the decision a peer of the agent grid,
 two territories with no reading order, and put the most important content on the

--- a/scripts/llm_cost_probe.py
+++ b/scripts/llm_cost_probe.py
@@ -2,9 +2,10 @@
 
 Sizing question this exists to answer: the 2025 measurement session wants the
 stack driven in ``rich`` mode over decision windows, and nobody knows what that
-costs. A full-season sweep through the deterministic path is already ~11.5 h of
-wall clock at 0.51 s/lap; with an unbounded number of LLM calls per lap the
-ceiling is unknown and it is billed per call.
+costs. The deterministic path sweeps a full season in about half an hour
+(``documents/eval_reports/decision_modes.md``); with an unbounded number of LLM
+calls per lap the ceiling is unknown and it is billed per call, so the ratio
+between the two paths is the thing to measure rather than assume.
 
 The unit is the LAP, not the race, because the session's sample is made of
 windows rather than whole races. Boot cost (model weights, Whisper, the RAG

--- a/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
@@ -297,10 +297,10 @@ export function AgentsWindow() {
         </div>
 
         {/* The six consoles below it, in named grid areas rather than source
-            order: the two chart cards take the tall slots, SITUATION and PIT
-            are compact and both feed the decision so they stack beside them,
-            and RADIO carries the wordiest content on the window - transcripts -
-            so it spans two columns.
+            order: the two chart cards take the tall slots, and SITUATION and
+            PIT are compact and both feed the decision so they stack beside
+            them. Two rows, not three, since PIT EXIT took the middle of the
+            bottom one and RADIO went down to a single column.
 
             SITUATION and PIT share ONE area through a stack rather than taking
             a grid row each. Given a row each they sat at the top of two equal

--- a/src/pitwall/ui/src/styles/agents.css
+++ b/src/pitwall/ui/src/styles/agents.css
@@ -274,15 +274,15 @@
  *
  * Named areas rather than source order, because three of the six want a shape
  * the reading order does not give them: the two chart cards need the tall
- * slots, SITUATION and PIT are compact and both feed the decision so they
- * stack beside them, and RADIO carries the wordiest content on the window -
- * transcripts - so it spans two columns.
+ * slots, and SITUATION and PIT are compact and both feed the decision so they
+ * stack beside them in one area.
  *
- * Rows 1 and 2 are `minmax(0, 1fr)` so the chart column splits the available
- * height evenly with the two stacked cards; row 3 is content-sized with a
- * floor. `minmax(0, …)` rather than `1fr` alone: a `1fr` row has an automatic
- * MINIMUM of its content, so a card that overflows pushes the grid past its
- * container instead of scrolling inside itself. */
+ * Two rows since PIT EXIT took the middle of the bottom one. Row 1 is
+ * `minmax(0, 1fr)` so the chart column takes the available height; row 2 is
+ * content-sized. `minmax(0, …)` rather than `1fr` alone: a `1fr` row has an
+ * automatic MINIMUM of its content, so a card that overflows pushes the grid
+ * past its container instead of scrolling inside itself. RADIO's one column and
+ * what it cost are documented on `.slot-exit` below, where the change was made. */
 
 .agents-grid {
   display: grid;

--- a/tests/eval/test_decision_modes.py
+++ b/tests/eval/test_decision_modes.py
@@ -2,16 +2,19 @@
 
 Two layers, deliberately split the same way ``test_position_projection.py`` splits:
 
-1. Pure tests that pin the contract — which stops the guard rails make
+1. Pure tests that pin the contract, which stops the guard rails make
    unanswerable, how an agreement is aggregated, when coverage is untrustworthy,
-   and that the report keeps saying it is a subset. These run everywhere.
+   and that the report keeps naming its scope. These run everywhere.
 
 2. One data-tier test that refuses to believe a sample it has not counted. It
    needs ``data/raw`` and skips without it.
 
-The report's honesty is itself under test here. ``test_render_states_the_subset``
+The report's honesty is itself under test here.
+``test_render_names_every_race_and_keeps_season_scope_apart_from_coverage``
 exists because the single most damaging edit anyone could make to this module is
-deleting the sentence that says the figures are conditional on six races.
+deleting the sentence that says which races the figures come from. That sentence
+used to say the sample was six races; since #1143 it says the whole 2025 season,
+and the test follows the scope rather than the wording.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## What

Four descriptions that no longer match the thing they describe, found by an adversarial gate over #1144 and #1149.

## The twin #1144 missed

`scripts/llm_cost_probe.py:4-6` sizes itself against *"A full-season sweep through the deterministic path is already ~11.5 h of wall clock at 0.51 s/lap"*. `documents/eval_reports/decision_modes.md:81-84` retires that estimate by name, and `src/strategy/eval/decision_modes.py:104-111` explains why: the tier replays only the union of the scoring windows, so a season is 8,393 laps at 0.213 s each, about half an hour. The probe was off by a factor of 23 in its own sizing rationale.

It now cites the report rather than a number, because the ratio between the two paths is the thing the probe exists to measure.

#1144 corrected four places describing the same retired sample and left this one. That is the repo's dominant defect, inside the change written to close an instance of it.

## Three the PIT EXIT sprint left

| where | said | is |
|---|---|---|
| `tests/eval/test_decision_modes.py:12-14` | `test_render_states_the_subset` guards the sentence saying the figures are conditional on six races | that test does not exist; the live one is `test_render_names_every_race_and_keeps_season_scope_apart_from_coverage`, and since #1143 the renderer says the whole 2025 season |
| `agents.css:275-286` and `AgentsWindow.tsx:299-303` | RADIO spans two columns, three-row grid | one column, two rows. Both files contradict themselves a few lines below, where the sprint added the correction beside the old enumeration instead of replacing it |
| `docs/pages/pitwall.md` | every string comes out of `agents_view/`, so the two surfaces cannot diverge | `builder.py:46-47`'s own first invariant names `agent_formatters`, which lives outside that directory; chart colours come from `src/arcade/palette`; and the Qt window is deleted, so there is one surface, not two |

The pitwall.md sentence is mine, from #1149. The intent was right and the specifics were not.

## Also

Three `[X]` entries in `ROADMAP.md` (lines 441-444) name Streamlit-era files that exist nowhere, not even under `legacy/`: `chart_builders.py`, `pages/strategy.py`, `pages/race_analysis.py`. Annotated with where that surface went, the way the retired dashboard-test line already is.

`docs/pages/streamlit.md` names two of the same paths and needs nothing: its first line already says the surface is retired and the paths below no longer exist.

## Checks

- `tests/eval/test_decision_modes.py` + `test_docs_site_links.py` + `test_diagrams_no_retired_surface.py`: 62 passed.
- `npm run build` in `src/pitwall/ui`: 0 TS errors. `npm run smoke`: 137 + 373 checks, so the layout the comments describe is the one that renders.
- `uvx ruff@0.15.22 check .` clean, `format --check .` 204 files.
- Zero em dashes and zero second person in the edited page.
