### PR TITLE
fix(agents): single-source the LLM retry budget and raise it above one

### DIFF
--- a/src/agents/_shared_defaults.py
+++ b/src/agents/_shared_defaults.py
@@ -20,6 +20,21 @@ from typing import Any, Mapping
 # one site at a time.
 DEFAULT_TOTAL_LAPS: int = 57
 
+# How many times an agent's LLM client retries a recoverable failure. The SDK retries
+# only connection errors, 408, 409, 429 and 5xx, and it waits what the provider asks:
+# ``openai._base_client.BaseClient._calculate_retry_timeout`` honours ``Retry-After``
+# when it is between 0 and 60 s, and otherwise backs off exponentially with jitter. So
+# the budget is spent in provider-declared waits rather than in guesses.
+#
+# It was 1, which is two attempts, and a single 429 mid-burst cost a whole lap of an LLM
+# run: the API reported 178831 of 200000 TPM used and asked for a retry, but a TPM
+# window drains over a MINUTE and both attempts landed inside it (#1153). Five covers
+# one window. It does NOT make a long enough burst safe; pacing the run still does that.
+#
+# Restated as a bare ``1`` in twelve places across six agent modules before this, which
+# is the same drift ``DEFAULT_TOTAL_LAPS`` above was consolidated to stop.
+LLM_MAX_RETRIES: int = 5
+
 
 def reading_or_default(source: Mapping[str, Any], key: str, default: float) -> float:
     """Read a numeric reading that may be ABSENT or PRESENT-AND-``None``.

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -40,7 +40,10 @@ from src.strategy.inference.guard_rails import (
     _NO_PIT_LAST_N_LAPS,
 )
 
-from src.agents._shared_defaults import DEFAULT_TOTAL_LAPS
+from src.agents._shared_defaults import (
+    DEFAULT_TOTAL_LAPS,
+    LLM_MAX_RETRIES,
+)
 from src.agents.race_state_builder import UNKNOWN_TYRE_LIFE
 
 # ── Repo root (with root-stop guard for uv tool install) ─────────────────────
@@ -1416,10 +1419,10 @@ class PitStrategyAgent:
                 model_kwargs={'parallel_tool_calls': False},
                 disable_streaming=True,
                 timeout=120,
-                max_retries=1,
+                max_retries=LLM_MAX_RETRIES,
             )
         else:
-            llm = ChatOpenAI(model=model_name, temperature=0, timeout=120, max_retries=1)
+            llm = ChatOpenAI(model=model_name, temperature=0, timeout=120, max_retries=LLM_MAX_RETRIES)
 
         self._react_agent = create_agent(
             llm, self._tools, system_prompt=_PIT_STRATEGY_SYSTEM_PROMPT

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -33,6 +33,7 @@ from src.agents._shared_defaults import (
     DEFAULT_AIR_TEMP_C,
     DEFAULT_TOTAL_LAPS,
     DEFAULT_TRACK_TEMP_C,
+    LLM_MAX_RETRIES,
     reading_or_default,
 )
 
@@ -1556,10 +1557,10 @@ class RaceSituationAgent:
                 api_key=api_key,
                 temperature=0,
                 timeout=120,
-                max_retries=1,
+                max_retries=LLM_MAX_RETRIES,
             )
         else:
-            llm = ChatOpenAI(model=model_name, temperature=0, timeout=120, max_retries=1)
+            llm = ChatOpenAI(model=model_name, temperature=0, timeout=120, max_retries=LLM_MAX_RETRIES)
 
         self._react_agent = create_agent(
             model=llm,

--- a/src/agents/radio_agent.py
+++ b/src/agents/radio_agent.py
@@ -143,6 +143,8 @@ from src.f1_strat_manager.rcm_events import (  # noqa: E402
     classify_rcm_event as _classify_rcm_event,
 )
 
+from src.agents._shared_defaults import LLM_MAX_RETRIES
+
 
 
 
@@ -808,7 +810,7 @@ def _get_radio_llm():
                 model=CFG.model_name,
                 temperature=0.0,
                 timeout=120,
-                max_retries=1,
+                max_retries=LLM_MAX_RETRIES,
             )
         else:
             base_llm = ChatOpenAI(
@@ -818,7 +820,7 @@ def _get_radio_llm():
                 temperature=0.0,
                 model_kwargs={"parallel_tool_calls": False},
                 timeout=120,
-                max_retries=1,
+                max_retries=LLM_MAX_RETRIES,
             )
         _structured_llm = base_llm.with_structured_output(RadioSynthesis)
     return _structured_llm

--- a/src/agents/rag_agent.py
+++ b/src/agents/rag_agent.py
@@ -46,6 +46,8 @@ from src.rag.retriever import (  # noqa: E402
     query_rag_tool,
 )
 
+from src.agents._shared_defaults import LLM_MAX_RETRIES
+
 # ── Optional LangChain / LangGraph imports ─────────────────────────────
 # Probed, not imported. `import langchain_openai` costs 14.3 s measured: it drags
 # the langgraph stack and transformers in behind it, and every consumer of the
@@ -179,7 +181,7 @@ def get_rag_react_agent():
 
         provider = os.environ.get("F1_LLM_PROVIDER", "lmstudio")
         if provider == "openai":
-            llm = ChatOpenAI(model="gpt-4.1-mini", temperature=0, timeout=120, max_retries=1)
+            llm = ChatOpenAI(model="gpt-4.1-mini", temperature=0, timeout=120, max_retries=LLM_MAX_RETRIES)
         else:
             llm = ChatOpenAI(
                 model="gpt-4.1-mini",
@@ -188,7 +190,7 @@ def get_rag_react_agent():
                 temperature=0,
                 model_kwargs={"parallel_tool_calls": False},
                 timeout=120,
-                max_retries=1,
+                max_retries=LLM_MAX_RETRIES,
             )
         _rag_agent = create_agent(
             model=llm,

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -47,6 +47,8 @@ import numpy as np
 import pandas as pd
 from pydantic import BaseModel, ConfigDict, Field
 
+from src.agents._shared_defaults import LLM_MAX_RETRIES
+
 logger = logging.getLogger(__name__)
 
 # ── Repo root (with root-stop guard for uv tool install) ─────────────────────
@@ -193,7 +195,7 @@ def _get_orchestrator_llm():
         provider = os.environ.get("F1_LLM_PROVIDER", "lmstudio")
         if provider == "openai":
             # No parallel_tool_calls: OpenAI rejects it when no tools are specified
-            llm = ChatOpenAI(model=CFG.model_name, temperature=CFG.temperature, timeout=120, max_retries=1)
+            llm = ChatOpenAI(model=CFG.model_name, temperature=CFG.temperature, timeout=120, max_retries=LLM_MAX_RETRIES)
         else:
             llm = ChatOpenAI(
                 model=CFG.model_name,
@@ -202,7 +204,7 @@ def _get_orchestrator_llm():
                 temperature=CFG.temperature,
                 model_kwargs={"parallel_tool_calls": False},
                 timeout=120,
-                max_retries=1,
+                max_retries=LLM_MAX_RETRIES,
             )
         if _temperature_was_dropped(llm, CFG.temperature):
             # ASCII only: this line lands on Windows terminals, where the repo's
@@ -1562,6 +1564,7 @@ def _run_mc_simulation(
 from src.rag.store_lock import LOCK_EXCEPTIONS as _LOCK_EXCEPTIONS
 from src.rag.store_lock import QDRANT_LOCK_SIGNATURE as _QDRANT_LOCK_SIGNATURE  # noqa: F401
 from src.rag.store_lock import is_store_locked as _is_store_locked
+
 
 
 # Logged once per process, not once per lap. A locked store fails every lap

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -37,6 +37,7 @@ from src.agents._shared_defaults import (
     DEFAULT_AIR_TEMP_C,
     DEFAULT_TOTAL_LAPS,
     DEFAULT_TRACK_TEMP_C,
+    LLM_MAX_RETRIES,
     reading_or_default,
 )
 from src.agents.race_state_builder import UNKNOWN_TYRE_LIFE, normalise_compound
@@ -1508,10 +1509,10 @@ class TireAgent:
                 api_key=api_key,
                 temperature=0,
                 timeout=120,
-                max_retries=1,
+                max_retries=LLM_MAX_RETRIES,
             )
         else:
-            llm = ChatOpenAI(model=model_name, temperature=0, timeout=120, max_retries=1)
+            llm = ChatOpenAI(model=model_name, temperature=0, timeout=120, max_retries=LLM_MAX_RETRIES)
 
         self._react_agent = create_agent(
             model=llm,

--- a/tests/agents/test_llm_retry_budget_is_single_sourced.py
+++ b/tests/agents/test_llm_retry_budget_is_single_sourced.py
@@ -1,0 +1,74 @@
+"""No agent restates the LLM retry budget as a literal (#1153).
+
+A 429 the API declared recoverable in 148 ms cost a whole lap of an LLM run,
+because ``max_retries=1`` is two attempts and a TPM window drains over a minute.
+The number itself was the smaller half of the problem: it was written out
+**twelve times across six modules**, once per provider branch, so raising it in
+one place and missing the other eleven was the likely outcome.
+
+This asserts the shape rather than the value. ``_shared_defaults`` is where the
+repo already collapses this kind of drift (see ``DEFAULT_TOTAL_LAPS``), and
+``test_no_shadowed_shared_defaults.py`` then stops an agent redefining the name.
+What is left to guard is the literal coming back.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+AGENTS = ROOT / "src" / "agents"
+
+# Every module that builds an LLM client. Named rather than globbed, so deleting a
+# module's client is visible here instead of silently shrinking the guard.
+_LLM_MODULES = (
+    "strategy_orchestrator.py",
+    "pit_strategy_agent.py",
+    "race_situation_agent.py",
+    "tire_agent.py",
+    "radio_agent.py",
+    "rag_agent.py",
+)
+
+
+def _max_retries_values(source: str) -> list[ast.expr]:
+    """Every ``max_retries=<expr>`` passed to a call in the module."""
+    return [
+        kw.value
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        for kw in node.keywords
+        if kw.arg == "max_retries"
+    ]
+
+
+def test_the_shared_budget_exists_and_beats_a_single_retry():
+    """The constant is importable, and it is worth more than the 1 it replaced."""
+    from src.agents._shared_defaults import LLM_MAX_RETRIES
+
+    assert isinstance(LLM_MAX_RETRIES, int)
+    assert LLM_MAX_RETRIES > 1, (
+        "one retry is two attempts, which is what let a mid-burst 429 cost a lap"
+    )
+
+
+@pytest.mark.parametrize("module", _LLM_MODULES)
+def test_the_module_builds_its_client_with_the_shared_budget(module: str):
+    """Both provider branches read the constant; neither restates a number."""
+    path = AGENTS / module
+    values = _max_retries_values(path.read_text(encoding="utf-8"))
+
+    assert len(values) == 2, (
+        f"{module} passes max_retries {len(values)} times, expected 2 "
+        f"(the openai branch and the lmstudio branch). A new client needs the "
+        f"constant too; a removed one needs this count updated."
+    )
+    for value in values:
+        assert isinstance(value, ast.Name) and value.id == "LLM_MAX_RETRIES", (
+            f"{module}:{value.lineno} passes a literal to max_retries. Import "
+            f"LLM_MAX_RETRIES from src.agents._shared_defaults instead, so raising "
+            f"the budget moves every call site at once."
+        )


### PR DESCRIPTION
Closes #1153.

## What

`max_retries` moves out of six agent modules into `src/agents/_shared_defaults.py` as `LLM_MAX_RETRIES`, and goes from **1 to 5**.

## Why

`f1-sim Lusail NOR McLaren --laps 6-8` in LLM mode lost lap 7 to a `RateLimitError: 429` on `gpt-4.1-mini`: TPM limit 200000, used 178831, requested 21663. Lap 7 of Qatar 2025 is the lap the Safety Car is deployed on, so the lap lost was the interesting one.

`max_retries=1` is two attempts. The message quotes a 148 ms estimate, but a TPM window drains over a **minute**, and one burst of laps fills it, so both attempts landed inside the same window.

The retry machinery is well behaved, which is what makes the budget the whole defect. `openai` 2.29.0:

```python
retry_after = self._parse_retry_after_header(response_headers)
if retry_after is not None and 0 < retry_after <= 60:
    return retry_after
```

It waits exactly what the provider asks when the header is sane, and backs off exponentially with jitter otherwise, and it only retries connection errors, 408, 409, 429 and 5xx. Each extra retry therefore costs a provider-declared wait rather than a guess.

## The twin, times six

The literal was restated **twelve times across six modules**, once for the `openai` branch and once for `lmstudio`:

`strategy_orchestrator.py` 196/205 · `pit_strategy_agent.py` 1419/1422 · `race_situation_agent.py` 1559/1562 · `tire_agent.py` 1511/1514 · `radio_agent.py` 811/821 · `rag_agent.py` 182/191

`_shared_defaults.py` is where this repo already collapses exactly this drift, and `DEFAULT_TOTAL_LAPS` three lines above the new constant records the previous instance in its own comment. Putting it there also brings `test_no_shadowed_shared_defaults.py` into play, which stops an agent redefining the name later.

## Guard

`tests/agents/test_llm_retry_budget_is_single_sourced.py` asserts the shape rather than the value: the constant beats 1, and each of the six modules passes `max_retries` exactly twice, both times as the `Name` node `LLM_MAX_RETRIES`. The count is asserted too, so adding a seventh client or deleting one is visible instead of silently shrinking the guard.

Watched RED against a mutant that put `max_retries=1` back into `tire_agent.py`, with the marker grepped to confirm it applied and `ast.parse` to confirm it still compiled. It failed on `[tire_agent.py]` at the literal assertion, then restored.

## What this does NOT fix

A TPM window is a minute wide and the budget is finite, so a long enough burst still exhausts it. This lowers the failure rate on a recoverable error; pacing the run is still the sizing lever for a measurement session.

`src/strategy/eval/alert_llm.py:68,74` builds `ChatOpenAI` with no `max_retries` at all and so gets the SDK default of 2. Left alone: it is the eval tier, not an agent, and changing it is a separate decision.

## Checks

- `tests/agents` **329 passed**.
- `tests/agents/test_llm_retry_budget_is_single_sourced.py` + `test_no_shadowed_shared_defaults.py` 19 passed.
- Real path: `f1-sim Lusail NOR McLaren --laps 1-20 --no-llm` reproduces the baseline exactly, `STAY_OUT·17 PIT_NOW·3`, 7 radio alerts, best lap 85.615 s.
- Both modules that needed a brand new import (`strategy_orchestrator`, `rag_agent`) were imported in a fresh interpreter to prove the name resolves.
- `uvx ruff@0.15.22 check .` clean, `format --check .` 205 files.
