### PR TITLE
Promote dev to main: f1-prefetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ For a scripted, no-menu run use `f1-sim <gp_name> <driver> <team> --year <yyyy>`
 ```bash
 uv tool install "git+https://github.com/VforVitorio/F1-StratLab.git"
 f1-arcade
+f1-prefetch --year 2025   # optional: fill the replay cache ahead of time (about six minutes per race otherwise)
 ```
 
 **Web app**: clone **with the telemetry submodule**, add an env file, then bring the stack up with Docker (FastAPI + the React SPA):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ f1-arcade    = "src.arcade.main:main"
 f1-webapp    = "scripts.run_webapp:main"
 f1-eval      = "src.strategy.eval.cli:main"
 f1-pitwall   = "src.pitwall.__main__:main"
+f1-prefetch  = "src.arcade.prefetch:main"
 
 [project.optional-dependencies]
 dev = [

--- a/src/arcade/prefetch.py
+++ b/src/arcade/prefetch.py
@@ -1,0 +1,305 @@
+"""Fill the arcade's replay cache ahead of time, for a season or a set of rounds.
+
+    f1-prefetch --year 2025                    # every round of the season
+    f1-prefetch --year 2025 --rounds 1,3,5-8   # only those, commas and ranges
+    f1-prefetch --year 2025 --with-radio       # also fetch the team radio corpus
+    f1-prefetch --year 2025 --force            # prepare cached rounds too
+
+Picking a race the arcade has never built costs 349 s measured for the
+telemetry alone, plus the downloads before it (`prepare.py`). The menu runs
+that on a worker thread so the window keeps drawing, but whoever picked the
+race still waits the first time, for every race. This command fills the cache
+in advance, unattended, so picking one later is instant.
+
+A thin front-end to :func:`src.arcade.prepare.prepare_race`, the routine the
+menu itself runs, so what this prepares and what the menu would prepare cannot
+differ. The one thing added is the skip: `prepare_race` is idempotent but its
+last stage still loads the pickle, ~5 s and ~380 MB of RSS for a race that
+needed nothing, so a round whose pickle is already on disk is skipped before
+the call is made.
+
+Contents:
+- parse_rounds: "1,3,5-8" into sorted round numbers.
+- is_cached: the skip check, asked of the loader's own path rule.
+- prefetch: the loop over rounds, printing progress and a summary.
+- exit_code: non-zero only when nothing was achieved and something broke.
+- main: the `f1-prefetch` entry point.
+
+--- WHERE TO CHANGE IF THE CACHE LAYOUT CHANGES ---
+Nothing here. The pickle path is `SessionLoader._cache_path` and the version
+tag is `src.arcade.config.CACHE_VERSION`; a bump there is what `--force` is for.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+from collections import Counter
+from collections.abc import Sequence
+from enum import Enum
+from pathlib import Path
+from typing import TextIO
+
+from src.arcade.config import ARCADE_CACHE_DIR, get_gp_names
+from src.arcade.data import SessionLoader
+from src.arcade.prepare import PrepareProgress, RaceDataUnavailable, prepare_race
+
+logger = logging.getLogger(__name__)
+
+
+class Outcome(str, Enum):
+    """What happened to one round, and the word the summary counts it under.
+
+    `UNAVAILABLE` is the dataset's answer that the round has nothing to fetch,
+    which is why it is neither a success nor a failure in `exit_code`.
+    """
+
+    PREPARED = "prepared"
+    SKIPPED = "skipped"
+    UNAVAILABLE = "unavailable"
+    FAILED = "failed"
+
+
+def parse_rounds(spec: str) -> list[int]:
+    """Turn a rounds spec such as "1,3,5-8" into sorted, de-duplicated round numbers.
+
+    Commas separate items and a dash marks an inclusive range. Anything else,
+    an empty item, a non-number, a zero, a descending range, raises ValueError
+    naming the item, so a typo dies at the parser instead of after the first
+    six-minute build.
+    """
+    rounds: set[int] = set()
+    for item in spec.split(","):
+        rounds.update(_parse_round_item(item.strip()))
+    return sorted(rounds)
+
+
+def _parse_round_item(item: str) -> range:
+    """One item of the spec, a round or an ascending range, as the rounds it names."""
+    low_text, is_range, high_text = item.partition("-")
+    try:
+        low = int(low_text)
+        high = int(high_text) if is_range else low
+    except ValueError as exc:
+        raise ValueError(f"not a round or a range of rounds: {item!r}") from exc
+    if low < 1 or high < low:
+        raise ValueError(f"rounds start at 1 and ranges ascend: {item!r}")
+    return range(low, high + 1)
+
+
+def is_cached(loader: SessionLoader, year: int, round_: int) -> bool:
+    """Whether the replay pickle for this round is already on disk.
+
+    Asked of the loader's own path rule so the check and the cache can never
+    disagree on a name. It is one `Path.exists`, microseconds, where
+    letting `prepare_race` find out costs the pickle load its last stage
+    always does: ~5 s and ~380 MB of RSS for a race that needed nothing.
+
+    Only presence is checked. The version tag lives inside the pickle, so a
+    `CACHE_VERSION` bump is invisible from here, which is what `--force` is for.
+    """
+    return loader._cache_path(year, round_).exists()
+
+
+def _emit(out: TextIO, text: str) -> None:
+    """One line, flushed, because the reader may be tailing a six-minute build."""
+    print(text, file=out, flush=True)
+
+
+class _StageReporter:
+    """Prints each stage as it starts and how long the previous one took.
+
+    `prepare_race` reports a stage once, at its start, so a stage's duration is
+    only known when the next one begins or the call returns. That is why this
+    holds the last report and why `close` exists: it settles the final stage.
+    """
+
+    def __init__(self, out: TextIO) -> None:
+        self._out = out
+        self._current: PrepareProgress | None = None
+
+    def __call__(self, progress: PrepareProgress) -> None:
+        self._settle()
+        self._current = progress
+        _emit(self._out, f"  {progress.label}")
+
+    def close(self) -> None:
+        self._settle()
+
+    def _settle(self) -> None:
+        if self._current is None:
+            return
+        elapsed = self._current.elapsed_s(time.monotonic())
+        _emit(self._out, f"  {self._current.stage}: {elapsed:.1f}s")
+        self._current = None
+
+
+def _attempt(
+    year: int,
+    round_: int,
+    gp_name: str,
+    *,
+    with_radio: bool,
+    on_progress: _StageReporter,
+) -> tuple[Outcome, str]:
+    """Run one preparation and turn whatever it raised into an outcome.
+
+    `RaceDataUnavailable` is the dataset saying the round has nothing to fetch,
+    so it is counted rather than raised. Anything else is a genuine failure,
+    logged with its traceback, and the loop moves on: one bad round must not
+    end an unattended run. Returns the outcome and the detail worth printing.
+    """
+    try:
+        prepare_race(year, round_, gp_name, strategy_enabled=with_radio, on_progress=on_progress)
+    except RaceDataUnavailable as exc:
+        return Outcome.UNAVAILABLE, str(exc)
+    except Exception as exc:  # noqa: BLE001 - counted and reported, the run goes on
+        logger.exception("Preparing %d round %d (%s) failed", year, round_, gp_name)
+        return Outcome.FAILED, f"{type(exc).__name__}: {exc}"
+    else:
+        return Outcome.PREPARED, ""
+
+
+def prefetch_round(
+    year: int,
+    round_: int,
+    gp_name: str,
+    *,
+    with_radio: bool,
+    force: bool,
+    loader: SessionLoader,
+    out: TextIO,
+) -> Outcome:
+    """Prepare one round unless its pickle is already there, and say what happened."""
+    if not force and is_cached(loader, year, round_):
+        _emit(out, "  cached, skipped")
+        return Outcome.SKIPPED
+
+    reporter = _StageReporter(out)
+    started = time.monotonic()
+    outcome, detail = _attempt(year, round_, gp_name, with_radio=with_radio, on_progress=reporter)
+    reporter.close()
+    elapsed = time.monotonic() - started
+    suffix = f": {detail}" if detail else ""
+    _emit(out, f"  {outcome.value} in {elapsed:.1f}s{suffix}")
+    return outcome
+
+
+def prefetch(
+    year: int,
+    rounds: Sequence[int],
+    *,
+    with_radio: bool,
+    force: bool,
+    cache_dir: Path = ARCADE_CACHE_DIR,
+    out: TextIO | None = None,
+) -> Counter[Outcome]:
+    """Prepare each round in turn and print a summary; returns the count per outcome.
+
+    The GP name comes from the same calendar the menu resolves it from, so the
+    two can only ever fetch the same race for a given round. `cache_dir` and
+    `out` exist for the tests: the real cache holds pickles that cost 349 s
+    each to rebuild, and nothing here may touch them through a fake.
+    """
+    out = out or sys.stdout
+    calendar = get_gp_names(year)
+    loader = SessionLoader(cache_dir=cache_dir)
+    counts: Counter[Outcome] = Counter()
+    started = time.monotonic()
+
+    for position, round_ in enumerate(rounds, start=1):
+        gp_name = calendar.get(round_, f"Round{round_}")
+        _emit(out, f"[{position}/{len(rounds)}] {year} R{round_:02d} {gp_name}")
+        outcome = prefetch_round(
+            year, round_, gp_name, with_radio=with_radio, force=force, loader=loader, out=out
+        )
+        counts[outcome] += 1
+
+    tally = ", ".join(f"{counts[outcome]} {outcome.value}" for outcome in Outcome)
+    _emit(out, f"Done in {time.monotonic() - started:.1f}s: {tally}")
+    return counts
+
+
+def exit_code(counts: Counter[Outcome]) -> int:
+    """Non-zero only when the run achieved nothing and something genuinely broke.
+
+    A skipped round is a success, its cache is already filled, and an
+    unavailable round is an answer rather than a failure. So a season where
+    every round is unavailable exits 0, and so does a run that prepared one
+    race and failed on five; the summary line carries the counts either way.
+    """
+    achieved = counts[Outcome.PREPARED] + counts[Outcome.SKIPPED]
+    if achieved == 0 and counts[Outcome.FAILED] > 0:
+        return 1
+    return 0
+
+
+def _rounds_argument(spec: str) -> list[int]:
+    """`parse_rounds` for argparse, which only relays a message raised as its own type."""
+    try:
+        return parse_rounds(spec)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="f1-prefetch",
+        description=(
+            "Fill the arcade's replay cache ahead of time, so picking a race from the "
+            "menu later is instant instead of a 349 s build. Rounds already cached are "
+            "skipped without being loaded."
+        ),
+    )
+    parser.add_argument("--year", type=int, required=True, help="Season to prepare, e.g. 2025.")
+    parser.add_argument(
+        "--rounds",
+        type=_rounds_argument,
+        default=None,
+        metavar="SPEC",
+        help='Rounds to prepare, commas and ranges: "1,3,5-8". Default: the whole calendar.',
+    )
+    parser.add_argument(
+        "--with-radio",
+        action="store_true",
+        help=(
+            "Also fetch the team radio corpus (~3 MB per race). Off by default because "
+            "the replay never reads it; only the agents do."
+        ),
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Prepare cached rounds too. A pickle at the current CACHE_VERSION is reloaded "
+            "rather than rebuilt (~5 s), so this is for a cache invalidated by a version bump."
+        ),
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Parse the flags, refuse rounds off the calendar, run, and return the exit code.
+
+    The calendar check happens before anything is prepared, on the reasoning
+    `prepare_race` orders its own stages by: a typo should fail now, not after
+    the first six-minute build.
+    """
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
+
+    calendar = get_gp_names(args.year)
+    rounds = args.rounds or sorted(calendar)
+    off_calendar = [round_ for round_ in rounds if round_ not in calendar]
+    if off_calendar:
+        parser.error(f"not on the {args.year} calendar (1-{max(calendar)}): {off_calendar}")
+
+    counts = prefetch(args.year, rounds, with_radio=args.with_radio, force=args.force)
+    return exit_code(counts)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/surfaces/test_arcade_prefetch.py
+++ b/tests/surfaces/test_arcade_prefetch.py
@@ -1,0 +1,292 @@
+"""`f1-prefetch` fills the replay cache without rebuilding what is already there.
+
+The command is a loop over `prepare_race` with one addition, a skip for rounds
+whose pickle exists, so what is asserted here is the loop's own behaviour: the
+rounds spec, the skip and its `--force` override, one round's failure not
+ending the run, the flags reaching the call, and the exit code.
+
+**`prepare_race` is always faked.** A real call is a download plus a 349 s
+build, and the cache directory is always a `tmp_path`: the six pickles under
+`data/cache/arcade/` cost that much each and nothing here may touch them.
+"""
+
+from __future__ import annotations
+
+import io
+import time
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+from src.arcade import prefetch as prefetch_module
+from src.arcade.config import get_gp_names
+from src.arcade.data import SessionLoader
+from src.arcade.prefetch import (
+    Outcome,
+    exit_code,
+    main,
+    parse_rounds,
+    prefetch,
+)
+from src.arcade.prepare import STAGE_TELEMETRY, PrepareProgress, RaceDataUnavailable
+
+YEAR = 2025
+
+
+class _FakePrepare:
+    """Stands in for `prepare_race`: records each call and raises where told to.
+
+    It reports one stage through `on_progress` the way the real one does, so
+    the printed progress can be asserted rather than eyeballed.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self.raising: dict[int, Exception] = {}
+
+    def __call__(self, year, round_, gp_name, *, strategy_enabled, on_progress=None):
+        self.calls.append(
+            {"year": year, "round": round_, "gp": gp_name, "strategy_enabled": strategy_enabled}
+        )
+        if on_progress is not None:
+            on_progress(
+                PrepareProgress(
+                    stage=STAGE_TELEMETRY, index=1, total=1, started_at=time.monotonic()
+                )
+            )
+        if round_ in self.raising:
+            raise self.raising[round_]
+        return object()
+
+    @property
+    def rounds(self) -> list[int]:
+        return [call["round"] for call in self.calls]
+
+
+@pytest.fixture
+def fake(monkeypatch: pytest.MonkeyPatch) -> _FakePrepare:
+    """Patch `prepare_race` where `prefetch` looks it up."""
+    stub = _FakePrepare()
+    monkeypatch.setattr(prefetch_module, "prepare_race", stub)
+    return stub
+
+
+def _cache(tmp_path: Path, round_: int) -> Path:
+    """Put a pickle where the LOADER would look for it, not where a string says."""
+    path = SessionLoader(cache_dir=tmp_path)._cache_path(YEAR, round_)
+    path.write_bytes(b"not a pickle, and it must never be opened")
+    return path
+
+
+def _run(tmp_path: Path, rounds: list[int], **flags) -> tuple[Counter, str]:
+    """`prefetch` against a temporary cache, returning the counts and what it printed."""
+    options = {"with_radio": False, "force": False, **flags}
+    out = io.StringIO()
+    counts = prefetch(YEAR, rounds, cache_dir=tmp_path, out=out, **options)
+    return counts, out.getvalue()
+
+
+# ── The rounds spec ───────────────────────────────────────────────────────────
+
+
+def test_rounds_accept_commas_and_ranges() -> None:
+    assert parse_rounds("1,3,5-8") == [1, 3, 5, 6, 7, 8]
+
+
+def test_rounds_come_back_sorted_and_deduplicated() -> None:
+    """The order typed is not the order run, and a round named twice runs once."""
+    assert parse_rounds("8, 3-4, 1, 3") == [1, 3, 4, 8]
+
+
+@pytest.mark.parametrize("spec", ["", "a", "1,,3", "0", "8-5", "-3", "5-", "1-2-3", "1.5"])
+def test_rounds_reject_nonsense(spec: str) -> None:
+    """A typo has to die here, not after the first six-minute build."""
+    with pytest.raises(ValueError):
+        parse_rounds(spec)
+
+
+# ── The skip ──────────────────────────────────────────────────────────────────
+
+
+def test_a_cached_race_is_skipped_without_loading_it(fake: _FakePrepare, tmp_path: Path) -> None:
+    """The pickle is on disk, so nothing may spend 5 s and 380 MB finding that out.
+
+    The file is put where the loader's own path rule says, so a check that
+    built its own name would look somewhere else and go on to prepare.
+    """
+    _cache(tmp_path, 1)
+    counts, text = _run(tmp_path, [1])
+    assert fake.calls == []
+    assert counts == Counter({Outcome.SKIPPED: 1})
+    assert "skipped" in text
+
+
+def test_force_prepares_a_cached_race_anyway(fake: _FakePrepare, tmp_path: Path) -> None:
+    """After a `CACHE_VERSION` bump the file is there and stale; `--force` is the way past."""
+    _cache(tmp_path, 1)
+    counts, _ = _run(tmp_path, [1], force=True)
+    assert fake.rounds == [1]
+    assert counts == Counter({Outcome.PREPARED: 1})
+
+
+def test_an_uncached_race_is_prepared(fake: _FakePrepare, tmp_path: Path) -> None:
+    counts, _ = _run(tmp_path, [2])
+    assert fake.rounds == [2]
+    assert counts == Counter({Outcome.PREPARED: 1})
+
+
+# ── One round's failure does not end the run ──────────────────────────────────
+
+
+def test_an_unavailable_race_does_not_stop_the_next(fake: _FakePrepare, tmp_path: Path) -> None:
+    """The dataset having nothing for a round is an answer, counted and moved past."""
+    fake.raising[2] = RaceDataUnavailable("No data published for Shanghai 2025.")
+    counts, text = _run(tmp_path, [2, 3])
+    assert fake.rounds == [2, 3]
+    assert counts == Counter({Outcome.UNAVAILABLE: 1, Outcome.PREPARED: 1})
+    assert "No data published for Shanghai" in text
+
+
+def test_a_genuine_failure_does_not_stop_the_next_either(
+    fake: _FakePrepare, tmp_path: Path
+) -> None:
+    """A dropped connection on round 2 of 24 must not cost the other 22."""
+    fake.raising[2] = ConnectionError("dropped")
+    counts, text = _run(tmp_path, [2, 3])
+    assert fake.rounds == [2, 3]
+    assert counts == Counter({Outcome.FAILED: 1, Outcome.PREPARED: 1})
+    assert "ConnectionError: dropped" in text
+
+
+# ── What reaches the call ─────────────────────────────────────────────────────
+
+
+def test_with_radio_is_the_strategy_flag(fake: _FakePrepare, tmp_path: Path) -> None:
+    """The radio corpus is fetched only when asked, and it is `strategy_enabled` that asks."""
+    _run(tmp_path, [2])
+    _run(tmp_path, [2], with_radio=True)
+    assert [call["strategy_enabled"] for call in fake.calls] == [False, True]
+
+
+def test_the_round_is_named_from_the_calendar(fake: _FakePrepare, tmp_path: Path) -> None:
+    """Same resolver as the menu, so the two can only fetch the same race for a round."""
+    _run(tmp_path, [3])
+    assert fake.calls[0]["gp"] == get_gp_names(YEAR)[3]
+    assert fake.calls[0]["year"] == YEAR
+
+
+# ── What a person watching the terminal reads ─────────────────────────────────
+
+
+def test_the_race_the_stage_and_its_duration_are_printed(
+    fake: _FakePrepare, tmp_path: Path
+) -> None:
+    _, text = _run(tmp_path, [2])
+    lines = text.splitlines()
+    assert lines[0].startswith("[1/1] 2025 R02 ")
+    assert any(line.startswith(f"  {STAGE_TELEMETRY}  (1/1)") for line in lines)
+    assert any(line.startswith(f"  {STAGE_TELEMETRY}: ") and line.endswith("s") for line in lines)
+    assert any(line.startswith("  prepared in ") for line in lines)
+
+
+def test_the_summary_counts_every_outcome(fake: _FakePrepare, tmp_path: Path) -> None:
+    _cache(tmp_path, 1)
+    fake.raising[2] = RaceDataUnavailable("nothing")
+    fake.raising[4] = RuntimeError("boom")
+    _, text = _run(tmp_path, [1, 2, 3, 4])
+    assert text.splitlines()[-1].endswith("1 prepared, 1 skipped, 1 unavailable, 1 failed")
+
+
+# ── The exit code ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("prepared", "skipped", "unavailable", "failed", "expected"),
+    [
+        (0, 0, 0, 0, 0),
+        (1, 0, 0, 5, 0),
+        (0, 1, 0, 5, 0),
+        (0, 0, 5, 0, 0),
+        (0, 0, 0, 1, 1),
+        (0, 0, 3, 2, 1),
+    ],
+)
+def test_the_exit_code_is_nonzero_only_when_nothing_was_achieved_and_something_broke(
+    prepared: int, skipped: int, unavailable: int, failed: int, expected: int
+) -> None:
+    counts = Counter(
+        {
+            Outcome.PREPARED: prepared,
+            Outcome.SKIPPED: skipped,
+            Outcome.UNAVAILABLE: unavailable,
+            Outcome.FAILED: failed,
+        }
+    )
+    assert exit_code(counts) == expected
+
+
+# ── The entry point ───────────────────────────────────────────────────────────
+
+
+class _FakePrefetch:
+    """Records what `main` hands to the loop, so every flag is seen to arrive."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def __call__(self, year, rounds, *, with_radio, force, **_):
+        self.calls.append(
+            {"year": year, "rounds": list(rounds), "with_radio": with_radio, "force": force}
+        )
+        return Counter()
+
+
+@pytest.fixture
+def loop(monkeypatch: pytest.MonkeyPatch) -> _FakePrefetch:
+    stub = _FakePrefetch()
+    monkeypatch.setattr(prefetch_module, "prefetch", stub)
+    return stub
+
+
+def test_every_flag_reaches_the_loop(loop: _FakePrefetch) -> None:
+    """A flag parsed and not passed is the pair-with-one-half-wired defect, so all four."""
+    main(["--year", "2025", "--rounds", "1,3", "--with-radio", "--force"])
+    assert loop.calls == [{"year": 2025, "rounds": [1, 3], "with_radio": True, "force": True}]
+
+
+def test_no_rounds_means_the_whole_calendar(loop: _FakePrefetch) -> None:
+    main(["--year", "2025"])
+    assert loop.calls[0]["rounds"] == sorted(get_gp_names(2025))
+    assert loop.calls[0] == {
+        "year": 2025,
+        "rounds": loop.calls[0]["rounds"],
+        "with_radio": False,
+        "force": False,
+    }
+
+
+def test_a_round_off_the_calendar_is_refused_before_anything_runs(loop: _FakePrefetch) -> None:
+    """`--rounds 1,30` must not build round 1 for six minutes and then discover 30."""
+    with pytest.raises(SystemExit) as exit_info:
+        main(["--year", "2025", "--rounds", "1,30"])
+    assert exit_info.value.code == 2
+    assert loop.calls == []
+
+
+def test_a_bad_spec_is_refused_with_its_reason(
+    loop: _FakePrefetch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(SystemExit) as exit_info:
+        main(["--year", "2025", "--rounds", "8-5"])
+    assert exit_info.value.code == 2
+    assert "ranges ascend" in capsys.readouterr().err
+    assert loop.calls == []
+
+
+def test_main_returns_the_exit_code_rather_than_raising_it(
+    loop: _FakePrefetch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One path for the console script and the tests: the code comes back as a value."""
+    monkeypatch.setattr(prefetch_module, "exit_code", lambda counts: 7)
+    assert main(["--year", "2025", "--rounds", "1"]) == 7


### PR DESCRIPTION
One change on top of 2.6.0: `f1-prefetch`, a command that fills the arcade replay cache ahead of time so opening a race later is instant rather than a 349 s build. Reasoning and checks in #1181.

The commit carries `Release-As: 2.6.1`, so release-please should cut a patch rather than the minor a `feat` would normally produce. 2.7.0 is planned to carry considerably more and this is worth shipping on top of 2.6.0 rather than waiting for it. The footer is in the branch commit body, not the PR body, because merges here pass `--body ""` and anything living only in a PR body never reaches the default branch.

Also closed on the way, with no code: #167, which reports `RadioAgentCFG` loading three transformer models at import for ~30 s. Measured at 0.88 s on the tag. The lazy-import work fixed it and nobody closed the issue.

## Checks

Every job green by name on #1181: `test`, `lint`, `typecheck`, `pitwall-ui`, `pip-audit`, `gitleaks`, `osv-scanner`, `scan-pr / osv-scan`, `analyze (python)`, `analyze (javascript-typescript)`, `CodeQL`.

`tests/surfaces` 569 passed, including 31 new ones each watched red against a compiling mutation. Ruff clean on 208 files. Real run: `f1-prefetch --year 2025 --rounds 1,3` skips both cached rounds in 1.16 s.

## Still open, and the more valuable half

Phase 1 of #1118, making the cold build cheaper, and inside it #1121: one `lap.get_telemetry()` call per lap where FastF1 offers one merge per driver and recommends against the per-lap form in its own docstring. 10.61 s per driver against 0.28 s, and that loop is 93% of the cold build, so roughly 140 s of the 349. It is not in this release because it likely changes the pickled bytes, which means a `CACHE_VERSION` bump and every existing cached race rebuilt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `f1-prefetch` command to prepopulate replay data for an entire season or selected rounds.
  * Supports optional radio data, forced refreshes, round ranges, progress reporting, and summary results.
  * Validates selected rounds before starting and continues processing when individual rounds are unavailable or fail.

* **Documentation**
  * Updated Arcade run instructions with an optional replay-cache prefetch step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->