### PR TITLE
fix(arcade): wire no_llm through to the strategy pipeline

### DIFF
--- a/src/arcade/app.py
+++ b/src/arcade/app.py
@@ -229,6 +229,7 @@ class F1ArcadeView(arcade.View):
         year: int = 2024,
         strategy_enabled: bool = False,
         team: str | None = None,
+        no_llm: bool = False,
     ) -> None:
         super().__init__(window=window)
         arcade.set_background_color(BG_COLOR)
@@ -245,6 +246,9 @@ class F1ArcadeView(arcade.View):
         self._year = year
         self._strategy_enabled = strategy_enabled
         self._team = team
+        # Reaches `_init_strategy_layer`'s `SimulateRequestDTO`, which used to
+        # hardcode `no_llm=False` regardless of what the caller wanted (#1155).
+        self._no_llm = no_llm
         self._strategy_connector = None  # set by __init__ if strategy_enabled
         self._strategy_state = None
         self._stream_server = None
@@ -429,7 +433,7 @@ class F1ArcadeView(arcade.View):
             team=self._team or "",
             driver2=self._driver_rival,
             risk_tolerance=0.5,
-            no_llm=False,
+            no_llm=self._no_llm,
             provider=provider,
             interval_s=0.0,
         )

--- a/src/arcade/main.py
+++ b/src/arcade/main.py
@@ -55,6 +55,16 @@ def _parse_args() -> argparse.Namespace:
         "--strategy", action="store_true", help="Enable strategy overlay (requires year 2025)."
     )
     parser.add_argument("--provider", choices=("lmstudio", "openai"), default="openai")
