### PR TITLE
chore(deps): drop nltk, which nothing in the shipped code imports

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -4,11 +4,12 @@ name: OSV-Scanner
 # any npm/JS manifests). Uploads SARIF to the Security tab. The submodule's own
 # manifests are owned by Security epic #223; this covers the parent.
 #
-# The full scan is BLOCKING again (#403 triaged the pre-existing backlog): nltk
-# was bumped to its fixed release, and the CVEs with no reachable fix (Pillow x6,
-# blocked by arcade's <11.4 pin; torch; ecdsa) are waived with documented reasons
-# in osv-scanner.toml, which osv-scanner auto-discovers. Any NEW vulnerability not
-# on that list fails the build.
+# The full scan is BLOCKING (#403 triaged the pre-existing backlog). A
+# vulnerability with no reachable fix is waived one entry at a time in
+# osv-scanner.toml, each carrying the reason the fix is out of reach and, where
+# the situation can change, an expiry date. osv-scanner auto-discovers that file,
+# and it is the only place the waivers are listed, so this comment does not
+# repeat them. Any vulnerability not on that list fails the build.
 on:
   push:
     branches: [main]

--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -58,6 +58,8 @@ uv sync --all-extras
 
 `uv sync` reads `pyproject.toml`, resolves the lockfile and pulls the CUDA-routed PyTorch wheel automatically **on Windows**. Everything else, Linux and macOS included, resolves to the CPU wheel: CI runners and CPU-only Linux boxes were downloading about 5 GB of unused CUDA libraries, so the markers were narrowed deliberately (`pyproject.toml`, #251). A Linux GPU box opts back in by editing those markers.
 
+`uv sync --all-extras` does not cover one notebook. `N19_sentiment_vader.ipynb` is the VADER sentiment baseline that RoBERTa replaced, so nothing on the three surfaces reaches it, and nltk was dropped from the dependencies rather than waived against an advisory with no patched release (#1176). That notebook runs with `uv run --with nltk jupyter lab`.
+
 Run the simulation against a saved race:
 
 ```bash

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -157,22 +157,9 @@ id = "PYSEC-2026-3447"
 ignoreUntil = 2026-10-12T00:00:00Z
 reason = "setuptools: fix in 83.0.0 blocked by torch 2.11/2.12 (setuptools<82 pin); flaw only affects MANIFEST.in exclude normalization when building an sdist on macOS APFS/HFS+, never exercised here. Revisit when CUDA-pinned torch allows setuptools>=83."
 
-# --- nltk (no patched release exists) -----------------------------------------
-# The advisory carries `last_affected: 3.10.3` and no `fixed` event, and 3.10.3
-# is the newest release, so there is nothing to bump to. The flaw is in the
-# model-artifact APIs (TransitionParser.train/parse, AveragedPerceptron.save and
-# load, PerceptronTagger.save_to_json, save_maxent_params) reading and writing
-# caller-controlled paths outside the pathsec roots. Nothing under src/, scripts/
-# or tests/ imports nltk at all, let alone those APIs: the only consumer in the
-# repository is the N19 VADER sentiment notebook, which calls
-# SentimentIntensityAnalyzer and nltk.download.
-#
-# That last sentence is the argument for dropping the dependency rather than for
-# tolerating it, which is what the ecdsa note above says in the same situation.
-# Tracked as its own decision in #1176 rather than settled here, because taking a
-# package out of the released distribution is a bigger change than a waiver and
-# the notebook is a documented reproduction path. Short window on purpose.
-[[IgnoredVulns]]
-id = "GHSA-8mgp-746c-j5xp"
-ignoreUntil = 2026-10-03T00:00:00Z
-reason = "nltk: no patched release exists (last_affected 3.10.3, no fix event). Affected model-artifact APIs are imported nowhere in src/scripts/tests; only the N19 VADER notebook uses nltk at all. Removal is the better fix, tracked in #1176."
+# --- nltk: waiver removed, the dependency is gone -----------------------------
+# GHSA-8mgp-746c-j5xp (CVE-2026-81726) had nothing to bump to: last_affected
+# 3.10.3, no fix event, and 3.10.3 is the newest release. Nothing under src/,
+# scripts/ or tests/ imported nltk; the only consumer was the N19 VADER sentiment
+# notebook. #1176 dropped the dependency, which took nltk out of the lock, so
+# there is no longer a vulnerability to ignore.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,6 @@ dependencies = [
     # Declared here on its own — it used to ride in via the retired voice extra
     # and librosa's transitive dependency, which is not a contract.
     "soundfile>=0.12.0",
-    "nltk>=3.10.0",
     "gliner>=0.2.25",
     "onnxruntime<1.24",
     "setfit>=1.1.3",

--- a/tests/infra/test_dep_imports.py
+++ b/tests/infra/test_dep_imports.py
@@ -314,7 +314,6 @@ _TIER2_IMPORTS = [
     "spacy",
     "setfit",
     "gliner",
-    "nltk",
     "seqeval",
     "jiwer",
     "whisper",  # openai-whisper imports under the ``whisper`` name
@@ -425,18 +424,6 @@ def test_langchain_core_message_imports():
 
     assert HumanMessage(content="x").content == "x"
     assert AIMessage(content="y").content == "y"
-
-
-def test_langchain_openai_canonical_import_path():
-    """ChatOpenAI must be importable from ``langchain_openai`` directly.
-
-    Guards against a future deprecation that pushes everything back to
-    ``langchain_community`` — the agent loaders import the short path.
-    """
-    pytest.importorskip("langchain_openai")
-    from langchain_openai import ChatOpenAI  # noqa: F401
-
-    assert ChatOpenAI.__name__ == "ChatOpenAI"
 
 
 def test_pyarrow_parquet_engine_available():

--- a/tests/infra/test_smoke.py
+++ b/tests/infra/test_smoke.py
@@ -1,35 +1,16 @@
-"""Smoke tests — verify CI infrastructure and project structure."""
+"""Real-data checks on ``RaceStateManager`` over the season parquets.
+
+Both tests read a real ``laps.parquet`` and skip when it is absent, so a clone
+without ``data/`` stays green.
+
+Contents:
+- ``test_race_state_manager_melbourne``: the lap_state golden check on Melbourne 2025.
+- ``test_qatar_2025_v7_pia_sc_override``: the RCM safety-car override regression.
+"""
 
 from pathlib import Path
 
 ROOT = Path(__file__).parent.parent.parent
-
-
-def test_src_structure():
-    """src/ directory exists with expected sub-packages."""
-    assert (ROOT / "src").is_dir()
-    assert (ROOT / "src" / "rag").is_dir()
-    assert (ROOT / "src" / "nlp").is_dir()
-    assert (ROOT / "src" / "agents").is_dir()
-    assert (ROOT / "src" / "simulation").is_dir()
-
-
-def test_notebooks_structure():
-    """Agent notebooks directory exists."""
-    assert (ROOT / "notebooks" / "agents").is_dir()
-
-
-def test_pyproject_exists():
-    """pyproject.toml is present at repo root."""
-    assert (ROOT / "pyproject.toml").is_file()
-
-
-def test_simulation_imports():
-    """RaceStateManager and RaceReplayEngine are importable."""
-    pytest = __import__("pytest")
-    pd = pytest.importorskip("pandas", reason="pandas not installed in this environment")  # noqa: F841
-    from src.simulation.race_state_manager import RaceStateManager  # noqa: F401
-    from src.simulation.replay_engine import RaceReplayEngine  # noqa: F401
 
 
 def test_race_state_manager_melbourne():

--- a/uv.lock
+++ b/uv.lock
@@ -1160,7 +1160,6 @@ dependencies = [
     { name = "librosa" },
     { name = "lightgbm" },
     { name = "matplotlib" },
-    { name = "nltk" },
     { name = "numpy" },
     { name = "onnxruntime" },
     { name = "openai-whisper" },
@@ -1246,7 +1245,6 @@ requires-dist = [
     { name = "lightgbm", specifier = ">=4.6.0" },
     { name = "matplotlib", specifier = ">=3.7.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
-    { name = "nltk", specifier = ">=3.10.0" },
     { name = "numpy", specifier = ">=1.24.0,<2.0.0" },
     { name = "onnxruntime", specifier = "<1.24" },
     { name = "openai-whisper", specifier = ">=20230918" },
@@ -3127,22 +3125,6 @@ resolution-markers = [
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
-]
-
-[[package]]
-name = "nltk"
-version = "3.10.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "defusedxml" },
-    { name = "joblib" },
-    { name = "regex" },
-    { name = "tqdm" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/e6/fe51d2bb1a3b446f59c5c8165999a9fee208bc346af90a7cbf7657bc0d75/nltk-3.10.3.tar.gz", hash = "sha256:bb9327a461c3811c2fa4900e03840401f2126adfb30c0072827c433bd2444ea4", size = 5137152, upload-time = "2026-08-12T23:46:37.258Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/6d/ebd2af4640b12168fdf0cb74b6118df2f32a2f62ec7e0c06fbfd80706639/nltk-3.10.3-py3-none-any.whl", hash = "sha256:ff9598a8e20518ee0d557745890cc4435b9578489e2dcbc69c4f81fa060caf7c", size = 1798643, upload-time = "2026-08-12T23:44:13.478Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

nltk leaves `pyproject.toml` and `uv.lock`. Nothing under `src/`, `scripts/` or `tests/` imports it; the only consumers are the N19 VADER notebook and its archived predecessor under `legacy/`.

## Why

GHSA-8mgp-746c-j5xp (CVE-2026-81726) has `last_affected: 3.10.3` and no `fixed` event, and 3.10.3 is the newest release, so no bump closes the alert. The nltk repository's own advisory agrees (range `<=3.10.3`, `patched_versions` empty). PYSEC-2026-3740 records `fixed: 3.10.3` and is wrong: the released 3.10.3 source still calls bare `open()` at `tag/perceptron.py:178,183,351`, `parse/transitionparser.py:564,583` and `classify/maxent.py:1596-1602`. The waiver in `osv-scanner.toml` argued for removal itself, the same way the ecdsa note at `osv-scanner.toml:139-145` settled python-jose.

## How

Six files. `pyproject.toml` loses one line; `uv lock` removes 18 and adds none, since `uv tree --package nltk --invert --universal --frozen` shows one parent, the project itself. click, defusedxml, joblib, regex and tqdm have other parents and stay.

The tier-2 entry in `tests/infra/test_dep_imports.py` goes too, and not for the reason the issue gave: `pytest.importorskip` skips on a missing module, so the suite would not have gone red. It would have printed a permanent SKIP under `-ra` for a package the project no longer declares.

The `osv-scanner.toml` waiver becomes a removal note in the shape the file already uses for ecdsa. The OSV-Scanner workflow header no longer names packages: it claimed nltk had been bumped to a fixed release, and listed an ecdsa waiver that was deleted along with its dependency. `docs/pages/getting-started.md` promised `uv sync --all-extras` was enough to run the notebooks, and now names N19 as the exception with the command that runs it.

The second commit is the session's test-pruning pass over `tests/infra`.

## Out of scope

Running N19 needs `uv run --with nltk`; `notebooks/**` is read-only so the note lives in the docs instead. `dev` is 10 commits behind `origin/main` after the 2.6.0 and 2.6.1 releases; the lock was regenerated on `dev` and the diff came out nltk-only, so that sync is housekeeping rather than a prerequisite. Line numbers in `documents/audits/` pointing at the old `test_smoke.py` are dated records and were left alone.

## Checks

- `uv sync --all-extras` completes and uninstalls nltk; `importlib.util.find_spec("nltk")` returns `None`.
- `uv run pytest`: 1429 passed, 5 skipped, exit 0, 16:59. No nltk skip.
- `f1-sim Budapest NOR McLaren --no-real-radios --no-llm`: 70/70 laps, exit 0.
- `grep -c nltk uv.lock`: 0.
- ruff 0.15.22 (the pinned CI version): `check` clean, `format --check` 208 files already formatted.
- `mypy src/rag/`: no issues.
- `tests/infra`: 77 passed / 5 skipped before, 71 passed / 5 skipped after.
