### PR TITLE
fix(eval): mark harness_sha dirty instead of naming the parent commit

### DIFF
--- a/src/strategy/eval/report.py
+++ b/src/strategy/eval/report.py
@@ -36,7 +36,14 @@ ERA_TAG = "2022-2025"
 
 
 def _harness_sha() -> str:
-    """Short git SHA of the repo the harness runs from, or ``unknown``.
+    """Describe the commit the harness runs from, or ``unknown``.
+
+    Uses ``git describe --always --dirty`` rather than a bare
+    ``rev-parse --short HEAD``: a report generated from a modified working
+    tree (the normal case, since regeneration happens before the change that
+    motivated it gets committed) gets a ``-dirty`` suffix, so the stamped
+    value tells a reader when it does NOT pin a reproducible commit instead
+    of silently naming the parent commit as if it did (#1152).
 
     Returns ``unknown`` when running outside a checkout (e.g. an installed
     tool venv) so a report is never blocked on git being available.
@@ -46,7 +53,7 @@ def _harness_sha() -> str:
         return "unknown"
     try:
         out = subprocess.run(
-            ["git", "-C", str(repo), "rev-parse", "--short", "HEAD"],
+            ["git", "-C", str(repo), "describe", "--always", "--dirty"],
             capture_output=True,
             text=True,
             timeout=5,
@@ -72,8 +79,9 @@ class ReportHeader:
     """Provenance stamp attached to every eval report (E-15).
 
     Invariants:
-    - ``harness_sha`` pins the code; ``artifacts`` pins the model weights;
-      together they make a report reproducible.
+    - ``harness_sha`` pins the code and ``artifacts`` pins the model weights;
+      together they make a report reproducible, and a ``-dirty`` suffix on
+      ``harness_sha`` says plainly when that does NOT hold.
     - ``generated_at`` is provenance only and is NOT part of report equality
       (two runs of the same code on the same data are "equal" bar the clock).
     - ``llm`` is ``none`` for pure-ML reports; NLP/orchestrator reports that

--- a/src/strategy/eval/report.py
+++ b/src/strategy/eval/report.py
@@ -36,14 +36,20 @@ ERA_TAG = "2022-2025"
 
 
 def _harness_sha() -> str:
-    """Describe the commit the harness runs from, or ``unknown``.
+    """Short git SHA of the repo the harness runs from, or ``unknown``.
 
-    Uses ``git describe --always --dirty`` rather than a bare
-    ``rev-parse --short HEAD``: a report generated from a modified working
-    tree (the normal case, since regeneration happens before the change that
-    motivated it gets committed) gets a ``-dirty`` suffix, so the stamped
-    value tells a reader when it does NOT pin a reproducible commit instead
-    of silently naming the parent commit as if it did (#1152).
+    Uses ``git describe --always --dirty --exclude='*'`` rather than a bare
+    ``rev-parse --short HEAD``. The ``--exclude`` pattern matches every tag,
+    so ``describe`` has no tag left to describe from and falls back to the
+    same short hash ``--always`` gives on its own; without it, ``describe``
+    walks back to the nearest reachable tag instead and stamps a long,
+    tag-relative description (e.g. ``legacy-2026-07-13-1098-g8b6cb305``) in
+    place of the short sha the header is supposed to pin. The one addition
+    over a bare ``rev-parse`` is the ``-dirty`` suffix, appended when the
+    working tree does not match the stamped commit: reports are regenerated
+    on a dirty tree before the change that motivated the regeneration gets
+    committed, so the sha used to be silently one commit stale with nothing
+    marking it (#1152).
 
     Returns ``unknown`` when running outside a checkout (e.g. an installed
     tool venv) so a report is never blocked on git being available.
@@ -53,7 +59,7 @@ def _harness_sha() -> str:
         return "unknown"
     try:
         out = subprocess.run(
-            ["git", "-C", str(repo), "describe", "--always", "--dirty"],
+            ["git", "-C", str(repo), "describe", "--always", "--dirty", "--exclude=*"],
             capture_output=True,
             text=True,
             timeout=5,

--- a/tests/eval/test_report_header_provenance.py
+++ b/tests/eval/test_report_header_provenance.py
@@ -7,18 +7,25 @@ renderer's ``artifacts`` placeholder in four reports without touching the
 renderer. The next regeneration put the em dash back in a fifth, so the tree held
 two spellings of the same empty value and neither traced to the code.
 
-These two tests close that loop from both ends: the renderer's placeholder is
-asserted directly, and every committed report is asserted to carry a placeholder
-the renderer can produce.
+Two tests close that loop from both ends: the renderer's placeholder is asserted
+directly, and every committed report is asserted to carry a placeholder the
+renderer can produce.
+
+A third test guards a separate defect in the same header (#1152):
+``harness_sha`` used to pin the parent commit with no marker saying the working
+tree that generated the report was never committed at all, so a report could
+name a commit that cannot produce the bytes it stamps.
 """
 
 from __future__ import annotations
 
 import re
+import subprocess
 from pathlib import Path
 
 import pytest
 
+import src.strategy.eval.report as report
 from src.strategy.eval.report import ReportHeader, _render_md
 
 ROOT = Path(__file__).parent.parent.parent
@@ -65,3 +72,37 @@ def test_committed_report_artifacts_line_matches_the_renderer(report: Path):
         assert re.fullmatch(r"[\w.\-]+=`[0-9a-f]+`", entry), (
             f"{report.name} artifacts entry {entry!r} is not a rendered name=`hash` pair"
         )
+
+
+def _run_git(repo: Path, *args: str) -> None:
+    """Run a git command against `repo`, raising if it fails."""
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+
+def test_harness_sha_marks_a_dirty_working_tree(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """`_harness_sha()` flags an uncommitted change instead of naming the parent commit.
+
+    Exercises a real, disposable git repository under `tmp_path` rather than
+    mocking `subprocess`, so the guard fails if the command reverts to
+    `git rev-parse --short HEAD`, which carries no dirty marker and always
+    names the last commit even when the tree that produced the report was
+    never committed (#1152).
+    """
+    repo = tmp_path / "probe"
+    repo.mkdir()
+    _run_git(repo, "init", "-q")
+    _run_git(repo, "config", "user.email", "probe@test.local")
+    _run_git(repo, "config", "user.name", "probe")
+    tracked = repo / "tracked.txt"
+    tracked.write_text("v1", encoding="utf-8")
+    _run_git(repo, "add", "tracked.txt")
+    _run_git(repo, "commit", "-q", "-m", "init")
+
+    monkeypatch.setattr(report, "_find_repo_root", lambda: repo)
+
+    clean_sha = report._harness_sha()
+    assert not clean_sha.endswith("-dirty"), f"clean tree stamped as dirty: {clean_sha!r}"
+
+    tracked.write_text("v2", encoding="utf-8")  # uncommitted change to a tracked file
+    dirty_sha = report._harness_sha()
+    assert dirty_sha.endswith("-dirty"), f"modified tree not flagged as dirty: {dirty_sha!r}"

--- a/tests/eval/test_report_header_provenance.py
+++ b/tests/eval/test_report_header_provenance.py
@@ -14,7 +14,12 @@ renderer can produce.
 A third test guards a separate defect in the same header (#1152):
 ``harness_sha`` used to pin the parent commit with no marker saying the working
 tree that generated the report was never committed at all, so a report could
-name a commit that cannot produce the bytes it stamps.
+name a commit that cannot produce the bytes it stamps. It also pins the SHAPE
+of the value, not only its dirty/clean state: a probe repo with no reachable
+tag cannot tell a bare ``git describe --always --dirty`` apart from the
+correct ``--exclude='*'`` form, since both fall back to the same short hash
+when there is nothing to describe from, so the probe repo carries a tag on
+purpose.
 """
 
 from __future__ import annotations
@@ -79,14 +84,29 @@ def _run_git(repo: Path, *args: str) -> None:
     subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
 
 
+# A short git SHA: hex digits only, git's usual 7-40 char abbreviation range.
+# A tag-relative `describe` output (`legacy-2026-07-13-1098-g8b6cb305`) fails
+# this on both counts, letters outside a-f and a length no abbreviation reaches.
+_SHORT_SHA = re.compile(r"^[0-9a-f]{4,40}$")
+
+
 def test_harness_sha_marks_a_dirty_working_tree(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """`_harness_sha()` flags an uncommitted change instead of naming the parent commit.
+    """`_harness_sha()` is a short sha, dirty-suffixed only when the tree is.
 
     Exercises a real, disposable git repository under `tmp_path` rather than
-    mocking `subprocess`, so the guard fails if the command reverts to
-    `git rev-parse --short HEAD`, which carries no dirty marker and always
-    names the last commit even when the tree that produced the report was
-    never committed (#1152).
+    mocking `subprocess`, with a tag on its first commit so the repo behaves
+    like this one (which carries `legacy-2026-07-13` on an ancestor of HEAD)
+    rather than a bare scratch repo, where a tagless `describe` looks
+    identical whether or not `--exclude` is passed.
+
+    Two things are pinned, not one. The dirty marker guards the fix from
+    #1152: reverting to `git rev-parse --short HEAD` carries no `-dirty`
+    suffix and always names the last commit, even when the tree that
+    produced the report was never committed. The shape guards the fix to
+    that fix: dropping `--exclude='*'` lets `describe` walk back to the
+    reachable tag and stamp a long, tag-relative description in its place,
+    which still ends in `-dirty` on schedule and would pass a check that
+    only looked at the suffix.
     """
     repo = tmp_path / "probe"
     repo.mkdir()
@@ -97,12 +117,19 @@ def test_harness_sha_marks_a_dirty_working_tree(tmp_path: Path, monkeypatch: pyt
     tracked.write_text("v1", encoding="utf-8")
     _run_git(repo, "add", "tracked.txt")
     _run_git(repo, "commit", "-q", "-m", "init")
+    # Annotated, not lightweight: `describe` ignores lightweight tags by default.
+    _run_git(repo, "tag", "-a", "unrelated-legacy-tag", "-m", "probe tag")
 
     monkeypatch.setattr(report, "_find_repo_root", lambda: repo)
 
     clean_sha = report._harness_sha()
     assert not clean_sha.endswith("-dirty"), f"clean tree stamped as dirty: {clean_sha!r}"
+    assert _SHORT_SHA.fullmatch(clean_sha), (
+        f"clean sha {clean_sha!r} is not a bare short sha, the reachable tag leaked in"
+    )
 
     tracked.write_text("v2", encoding="utf-8")  # uncommitted change to a tracked file
     dirty_sha = report._harness_sha()
-    assert dirty_sha.endswith("-dirty"), f"modified tree not flagged as dirty: {dirty_sha!r}"
+    assert dirty_sha == f"{clean_sha}-dirty", (
+        f"dirty sha {dirty_sha!r} is not the clean sha plus -dirty"
+    )


### PR DESCRIPTION
## What

`_harness_sha()` in `src/strategy/eval/report.py` ran `git rev-parse --short HEAD`, which pins the parent commit with no way to say the working tree that produced a report was never committed.

## Why

Reports are regenerated on a dirty tree before the change that motivated the regeneration lands, so the stamped sha was always one commit stale, and nothing marked it. Both committed generations of `decision_modes` show it: the pinned commit cannot render the artifacts line or the sample size the report states in the same file.

## How

Switched `_harness_sha()` to `git describe --always --dirty --exclude=*`, so a report generated from a modified tree carries a `-dirty` suffix instead of silently naming a commit it does not match. Updated the `ReportHeader` docstring's invariant to state that.

The `--exclude=*` flag is load-bearing on its own, not decoration. A first version of this fix used `git describe --always --dirty` with no `--exclude`, and in this repo that returns `legacy-2026-07-13-1098-g8b6cb305`: `describe` walks back to the nearest reachable tag and stamps a tag-relative description instead of the short sha the header is supposed to pin. `--exclude=*` matches every tag, so `describe` has none left and falls back to the same short hash `--always` gives on its own, with `-dirty` still appended when the tree does not match.

Checked for the same pattern elsewhere in the codebase (a grep across `src/` and `scripts/` for `rev-parse`/`git describe`): `report.py` is the only project code computing a git sha this way, so there is no second copy of the bug to fix.

Added a test that builds a real, disposable git repository under `tmp_path`, points `_harness_sha()` at it via `monkeypatch`, and asserts a clean tree is not flagged while a tracked, uncommitted change is. The probe repo carries an annotated tag on its first commit (an unannotated one is invisible to `describe` by default and would not reproduce the tag-relative bug), and the test also asserts the clean value matches a short-hex-sha pattern, not only the dirty/clean suffix.

Verified the guard fails for the right reason twice. Reverting the whole command to `rev-parse --short HEAD` failed with `modified tree not flagged as dirty: '7dd0185'`, the bare parent sha with no marker. Dropping only `--exclude=*` (the actual regression caught by hand in review, not by the first version of this guard) failed with `clean sha 'unrelated-legacy-tag' is not a bare short sha, the reachable tag leaked in` — the first version of the test could not have caught this, since a probe repo with no reachable tag makes the two commands indistinguishable.

## Out of scope

Does not regenerate `documents/eval_reports/decision_modes.{md,json}` or any other committed report. The renderer change is the whole fix; committed reports pick up the new header format the next time each is regenerated, which is a separate, larger sweep.

## Checks

- `uv run pytest tests/eval/test_report_header_provenance.py` (11 passed) and the full `tests/eval/` suite in a checkout with data present (104 passed)
- `uvx ruff@0.15.22 check .` and `format --check .` clean, repo-wide
- No LLM calls made

Closes #1152