+    parser.add_argument(
+        "--no-llm",
+        action="store_true",
+        help=(
+            "Run the strategy layer on the deterministic profile (zero LLM "
+            "clients, zero cost) instead of the LLM-synthesised one. Only "
+            "takes effect with --viewer and --strategy; the in-window menu "
+            "has no toggle for it yet."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -89,6 +99,7 @@ def _show_viewer_directly(window: arcade.Window, args: argparse.Namespace) -> No
     if args.driver2:
         cfg.driver_rival = args.driver2.upper()
     cfg.strategy_mode = args.strategy
+    cfg.no_llm = args.no_llm
     view = MenuView(window)
     window.show_view(view)
     view.launch_with(cfg)

--- a/src/arcade/strategy.py
+++ b/src/arcade/strategy.py
@@ -483,7 +483,7 @@ class SimConnector(threading.Thread):
         # instead of the plan the model was given.
         memory_block = self._memory.block()
         rec, agent_outputs = run_strategy_pipeline(
-            race_state, laps_df, lap_state, memory=self._memory
+            race_state, laps_df, lap_state, memory=self._memory, no_llm=self._request.no_llm
         )
         self._memory.record(race_state.lap, rec)
         plan_changed = self._memory.last_call_changed()

--- a/src/arcade/strategy_pipeline.py
+++ b/src/arcade/strategy_pipeline.py
@@ -35,15 +35,25 @@ def run_strategy_pipeline(
     laps_df: pd.DataFrame,
     lap_state: dict | None = None,
     memory: "DecisionMemory | None" = None,
+    no_llm: bool = False,
 ) -> tuple["StrategyRecommendation", dict]:
     """Run the full N31 pipeline; return the recommendation and per-agent outputs.
 
-    Public signature stays backward compatible: ``memory`` is optional and
-    defaults to ``None``, so ``src/arcade/strategy.py`` and the dashboard
-    formatters that already call this positionally keep working unchanged. The
-    ``agent_outputs`` dict carries the same keys as before (``pace_out``/
-    ``tire_out``/``situation_out``/``radio_out``/``pit_out``/
-    ``regulation_context``/``rag``/``active``) plus ``guardrail_reason``.
+    Public signature stays backward compatible: ``memory`` and ``no_llm`` are
+    both optional and default to the pre-existing behaviour (LLM synthesis),
+    so ``src/arcade/strategy.py`` and the dashboard formatters that already
+    call this positionally keep working unchanged. The ``agent_outputs`` dict
+    carries the same keys as before (``pace_out``/``tire_out``/
+    ``situation_out``/``radio_out``/``pit_out``/``regulation_context``/
+    ``rag``/``active``) plus ``guardrail_reason``.
+
+    ``no_llm`` (#1155) selects ``run_lap``'s deterministic profile instead of
+    the LLM-synthesised one: ``True`` routes through ``"no-llm"`` (zero LLM
+    clients, ``src/strategy/inference/no_llm.py``), ``False`` keeps the
+    existing ``"rich"`` profile. The caller carried this flag through two
+    dataclasses and a constructor call without it ever reaching here, so
+    setting it on the arcade's request changed nothing and the arcade always
+    ran the paid path.
 
     **The stage timings are LOGGED, not returned and not broadcast (#1045).**
     This docstring used to say they were dropped here and that "a future arcade
@@ -60,8 +70,9 @@ def run_strategy_pipeline(
 
     DEBUG and not INFO: this runs once per lap of every arcade race.
     """
+    profile = "no-llm" if no_llm else "rich"
     rec, agent_outputs, timings = run_lap(
-        race_state, laps_df, lap_state, profile="rich", memory=memory
+        race_state, laps_df, lap_state, profile=profile, memory=memory
     )
     if logger.isEnabledFor(logging.DEBUG):
         breakdown = " ".join(f"{stage}={seconds:.3f}s" for stage, seconds in timings.items())

--- a/src/arcade/views.py
+++ b/src/arcade/views.py
@@ -68,6 +68,10 @@ class LaunchConfig:
     driver_rival: str = "LEC"
     team: str = "McLaren"
     strategy_mode: bool = False
+    # Reachable only through `--viewer --no-llm` (main.py:_show_viewer_directly);
+    # the in-window menu has no row for it, so an interactive launch keeps the
+    # LLM path by default. #1155.
+    no_llm: bool = False
 
 
 @dataclass
@@ -910,5 +914,6 @@ class MenuView(arcade.View):
             year=self._cfg.year,
             strategy_enabled=self._cfg.strategy_mode,
             team=self._cfg.team,
+            no_llm=self._cfg.no_llm,
         )
         self.window.show_view(view)

--- a/src/pitwall/agents_view/decision.py
+++ b/src/pitwall/agents_view/decision.py
@@ -313,18 +313,23 @@ def build_orchestrator(
     **There is no guardrail line, and that is the fix rather than an omission
     (#974).** The window used to render `⚠ Guardrail: <reason>` from
     `latest["guardrail_reason"]`, a field typed, documented, styled and tested
-    on a path that cannot deliver it. The chain, walked end to end:
+    on a path that cannot deliver it. The chain, walked end to end, at the
+    time #974 removed the render:
 
     - `apply_guard_rails` produces a reason at exactly one production site,
       `src/strategy/inference/no_llm.py:302`.
     - `run_lap` hardcodes `guardrail_reason=None` for the `rich` profile
       (`src/strategy/inference/engine.py:303`), because rich mode puts the
       bounds in the LLM's prompt instead of applying them after the fact.
-    - `src/arcade/strategy_pipeline.py:48` hardcodes `profile="rich"`, and
-      `src/arcade/app.py` builds its request with a literal `no_llm=False`.
+    - the arcade had no way to reach any other profile: `run_strategy_pipeline`
+      hardcoded `profile="rich"` and `src/arcade/app.py` built its request
+      with a literal `no_llm=False`, both since fixed (#1155).
 
-    Therefore, on every arcade path the value is None by construction, and the
-    line was permanently blank.
+    On the arcade's default (LLM) path the value is still None by
+    construction, for the same reason as always: rich mode never calls
+    `apply_guard_rails`. `--no-llm` (#1155) now reaches a profile that can
+    produce a real reason, and the window still does not render it. Restoring
+    the line is the breadcrumb below, not something #1155 took on.
 
     --- WHERE TO CHANGE IF THE ARCADE LEARNS TO RUN WITHOUT AN LLM ---
     Restore the field here, the `guardrail` key on `OrchestratorView`

--- a/tests/surfaces/test_arcade_no_llm_wire.py
+++ b/tests/surfaces/test_arcade_no_llm_wire.py
@@ -13,6 +13,13 @@ The defect lived in the hop between them, so the guard has to sit there too.
 and `_build_decision` all run for real, so a "fix" that reconnects the wire at
 the wrong hop (patching the middle back to a hardcoded profile, say) still
 fails this file, not just the line it touched.
+
+Data-tier (`skip_no_tire_models`): importing `src.arcade.strategy_pipeline` pulls
+in `src.strategy.inference.engine`, which pulls in the full agent stack, and
+`TireAgentConfig` reads `data/models/tire_degradation/routing_config.json` at
+import time regardless of which profile a test exercises. Runs locally + on the
+data tier; skips on bare CI, same as `tests/engine/test_engine_no_llm.py` and
+`tests/audit/test_engine_scope_defaults.py`, which import the same chain.
 """
 
 from __future__ import annotations
@@ -23,9 +30,13 @@ from typing import Any
 import pandas as pd
 import pytest
 
+from tests.conftest import skip_no_tire_models as _skip_no_models
+
 pytest.importorskip("arcade", reason="the arcade replay is an optional surface")
 
 from src.arcade.strategy import SimConnector, SimulateRequestDTO, StrategyState  # noqa: E402
+
+pytestmark = _skip_no_models
 
 
 def _connector(no_llm: bool) -> SimConnector:

--- a/tests/surfaces/test_arcade_no_llm_wire.py
+++ b/tests/surfaces/test_arcade_no_llm_wire.py
@@ -1,0 +1,120 @@
+"""#1155: `no_llm` reaches `run_lap`'s profile, all the way from the request.
+
+`no_llm` was carried through two dataclasses and a constructor call and dropped
+at the last hop: `SimConnector._step_once` (`strategy.py:485`) called
+`run_strategy_pipeline` without it, and `run_strategy_pipeline`
+(`strategy_pipeline.py:33-38`) had no parameter to receive it and hardcoded
+`profile="rich"` (`:64`). Setting the flag on the arcade's request changed
+nothing, and a unit test of either end would have passed throughout: the
+request held the value, and `run_lap` already accepted a `profile` keyword.
+The defect lived in the hop between them, so the guard has to sit there too.
+
+`run_lap` is the only thing patched below. `_step_once`, `run_strategy_pipeline`
+and `_build_decision` all run for real, so a "fix" that reconnects the wire at
+the wrong hop (patching the middle back to a hardcoded profile, say) still
+fails this file, not just the line it touched.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pandas as pd
+import pytest
+
+pytest.importorskip("arcade", reason="the arcade replay is an optional surface")
+
+from src.arcade.strategy import SimConnector, SimulateRequestDTO, StrategyState  # noqa: E402
+
+
+def _connector(no_llm: bool) -> SimConnector:
+    """A `SimConnector` whose request carries `no_llm`, nothing else exercised."""
+    request = SimulateRequestDTO(
+        year=2025, gp="Lusail", driver="NOR", team="McLaren", no_llm=no_llm
+    )
+    return SimConnector(request=request, state=StrategyState())
+
+
+def _fake_race_state() -> SimpleNamespace:
+    """Just enough fields for the real, unpatched `_build_decision` to read back."""
+    return SimpleNamespace(lap=1, compound="MEDIUM", tyre_life=5, position=3, gap_ahead_s=1.2)
+
+
+def _fake_run_lap(captured: dict[str, Any]):
+    """A `run_lap` stand-in that records `profile` and returns a minimal, valid triple.
+
+    Signature mirrors the real `run_lap` exactly (`race_state, laps_df, lap_state,
+    *, profile, return_agent_outputs, memory`) so a caller that drifts its call
+    shape fails here instead of at the real boundary.
+    """
+
+    def run_lap(
+        race_state, laps_df, lap_state, *, profile="rich", return_agent_outputs=True, memory=None
+    ):
+        captured["profile"] = profile
+        captured["memory"] = memory
+        rec = SimpleNamespace(
+            action="STAY_OUT",
+            confidence=0.5,
+            reasoning="",
+            scenario_scores={},
+            pace_mode=None,
+            risk_posture=None,
+            pit_lap_target=None,
+            compound_next=None,
+            undercut_target=None,
+            contingencies=None,
+            key_risks=None,
+        )
+        return rec, {}, {"total": 0.0}
+
+    return run_lap
+
+
+@pytest.mark.parametrize("no_llm, expected_profile", [(True, "no-llm"), (False, "rich")])
+def test_the_request_reaches_run_lap_as_the_matching_profile(monkeypatch, no_llm, expected_profile):
+    """`no_llm=True/False` on the request must reach `run_lap` as `profile="no-llm"`/`"rich"`.
+
+    Drives the real `_step_once` end to end. `_build_race_state` is stubbed
+    because race-state construction is not the wire under test here (it has
+    its own coverage elsewhere); `run_lap` is stubbed because calling it for
+    real needs model weights and, on the rich profile, an LLM client. Every
+    hop between the two — `_step_once`, `run_strategy_pipeline`,
+    `_build_decision` — is the real production code.
+    """
+    import src.arcade.strategy_pipeline as pipeline_module
+
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(pipeline_module, "run_lap", _fake_run_lap(captured))
+
+    connector = _connector(no_llm)
+    monkeypatch.setattr(
+        connector, "_build_race_state", lambda lap_state, prev_lap_time: _fake_race_state()
+    )
+
+    connector._step_once(pd.DataFrame(), {"lap_number": 1, "driver": {"lap_time_s": 90.0}}, 90.0)
+
+    assert captured.get("profile") == expected_profile, (
+        f"no_llm={no_llm} on the request reached run_lap as "
+        f"profile={captured.get('profile')!r}, expected {expected_profile!r} — "
+        f"the flag is dropped somewhere between the request and run_lap"
+    )
+
+
+def test_run_strategy_pipeline_defaults_to_the_rich_profile(monkeypatch):
+    """A caller that omits `no_llm` entirely must keep the pre-#1155 behaviour.
+
+    `run_strategy_pipeline`'s docstring promises backward compatibility: `memory`
+    and `no_llm` are both optional. This pins the second half of that promise —
+    the dashboard formatters the docstring names call this positionally without
+    ever knowing `no_llm` exists, and they must keep getting `"rich"`.
+    """
+    from src.arcade.strategy_pipeline import run_strategy_pipeline
+
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr("src.arcade.strategy_pipeline.run_lap", _fake_run_lap(captured))
+
+    run_strategy_pipeline(_fake_race_state(), pd.DataFrame(), {"lap_number": 1})
+
+    assert captured["profile"] == "rich"

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -1452,10 +1452,13 @@ def test_the_window_renders_no_guardrail_line_because_nothing_can_fill_it():
     """#974: a field typed, styled, documented and written by no producer.
 
     The view used to carry `⚠ Guardrail: <reason>` from
-    `latest["guardrail_reason"]`. `run_lap` hardcodes that to None for the
-    `rich` profile, `strategy_pipeline` hardcodes `profile="rich"`, and
-    `src/arcade/app.py` builds its request with a literal `no_llm=False`, so
-    on every arcade path the line was permanently blank.
+    `latest["guardrail_reason"]`. At the time #974 removed the render,
+    `run_lap` hardcoded that to None for the `rich` profile,
+    `strategy_pipeline` hardcoded `profile="rich"`, and `src/arcade/app.py`
+    built its request with a literal `no_llm=False`, so on every arcade path
+    the line was permanently blank. #1155 fixed the last two, so `--no-llm`
+    now reaches a profile that CAN produce a real reason; `build_orchestrator`
+    still drops the key regardless of profile, which is what this test pins.
 
     Asserted as the KEY BEING ABSENT while a reason is supplied, not as an
     empty string. An empty string is what the defect produced for its whole


### PR DESCRIPTION
## What

`no_llm` was carried by two dataclasses and a constructor call and dropped at the last hop. `SimConnector._step_once` (`src/arcade/strategy.py:485`) called `run_strategy_pipeline` without it, and `run_strategy_pipeline` (`src/arcade/strategy_pipeline.py:33-38`) had no parameter to receive it and hardcoded `profile="rich"` (`:64`). Setting the flag on the arcade's request changed nothing, and the arcade had no way to run without the LLM at all.

## Why

Found while recording the 2.6 demo assets: a run set up with `no_llm` called OpenAI on lap 1 and had to be killed after about eight calls. `f1-sim` has `--no-llm`; the arcade had no equivalent.

## How

- `run_strategy_pipeline` (`strategy_pipeline.py:33-38`) gained a `no_llm: bool = False` keyword and picks `profile = "no-llm" if no_llm else "rich"`.
- `SimConnector._step_once` (`strategy.py:486`) now passes `no_llm=self._request.no_llm`.
- `src/arcade/main.py`: new `--no-llm` flag, threaded into the `LaunchConfig` the `--viewer` shortcut builds.
- `src/arcade/views.py`: `LaunchConfig` gained a `no_llm` field (default `False`, so the interactive menu is unaffected); `F1ArcadeView(...)` now receives it.
- `src/arcade/app.py`: `F1ArcadeView.__init__` gained `no_llm: bool = False`, stored as `self._no_llm`; `_init_strategy_layer` now passes `no_llm=self._no_llm` instead of a literal `no_llm=False`.

### Why `views.py` is in this diff

The issue scoped three files. `views.py` is not one of them, but it is not scope creep either: it is the only path from the CLI flag to the request object. `main.py --no-llm` sets `cfg.no_llm` on a `LaunchConfig`; that config is what `_show_replay` reads when it constructs `F1ArcadeView(...)`; that constructor is what feeds `_init_strategy_layer`'s `SimulateRequestDTO`. There is no way to thread the flag from `main.py` to `app.py:432` (now `:436`) without touching the `LaunchConfig` field and the one constructor call that passes it on. The change there is five lines: one dataclass field, one keyword at one call site.

### Why `decision.py` and its test are in this diff

`build_orchestrator`'s docstring (`src/pitwall/agents_view/decision.py:313-327`) documented, with file:line citations, why the arcade could never produce a real `guardrail_reason`: it named the exact two hardcodes this PR removes (`strategy_pipeline.py`'s `profile="rich"`, `app.py`'s literal `no_llm=False`). That reasoning stops being true the moment this PR lands: `--no-llm` now reaches a profile that can produce a real reason. Left alone, the docstring would describe a mechanism this same PR deletes.

This is a comment-only fix, not new scope. `build_orchestrator`'s code is unchanged; it still drops the `guardrail` key regardless of profile (restoring that line is `#974`'s follow-up, named in the docstring's own `WHERE TO CHANGE` breadcrumb, not something this PR takes on). The paired test, `test_the_window_renders_no_guardrail_line_because_nothing_can_fill_it`, had its docstring updated the same way. **Its assertions are byte-for-byte unchanged** (`assert "guardrail" not in supplied`, `assert "guardrail" not in idle`, `assert "min stint" not in str(supplied)`), and so are its inputs. Nothing about the guard was relaxed to accommodate this change; only the comment explaining why it still holds was corrected.

## Guard

New file `tests/surfaces/test_arcade_no_llm_wire.py`, three tests. The main one drives the real `_step_once` end to end with only `run_lap` patched (`_build_race_state` is stubbed since race-state construction is not the wire under test), so a fix that reconnects the wire at the wrong hop still fails it.

Mutation check: reintroduced the bug by dropping `no_llm=` from the `_step_once` call site, marked with a grepped comment, confirmed the file still parses (`ast.parse`), ran the guard:

```
FAILED tests/surfaces/test_arcade_no_llm_wire.py::test_the_request_reaches_run_lap_as_the_matching_profile[True-no-llm]
AssertionError: no_llm=True on the request reached run_lap as profile='rich', expected 'no-llm'
1 failed, 2 passed in 4.79s
```

The `no_llm=False` case passed even with the bug present, which is exactly the issue's own observation: the value that gets ignored happens to match the behaviour. Restored the line and reran: `3 passed`.

## Checks

- `tests/surfaces` + `tests/cli`: 528 passed, 18 skipped (submodule/pickle not present in this worktree, unrelated to this change).
- `ruff check .` and `ruff format --check .`: clean, repo-wide.
- Real path, `SimConnector._drive_pipeline()` driven directly (no mocks) against real Lusail 2025 telemetry with `no_llm=True` and `ChatOpenAI` bombed in every agent module that exposes one at module scope: 5 laps processed, zero LLM clients constructed.
- Real path, `f1-sim Lusail NOR McLaren --laps 1-20 --no-llm`: unchanged, `STAY_OUT·17 PIT_NOW·3`, radio alerts 7, best lap 85.615s.

## Out of scope

- Restoring the guardrail line on the AGENTS window (`#974`'s follow-up, breadcrumb already in `decision.py`).
- `docs/pages/arcade-quick-start.md:49` claims the AGENTS card has "a guardrail line that shows when the no-LLM hard guard overrode the LLM pick." `build_orchestrator` (`src/pitwall/agents_view/decision.py:308-345`) never emits a `guardrail` key on any profile, so no window has ever shown that line since `#974`. Left alone here since it is unrelated to this fix; worth its own issue.

Closes #1155