### PR TITLE
Promote dev to main: the second scanner round

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -25,8 +25,8 @@ permissions:
 jobs:
   scan-scheduled:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.8"
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.5.1"
 
   scan-pr:
     if: ${{ github.event_name == 'pull_request' }}
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.3.8"
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.5.1"

--- a/docs/app/markdown.js
+++ b/docs/app/markdown.js
@@ -288,6 +288,12 @@ async function renderMermaidBlocks(root) {
     const id = b.dataset.mermaidId || ("m" + Math.random().toString(36).slice(2, 9));
     try {
       const { svg } = await mermaid.render(id, code);
+      // What makes this safe is mermaid's own securityLevel, set to antiscript
+      // where this file configures it. Measured by rendering hostile labels
+      // through this same call and reading the attribute nodes back: script
+      // elements, every on* handler and javascript: hrefs are all gone, and no
+      // payload ran. CodeQL reads js/xss-through-dom here anyway, because it
+      // cannot follow the sanitising across the library boundary.
       b.innerHTML = svg + MERMAID_EXPAND_BUTTON;
       b.dataset.rendered = "1";
     } catch (e) {

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -156,3 +156,23 @@ reason = "torch: no upstream fix; CUDA-pinned; requires attacker-controlled in-p
 id = "PYSEC-2026-3447"
 ignoreUntil = 2026-10-12T00:00:00Z
 reason = "setuptools: fix in 83.0.0 blocked by torch 2.11/2.12 (setuptools<82 pin); flaw only affects MANIFEST.in exclude normalization when building an sdist on macOS APFS/HFS+, never exercised here. Revisit when CUDA-pinned torch allows setuptools>=83."
+
+# --- nltk (no patched release exists) -----------------------------------------
+# The advisory carries `last_affected: 3.10.3` and no `fixed` event, and 3.10.3
+# is the newest release, so there is nothing to bump to. The flaw is in the
+# model-artifact APIs (TransitionParser.train/parse, AveragedPerceptron.save and
+# load, PerceptronTagger.save_to_json, save_maxent_params) reading and writing
+# caller-controlled paths outside the pathsec roots. Nothing under src/, scripts/
+# or tests/ imports nltk at all, let alone those APIs: the only consumer in the
+# repository is the N19 VADER sentiment notebook, which calls
+# SentimentIntensityAnalyzer and nltk.download.
+#
+# That last sentence is the argument for dropping the dependency rather than for
+# tolerating it, which is what the ecdsa note above says in the same situation.
+# Tracked as its own decision in #1176 rather than settled here, because taking a
+# package out of the released distribution is a bigger change than a waiver and
+# the notebook is a documented reproduction path. Short window on purpose.
+[[IgnoredVulns]]
+id = "GHSA-8mgp-746c-j5xp"
+ignoreUntil = 2026-10-03T00:00:00Z
+reason = "nltk: no patched release exists (last_affected 3.10.3, no fix event). Affected model-artifact APIs are imported nowhere in src/scripts/tests; only the N19 VADER notebook uses nltk at all. Removal is the better fix, tracked in #1176."

--- a/uv.lock
+++ b/uv.lock
@@ -2788,14 +2788,14 @@ wheels = [
 
 [[package]]
 name = "mistune"
-version = "3.3.0"
+version = "3.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/9c/1939635275ec7258e2b43b00dafabc36d89ad11aa7838d375dc1b0e561cb/mistune-3.3.0.tar.gz", hash = "sha256:3074ec4c61b384abe725128e4dcbb483f5a09cc4632012505cdee655d3a113b9", size = 110936, upload-time = "2026-06-21T13:11:39.458Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/92/328a294a6de83bacb95bed01f04e0eaff4e3616ee359fc821a5dfc539b02/mistune-3.3.4.tar.gz", hash = "sha256:58b5c96d6fcb61190dfe5fae498d2b2065f99cf61e9649418fd54cf1ada86dfe", size = 121426, upload-time = "2026-07-22T05:22:30.89Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/76/b90f9d48d43fbd80a79a20d3eab2e5109859c7a56dc663b23187385898f3/mistune-3.3.0-py3-none-any.whl", hash = "sha256:a758e578acda49d8195f9a860b132dae2cf7bf409381393b1c4e6e489a65397b", size = 61250, upload-time = "2026-06-21T13:11:37.938Z" },
+    { url = "https://files.pythonhosted.org/packages/77/e4/288365afae98953bc01de09f686f40d8ee84578135aa7767d5d4e60b5278/mistune-3.3.4-py3-none-any.whl", hash = "sha256:ee015381e955e370962968befe1d729ab60fafb6a715ac6751763fbce38c8d4a", size = 66862, upload-time = "2026-07-22T05:22:29.419Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Third promotion of the 2.6 line, and the second one driven by what the scanners said about `main`.

- #1177: mistune to 3.3.4 (`CVE-2026-76098`), an nltk waiver in `osv-scanner.toml` for a CVE with no patched release, and a measurement recorded in `docs/app/markdown.js` explaining why `js/xss-through-dom` needs no code change.
- #1178: `osv-scanner-action` to v2.5.1 on both reusable workflows, which is what Dependabot #1157 and #1158 asked for against `main`.

## Checks

Every job green by name on both PRs, including `CodeQL`, which went red on the first attempt at #1177 and is green here.

`tests/surfaces tests/cli tests/eval tests/infra` 727 passed. Docs driven with Playwright across four diagram pages: 6 blocks rendered, 46 `<br>` and 156 `foreignObject`s surviving, 0 render errors, 0 live event-handler attributes.

## After this merges

The scanners run on `main` again. Only then the release PR #712, per the same rule as last time: a finding before the tag is a commit, the same finding after it is a patch release.

## Tracker state, since it changes with this

The first promotion closed 101 issues. Another 25 were fixed and stayed open because the closing keyword lived only in the PR body, and merges here pass `--body ""` so release-please does not double-count the merge commit, which strips the keyword before it reaches the default branch. All 25 were verified on `main` with `git merge-base --is-ancestor` and then closed by hand. 138 open down to 113.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Updated automated vulnerability scanning workflows to newer scanner versions.
  - Added a temporary exception for a known NLTK advisory through October 3, 2026.
  - Documented the security handling for Mermaid-rendered content.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->