### PR TITLE
Promote dev to main: the entry-point docs

### DIFF
--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -18,17 +18,31 @@ The quickest path. Installs the latest release into the current environment with
 uv pip install https://github.com/VforVitorio/F1-StratLab/releases/download/v__DOCS_VERSION__/f1_strat_manager-__DOCS_VERSION__-py3-none-any.whl
 ```
 
-After install, five console entry points are available:
+After install, seven console entry points are available:
 
 ```bash
 f1-strat       # interactive launcher (recommended starting point)
 f1-sim         # headless CLI simulation against a saved race
-f1-arcade      # pyglet 2D replay plus the live strategy surfaces
+f1-arcade      # pyglet 2D replay plus the two PITWALL windows
 f1-webapp      # post-race web app (wraps `docker compose up`)
+f1-prefetch    # fill the arcade replay cache ahead of time
 f1-eval        # regenerate the evaluation reports (registry, calibration, hygiene, projection, ...)
+f1-pitwall     # attach the two PITWALL windows to an arcade already running
 ```
 
-`f1-eval` is a developer/thesis tool, not an end-user surface, it writes versioned markdown + JSON reports under `documents/eval_reports/` (`f1-eval registry`, `f1-eval calibration`, `f1-eval all`, ...). The first four are what a new user actually runs.
+The first four are what a new user actually runs.
+
+`f1-prefetch` exists because the first launch of any given race builds its replay telemetry, which takes minutes. It runs the same preparation the arcade menu runs, for a whole season or a rounds spec, so the wait can be paid in advance rather than while somebody is waiting to watch:
+
+```bash
+f1-prefetch --year 2025                   # the whole calendar
+f1-prefetch --year 2025 --rounds 1,3,5-8  # commas and ranges
+f1-prefetch --year 2025 --with-radio      # also fetch the team radio the agents read
+```
+
+Rounds already cached are skipped without being loaded, so re-running it costs one filesystem check per round.
+
+`f1-eval` and `f1-pitwall` are developer tools rather than end-user surfaces. The first writes versioned markdown and JSON reports under `documents/eval_reports/` (`f1-eval registry`, `f1-eval calibration`, `f1-eval all`, ...); the second opens the PITWALL windows against an arcade process that is already running, which is how the UI is developed without restarting the replay.
 
 First boot triggers a one-time download of the cached models and reference data into `~/.f1-strat/`. Subsequent runs are offline.
 

--- a/docs/pages/pitwall.md
+++ b/docs/pages/pitwall.md
@@ -40,7 +40,14 @@ desktop.
 ## Launching
 
 Nothing extra to run. `f1-arcade --strategy` (or `python -m src.arcade.main …
---strategy`) spawns it. To develop against an already-running arcade:
+--strategy`) spawns it.
+
+The first launch of any given race builds its replay telemetry, which takes
+minutes, so the menu reports the stages while a worker thread does the work.
+`f1-prefetch --year 2025` runs that same preparation for a whole season ahead
+of time, and skips the rounds already cached.
+
+To develop against an already-running arcade:
 
 ```bash
 python -m src.pitwall


### PR DESCRIPTION
Documentation only, #1184. The docs site deploys from `main`, so the correction is not live until this lands.

`docs/pages/getting-started.md` claimed five console entry points and listed five. There are seven: `f1-pitwall` shipped with 2.6.0 and `f1-prefetch` with 2.6.1, and neither was documented anywhere. `f1-prefetch` now gets a short section rather than a line in a list, since the reason it exists is not readable from its name.

`docs/pages/pitwall.md` documented the cold build cost without mentioning that the wait can now be paid ahead of time.

No version bump: `docs:` commits do not move release-please.

## Checks

Every command in the new text was run rather than transcribed. Seven entry points against `[project.scripts]`. Prettier on `getting-started.md` only, since `pitwall.md` was already unformatted before this change and reformatting it would bury two added lines under a whole-file rewrite. All jobs green by name on #1184.