### PR TITLE
docs(readme): lead with the PITWALL demo and show the three arcade windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ F1 StratLab is an open-source multi-agent AI platform for Formula 1 race replay 
 </div>
 
 <div align="center">
-  <a href="docs/assets/demo/arcade-demo.mp4">
-    <img src="docs/assets/demo/arcade-demo.gif" alt="F1 StratLab arcade demo: 2D race replay, strategy dashboard and live telemetry" width="860"/>
+  <a href="docs/assets/demo/pitwall-demo.mp4">
+    <img src="docs/assets/demo/pitwall-demo.gif" alt="F1 StratLab at Qatar 2025: the Safety Car arrives mid-lap, sixteen of twenty cars box, and the system calls PIT NOW" width="860"/>
   </a>
 </div>
 
 <div align="center">
-  <sub>▶ The <strong>Arcade</strong>: 2D race replay, strategy dashboard and live telemetry, all driven by one shared stream. <a href="docs/assets/demo/arcade-demo.mp4">Click for the full clip</a>, or see all three surfaces on the <a href="https://vforvitorio.github.io/f1stratlab-web/#demo-carousel">landing page</a>.</sub>
+  <sub>▶ <strong>Qatar 2025, lap 7.</strong> The Safety Car comes out mid-lap and sixteen of the twenty cars box. McLaren stays out. This is what the three windows were saying while that happened. <a href="docs/assets/demo/pitwall-demo.mp4">Full clip ▶</a> · <a href="https://vforvitorio.github.io/f1stratlab-web/#demo-carousel">all three surfaces on the landing page</a>.</sub>
 </div>
 
 <div align="center">
@@ -64,10 +64,34 @@ See [`ARCHITECTURE.md`](ARCHITECTURE.md) for the one-page topology and [`docs/`]
 | Surface                            | Command                                                                                                     | When to use                                                                                          |
 | ---------------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | **CLI**                      | `f1-strat` (interactive wizard) · `f1-sim Melbourne VER "Red Bull Racing" --year 2025` (headless)                                                      | Headless Rich-based live inference panel for a single race. `f1-strat` opens an arrow-key menu (GP, driver, provider, head-to-head); `f1-sim` is the scripted form. |
-| **Arcade** (primary live UI) | `f1-arcade --viewer --year 2025 --round 3 --driver VER --team "Red Bull Racing" --driver2 LEC --strategy` | Three-window 2D race replay + the two PITWALL windows (AGENTS and DATA). No backend required. |
+| **Arcade** (primary live UI) | `f1-arcade --viewer --year 2025 --round 3 --driver VER --team "Red Bull Racing" --driver2 LEC --strategy` | Three windows off one stream: the 2D race replay plus PITWALL DATA and PITWALL AGENTS. No backend required. |
 | **Web app** (post-race)    | `f1-webapp` (wraps `docker compose up`)                                                               | React SPA (Vite + TypeScript + Tailwind + ECharts): telemetry dashboard, 60fps driver comparison, ML model lab, multi-agent pit-wall strategy, race analysis, and a streaming AI chat that renders tool results inline. Backed by FastAPI. |
 
-The Arcade is in the hero above. Here are the other two:
+### What the Arcade opens
+
+Three windows off one shared stream, and the row below is **one moment on all three**: the lap the Safety Car arrives.
+
+<table>
+<tr>
+<td width="33%" align="center">
+  <img src="docs/assets/demo/pitwall-row-replay.gif" alt="The pyglet replay: twenty cars on the circuit outline with the Safety Car pill lit" width="100%"/>
+  <br/>
+  <sub><strong>Replay</strong> · where the cars are</sub>
+</td>
+<td width="33%" align="center">
+  <img src="docs/assets/demo/pitwall-row-data.gif" alt="PITWALL DATA: the twenty-row timing tower, sector times and the own-car traces" width="100%"/>
+  <br/>
+  <sub><strong>PITWALL · DATA</strong> · what the timing screen says</sub>
+</td>
+<td width="33%" align="center">
+  <img src="docs/assets/demo/pitwall-row-agents.gif" alt="PITWALL AGENTS: the decision band over the six specialist consoles" width="100%"/>
+  <br/>
+  <sub><strong>PITWALL · AGENTS</strong> · what it decided, and why</sub>
+</td>
+</tr>
+</table>
+
+The other two surfaces:
 
 <table>
 <tr>


### PR DESCRIPTION
## What

The README hero embedded `arcade-demo.gif`, which predates PITWALL and shows the two PySide6 windows this release replaced. Swapped for the 2.6 demo, and added a three-column row of the windows the arcade actually opens.

## The hero

Now the Qatar 2025 Safety Car lap, which is the release's own subject: the car comes out mid-lap, sixteen of the twenty cars box, McLaren does not. Caption says that instead of listing features.

## The row

Three columns, one row, under the hero:

| | |
|---|---|
| `pitwall-row-replay.gif` | **Replay**, where the cars are |
| `pitwall-row-data.gif` | **PITWALL · DATA**, what the timing screen says |
| `pitwall-row-agents.gif` | **PITWALL · AGENTS**, what it decided, and why |

They are **one moment on three surfaces**, cut from a single deterministic `--no-llm` session and anchored on the Safety Car flip that all three show on the same broadcast tick. Not three takes of the same lap. 1.66 MB for the row.

## Also

The surfaces table said the Arcade is a "Three-window 2D race replay + the two PITWALL windows (AGENTS and DATA)", which counts to five. It is three windows off one stream.

## Checks

- Every `docs/assets/` path referenced in the README resolves on disk, checked programmatically rather than by eye.
- `tests/surfaces/test_docs_site_links.py` 4 passed.
- No em dashes; no remaining reference to `arcade-demo`.

## Out of scope

`f1stratlab-web` still carries the old arcade video in its demo carousel (`components/Sections.jsx:1248`), and its `foot` string names the Qt dashboard that no longer exists. Separate repo, separate change.