### PR TITLE
Promote dev to main: the four scanner findings

### DIFF
--- a/docs/app/markdown.js
+++ b/docs/app/markdown.js
@@ -72,8 +72,18 @@ function escapeHTML(s) {
 }
 
 function slugify(s) {
-  return s.toLowerCase()
-    .replace(/<[^>]+>/g, "")
+  // The tag strip repeats until it stops changing the string. One pass is
+  // bypassable by nesting, because `<<a>script>` becomes `<script>`, and
+  // CodeQL flags exactly that (js/incomplete-multi-character-sanitization).
+  // The character filter below already makes the output safe on its own, so
+  // this is about the value being sanitised where it is computed rather than
+  // relying on a later line to cover for it.
+  let stripped = s.toLowerCase();
+  for (let before = null; before !== stripped; ) {
+    before = stripped;
+    stripped = stripped.replace(/<[^>]+>/g, "");
+  }
+  return stripped
     .replace(/[^a-z0-9\s-]/g, "")
     .replace(/\s+/g, "-")
     .replace(/-+/g, "-")
@@ -184,7 +194,12 @@ function ensureMermaid() {
   mermaid.initialize({
     startOnLoad: false,
     theme: "base",
-    securityLevel: "loose",
+    // `antiscript`, not `loose`: the labels across docs/pages use <br/> for
+    // multi-line nodes, which `strict` would escape, but `loose` sanitises
+    // nothing at all and the rendered SVG goes straight into innerHTML
+    // (js/xss-through-dom). `antiscript` keeps the markup those labels need
+    // and drops script tags.
+    securityLevel: "antiscript",
     fontFamily: "Inter, system-ui, sans-serif",
     themeVariables: MERMAID_PALETTE[theme],
   });

--- a/src/pitwall/ui/scripts/clean-dist.mjs
+++ b/src/pitwall/ui/scripts/clean-dist.mjs
@@ -41,20 +41,34 @@ function remaining() {
 
 if (remaining() !== 0) {
   try {
-    rmSync(DIST, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    rmSync(DIST, {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+      retryDelay: 100,
+    });
   } catch (error) {
-    console.error(`clean-dist: node rm failed (${error.code ?? error.message}), trying the shell`);
+    console.error(
+      `clean-dist: node rm failed (${error.code ?? error.message}), trying the shell`,
+    );
   }
 }
 
 if (remaining() !== 0) {
   // The platform's own delete. Reached routinely on this machine, not as a
   // last resort, so it is not treated as an error path.
+  //
+  // The directory travels as `cwd` and the argument is the literal "dist", so
+  // nothing derived from the script's own location reaches `cmd /c`, which
+  // re-parses whatever text it is given. Node's own argument escaping already
+  // covered the paths that matter, measured on a tree under a directory named
+  // "A & B" where both forms delete correctly, so this is about not building a
+  // command line out of a path at all rather than about a delete that fails.
   const [command, args] =
     process.platform === "win32"
-      ? ["cmd", ["/c", "rmdir", "/s", "/q", DIST]]
-      : ["rm", ["-rf", DIST]];
-  spawnSync(command, args, { stdio: "ignore" });
+      ? ["cmd", ["/c", "rmdir", "/s", "/q", "dist"]]
+      : ["rm", ["-rf", "dist"]];
+  spawnSync(command, args, { cwd: dirname(DIST), stdio: "ignore" });
 }
 
 if (remaining() !== 0) {

--- a/uv.lock
+++ b/uv.lock
@@ -1000,7 +1000,7 @@ wheels = [
 
 [[package]]
 name = "datasets"
-version = "4.7.0"
+version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dill" },
@@ -1018,9 +1018,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/9c/ba18de0b70858533e422ed6cfe0e46789473cef7fc7fc3653e23fa494730/datasets-4.7.0.tar.gz", hash = "sha256:4984cdfc65d04464da7f95205a55cb50515fd94ae3176caacb50a1b7273792e2", size = 602008, upload-time = "2026-03-09T19:01:49.298Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/5b/836516269d4f618efe621661cfb6f9acc57e6f95265db3efaee48a5ffe04/datasets-5.0.1.tar.gz", hash = "sha256:ce22bb851efd7494f08aad33b940803784434f6e77763d00679a0dc45fcf686a", size = 641498, upload-time = "2026-07-28T11:09:12.016Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/03/c6d9c3119cf712f638fe763e887ecaac6acbb62bf1e2acc3cbde0df340fd/datasets-4.7.0-py3-none-any.whl", hash = "sha256:d5fe3025ec6acc3b5649f10d5576dff5e054134927604e6913c1467a04adc3c2", size = 527530, upload-time = "2026-03-09T19:01:47.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/0b/98fc6eb83333508ca5f44c52b3e287ea8137a0ad582714e2cbc67a02154b/datasets-5.0.1-py3-none-any.whl", hash = "sha256:9fbf73688f8c18f7529b4fe592abd04015f81d1e58001e4bac73ffb2b39d7cc4", size = 559079, upload-time = "2026-07-28T11:09:10.266Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Second promotion of the 2.6 line. The first one gave OSV-Scanner and CodeQL their first look at this tree on `main`, and these are the fixes for what they found.

Three commits, all from #1173:

- `datasets` 4.7.0 to 5.0.1, closing `CVE-2026-66007`. It was not in any of the four Dependabot PRs.
- `docs/app/markdown.js`, two CodeQL findings: slugify stripped tags in a single pass, which nesting bypasses, and mermaid ran at `securityLevel: loose` while its rendered SVG goes into `innerHTML`.
- `src/pitwall/ui/scripts/clean-dist.mjs`, the Windows fallback handed a path to `cmd /c` as text.

Full reasoning, including what the clean-dist change deliberately does not fix, is in #1173.

## Checks

Every job green by name on #1173: `test`, `lint`, `typecheck`, `pitwall-ui`, `pip-audit`, `gitleaks`, `osv-scanner`, `scan-pr / osv-scan`, `analyze (python)`, `analyze (javascript-typescript)`, `CodeQL`.

`tests/surfaces tests/cli tests/eval` 650 passed, 0 skipped. `tests/infra` 77 passed. `f1-sim Lusail NOR McLaren --laps 1-20 --no-llm` reproduces `STAY_OUT·17 PIT_NOW·3`, 7 radio alerts, best lap 85.615 s.

## After this merges

Wait for OSV-Scanner, CodeQL, gitleaks and pip-audit to run on `main` before touching the release PR. A scanner finding after the tag is a patch release; the same finding before it is a commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of nested HTML tags in generated content, ensuring potentially unsafe script tags are fully removed.
  * Updated Mermaid rendering security while preserving intended line breaks in multi-line labels.
  * Improved distribution cleanup reliability during build and packaging workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->