### PR TITLE
docs(pitwall): document the DATA window's other two tabs

### DIFF
--- a/docs/pages/pitwall.md
+++ b/docs/pages/pitwall.md
@@ -81,9 +81,9 @@ field by lap fraction, and the **radio feed**: race control messages and
 driver radio in one list, newest line on top, the header naming the total so
 the cut at the bottom is never silent. The feed carries the whole field
 rather than only the pinned car, a rival's line marked `BROADCAST`, the same
-tag band 4 gives a rival's trace: a real team receives the public broadcast
-radio feed too, so showing it is fidelity rather than a privilege the window
-grants itself.
+tag the rival's traces carry. A real team receives the public broadcast radio
+feed too, so showing it is fidelity rather than a privilege the window grants
+itself.
 
 **RACE PACE** is a grid, one column per driver and one row per lap: how quick
 each lap was. **RACE TRACE** is a chart of the same laps read the other way,
@@ -96,12 +96,15 @@ own arithmetic: a grid squeezed to half this height stops showing enough laps
 to read as a history, and a trace squeezed the same way, to roughly 300 px,
 stops resolving the gaps it exists to show.
 
-Shipping both, with the grid one click from the default tab, runs against
-what the pit-wall research behind this window found. Across seven sources and
-six photographs of a real SBG/Catapult RaceX client, not one race-trace line
-chart appears on a wall, while the literature names the gapper plot the
-central strategy tool, and the pace grid takes up more screen area than
-anything else in the photographs. RACE TRACE stays because the question it
+Shipping both, with the grid one click from the default tab, follows what the
+pit-wall research behind this window found and what it could not settle.
+Across seven sources and six photographs of a real SBG/Catapult RaceX client,
+not one race-trace line chart appears on a wall, while the literature names
+the gapper plot the central strategy tool, and the pace grid takes up more
+screen area than anything else in the photographs. The photographs cover the
+in-session view, so they cannot rule out a trace living on an analysis tab;
+what they establish is which of the two a wall keeps in front of it during a
+race. RACE TRACE stays because the question it
 answers has no other tab that can answer it.
 
 Four details that are not cosmetic:

--- a/docs/pages/pitwall.md
+++ b/docs/pages/pitwall.md
@@ -68,10 +68,41 @@ green for a driver's own best, amber for slower than his own. Under it, the
 **bests**: S1, S2, S3 and Lap ranked across the field with their percentage off
 the leader, and the theoretical lap those three sectors recombine into.
 
-**Right: the own car's lap** as four locked-axis traces against distance: Δ
-Time, Speed, Brake, Throttle, ported field by field from the Qt telemetry
-panel, plus a shared vertical cursor marking where the car is on the lap, and a
-schematic **track ring** placing the whole field by lap fraction.
+**Right: a tab strip over three panels**, because the column has 825 px of
+width to give and sharing it costs one of them too much: with the track ring
+still mounted, the pace grid's columns narrow enough that 1,101 of 1,140
+cells clip. The panels take turns instead.
+
+**TRACES**, the tab open by default, is the own car's lap as four locked-axis
+traces against distance: Δ Time, Speed, Brake, Throttle, ported field by field
+from the Qt telemetry panel, plus a shared vertical cursor marking where the
+car is on the lap. Beside it, a schematic **track ring** placing the whole
+field by lap fraction, and the **radio feed**: race control messages and
+driver radio in one list, newest line on top, the header naming the total so
+the cut at the bottom is never silent. The feed carries the whole field
+rather than only the pinned car, a rival's line marked `BROADCAST`, the same
+tag band 4 gives a rival's trace: a real team receives the public broadcast
+radio feed too, so showing it is fidelity rather than a privilege the window
+grants itself.
+
+**RACE PACE** is a grid, one column per driver and one row per lap: how quick
+each lap was. **RACE TRACE** is a chart of the same laps read the other way,
+where everyone is relative to a reference over the whole race: one cut down
+it at a given lap gives every gap in the field at that moment, a question
+the grid cannot answer.
+
+Splitting the two across tabs rather than stacking them repeats the column's
+own arithmetic: a grid squeezed to half this height stops showing enough laps
+to read as a history, and a trace squeezed the same way, to roughly 300 px,
+stops resolving the gaps it exists to show.
+
+Shipping both, with the grid one click from the default tab, runs against
+what the pit-wall research behind this window found. Across seven sources and
+six photographs of a real SBG/Catapult RaceX client, not one race-trace line
+chart appears on a wall, while the literature names the gapper plot the
+central strategy tool, and the pace grid takes up more screen area than
+anything else in the photographs. RACE TRACE stays because the question it
+answers has no other tab that can answer it.
 
 Four details that are not cosmetic:
 


### PR DESCRIPTION
## What

Rewrites the "Right" half of the PITWALL DATA section in `docs/pages/pitwall.md` from the code. The right column is a tab strip over three panels (TRACES, RACE PACE, RACE TRACE), and the page described only TRACES, naming two of its three panels and leaving the radio feed out entirely.

## Why

`src/pitwall/ui/src/features/data/DataWindow.tsx` renders a `role="tablist"` over three tabs, each mounting a different panel. The page's prose predates the tabs and described the column as if TRACES were the whole thing. PR #1149 rewrote the AGENTS section against the code and left this half untouched, so the half that was already wrong stayed wrong.

## How

Read `DataWindow.tsx` (its module docstring and the tab-strip block), `RacePaceGrid.tsx`, `RaceTraceChart.tsx` and `RadioFeed.tsx`, and rewrote the section to cover:

- why the column is a tab strip: 825 px of width to give, and 1,101 of 1,140 pace-grid cells clip once the track ring stays mounted alongside it
- what each of the three tabs answers: TRACES (own-car traces, track ring, radio feed), RACE PACE (one column per driver, one row per lap), RACE TRACE (the same laps read the other way, one cut down the chart gives every gap in the field at a given lap)
- the radio feed, previously absent from the page: whole field, a `BROADCAST` tag on a rival's line, newest line on top
- the pace-grid-over-race-trace decision, and its evidence: across seven sources and six photographs of a real SBG/Catapult RaceX client, no race-trace line chart appears on a wall, while the pace grid takes up more screen area than anything else in the photographs, and the page shipped both without saying why

## Out of scope

No changes under `src/pitwall/`. Read-only against the component code.

## Checks

- `uv run pytest tests/surfaces/test_docs_site_links.py tests/surfaces/test_diagrams_no_retired_surface.py` (24 passed)
- `uvx ruff@0.15.22 check .` and `format --check .` clean, repo-wide
- No LLM calls made

Closes #1156