### PR TITLE
docs(arcade): describe the AGENTS window the quick start actually opens

### DIFF
--- a/docs/pages/arcade-quick-start.md
+++ b/docs/pages/arcade-quick-start.md
@@ -46,7 +46,16 @@ Track outline with the DRS zones drawn in green, two driver icons (our driver in
 
 ### PITWALL · AGENTS
 
-Orchestrator card on the left (action badge, confidence bar, pace/risk chips, plan strip with compound pill, and a guardrail line that shows when the no-LLM hard guard overrode the LLM pick), scenario bars beneath it (four bars for STAY_OUT / PIT_NOW / UNDERCUT / OVERCUT) and reasoning tabs below that. On the right, a 3x2 grid of sub-agent cards: Pace (N25), Tire (N26), Situation (N27), Radio (N29), Pit (N28, dimmed when inactive), RAG (N30, dimmed when inactive). Pace and Tire carry embedded ECharts plots.
+Four strata, top to bottom: header, decision band, agent grid, status bar. The band runs left to right in the order a reader asks the questions, which is what the orchestrator is doing, why, on what evidence, and what happens next: the orchestrator card with its action badge and confidence bar, the reasoning panel, the scenario bars (STAY_OUT / PIT_NOW / UNDERCUT / OVERCUT, scored by the Monte Carlo over the agents' own distributions) and the plan strip.
+
+Under it a grid places its cards by name rather than in reading order, because three of them want a shape reading order does not give them:
+
+```
+pace   tire   side
+radio  exit   rag
+```
+
+`side` stacks Situation (N27) and Pit (N28); `exit` is the PIT EXIT card, which answers what position a stop taken on this lap rejoins in and which cars land either side. Pace (N25) and Tire (N26) carry embedded ECharts plots, and Radio (N29) and RAG (N30) dim when inactive.
 
 ### PITWALL · DATA
 


### PR DESCRIPTION
## What

The AGENTS paragraph of `docs/pages/arcade-quick-start.md` described a window that has not existed since sprint 10, plus a line that no window renders.

## Two things wrong

**The guardrail line.** The page promised "a guardrail line that shows when the no-LLM hard guard overrode the LLM pick". `build_orchestrator` (`src/pitwall/agents_view/decision.py:308-370`) emits no `guardrail` key from either of its return blocks, on any profile. That is deliberate: `decision.py:312` says in writing that there is no guardrail line and that it is the fix rather than an omission (#974), and `test_pitwall_agents_view.py` pins the key as **absent** even when a reason is fed in directly, asserting absence rather than an empty string because an empty string is what the defect produced.

**The layout.** The page described "orchestrator card on the left … scenario bars beneath it … on the right, a 3x2 grid of sub-agent cards". That is the 540 / 740 horizontal split the port inherited and dropped. `AgentsWindow.tsx` replaced it with four strata, and the grid is two rows of three placed by name rather than in reading order:

```
pace   tire   side
radio  exit   rag
```

`side` stacks Situation and Pit; `exit` is **PIT EXIT**, the release's one new model output, which the page did not mention at all.

## How this got here

Same shape as #1156 on the sibling page, and worth naming because it is the third instance today: one section corrected and its twin left alone. #1156 fixed `pitwall.md`'s DATA section; this page's DATA section was already correct and its AGENTS section was not.

## Out of scope

`arcade-quick-start.md:109` uses second person ("a list you asked for"), which `PROSE_ANTIPATTERNS.md` rules out. Pre-existing, untouched here, and a different concern.

Whether the AGENTS window should now grow a real guardrail line is a product question, not a docs one. #1155 removed two of the three hardcodes that made `guardrail_reason` permanently `None` on every arcade path, so #974's argument that the line would always be blank is weaker than it was. Worth raising separately.

## Checks

- Every claim in the new text read off `AgentsWindow.tsx` and `styles/agents.css`.
- `tests/surfaces/test_docs_site_links.py` 4 passed.
- No em dashes, no new second person, no heading changes.

Closes #1163