### PR TITLE
chore(deps): bump osv-scanner-action to v2.5.1

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -25,8 +25,8 @@ permissions:
 jobs:
   scan-scheduled:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.8"
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.5.1"
 
   scan-pr:
     if: ${{ github.event_name == 'pull_request' }}
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.3.8"
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.5.1"


### PR DESCRIPTION
Both reusable workflows in `.github/workflows/osv-scanner.yml`, the scheduled scan and the PR scan, were pinned at `v2.3.8`.

Dependabot opened #1157 and #1158 for these against `main`, since that is the default branch. Applied here instead so the change reaches `main` through `dev` like everything else, and those two get closed pointing at this.

Landing it before the release rather than after is deliberate: a newer scanner can surface advisories the old one did not, and a finding before the tag is a commit while the same finding after it is a patch release.

## Checks

The bump is verified by this PR own run: `scan-pr / osv-scan` executes on the new version against the current `uv.lock`, which carries the `osv-scanner.toml` waivers from #1177.