### PR TITLE
fix(tests): repoint the Qatar smoke test at the RCM parquet that exists

### DIFF
--- a/tests/cli/test_provider_precedence.py
+++ b/tests/cli/test_provider_precedence.py
@@ -14,8 +14,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 ROOT = Path(__file__).parent.parent.parent
 _CLI = ROOT / "scripts" / "run_simulation_cli.py"
 
@@ -42,12 +40,6 @@ def test_the_flag_defaults_to_unset_not_to_a_provider():
         f"default here silently wins over the .env the project asks users to configure. "
         f"Block reads:\n{block}"
     )
-
-
-@pytest.mark.parametrize("provider", ["openai", "lmstudio"])
-def test_both_providers_are_still_accepted(provider):
-    """Passing it must keep working, including passing the fallback explicitly."""
-    assert provider in _provider_block()
 
 
 def test_the_env_is_only_written_when_the_flag_was_passed():

--- a/tests/infra/test_smoke.py
+++ b/tests/infra/test_smoke.py
@@ -1,28 +1,63 @@
 """Real-data checks on ``RaceStateManager`` over the season parquets.
 
-Both tests read a real ``laps.parquet`` and skip when it is absent, so a clone
-without ``data/`` stays green.
+Both tests read real parquets and skip when one is absent, so a clone without
+``data/`` stays green.
 
 Contents:
+- ``_data_root``: the anchor both tests resolve their paths against.
+- ``_skip_unless_present``: the skip guard, which names the file that is missing.
 - ``test_race_state_manager_melbourne``: the lap_state golden check on Melbourne 2025.
 - ``test_qatar_2025_v7_pia_sc_override``: the RCM safety-car override regression.
 """
 
 from pathlib import Path
 
-ROOT = Path(__file__).parent.parent.parent
+import pytest
+
+# Both tests read parquets that ship from Hugging Face rather than git, which is
+# what the marker records. Applied at module level so the two cannot drift apart.
+pytestmark = pytest.mark.data
+
+
+def _data_root() -> Path:
+    """The tree the production code reads, which ``F1_STRAT_DATA_ROOT`` can move.
+
+    Returns:
+        The resolved data directory, so a probe here and a read in the code under
+        test always name the same tree.
+
+    Anchoring on the repo instead lets a probe HIT while the code MISSES, which
+    turns a skip into a hard failure. Called inside a test rather than at module
+    scope, so collection never runs this function's mkdir.
+    """
+    from src.f1_strat_manager.data_cache import get_data_root
+
+    return get_data_root()
+
+
+def _skip_unless_present(*paths: Path) -> None:
+    """Skip on the first missing path, naming that path.
+
+    Args:
+        paths: Files the caller reads, in the order they are read.
+
+    The guard this replaces and-ed two paths into a single message asserting that
+    neither was available. One of the two resolved, so the message was false and a
+    path that matched nothing on any machine stayed invisible for months (#1172).
+    A skip reason that does not name the file cannot be told from a real absence.
+    """
+    for path in paths:
+        if not path.exists():
+            pytest.skip(f"not on disk: {path}")
 
 
 def test_race_state_manager_melbourne():
     """RaceStateManager produces a valid lap_state from the Melbourne 2025 parquet."""
-    import pytest
-
     pd = pytest.importorskip("pandas", reason="pandas not installed in this environment")
     from src.simulation.race_state_manager import RaceStateManager
 
-    laps_path = ROOT / "data" / "raw" / "2025" / "Melbourne" / "laps.parquet"
-    if not laps_path.exists():
-        pytest.skip("Melbourne 2025 parquet not available in this environment")
+    laps_path = _data_root() / "raw" / "2025" / "Melbourne" / "laps.parquet"
+    _skip_unless_present(laps_path)
 
     laps = pd.read_parquet(laps_path)
     rsm = RaceStateManager(laps, "NOR", "McLaren", gp_name="Melbourne", year=2025)
@@ -37,27 +72,77 @@ def test_race_state_manager_melbourne():
     assert "gp_name" in state["session_meta"]
 
 
-def test_qatar_2025_v7_pia_sc_override():
+def test_qatar_2025_v7_pia_sc_override(monkeypatch):
     """Catar 2025 V7 (PIA, McLaren) — RCM override flips sc_prob_3lap to 1.0.
 
     Reproduces the McLaren strategic miss from the real race (a deployed SC at V7
     that the LightGBM model predicted with low probability).  The override should
     flag sc_currently_active=True and elevate threat_level to HIGH regardless of
     what the model returned for raw sc_prob.
-    """
-    import pytest
 
+    Importing the agent builds the module-level ``CFG``, which loads both LightGBM
+    models, both calibrators and two processed parquets, so those are probed too:
+    without them the import raises where a skip is the honest answer.
+
+    The ReAct round trip is stubbed and nothing else is. ``_run_core`` computes the
+    override before it constructs the output, and ``threat_level`` is derived inside
+    that constructor, so the three assertions below read the forced values and never
+    the model's. What still runs for real is everything they depend on: the Lusail
+    parquet through ``RaceStateManager``, the Qatar RCM row through
+    ``_to_rcm_event``, the event classifier, ``_neutralization_from_rcm``, the
+    override arithmetic and the band. Left live, the test instead needs a backend on
+    localhost:1234, fails in 45 s on any machine without one, and would be the first
+    test here to reach a real LLM client, so a shell exporting F1_LLM_PROVIDER=openai
+    would spend credits on every run of the suite.
+    """
     pd = pytest.importorskip("pandas", reason="pandas not installed")
     pytest.importorskip("langchain_openai", reason="needs LLM stack")
 
-    laps_path = ROOT / "data" / "raw" / "2025" / "Lusail" / "laps.parquet"
-    rcm_path = ROOT / "data" / "raw" / "2025" / "Lusail" / "rcm.parquet"
-    if not (laps_path.exists() and rcm_path.exists()):
-        pytest.skip("Qatar 2025 parquets not available in this environment")
+    from src.f1_strat_manager.gp_slugs import resolve_gp_slug
 
-    from src.agents.race_situation_agent import run_race_situation_agent_from_state
+    root = _data_root()
+    laps_path = root / "raw" / "2025" / "Lusail" / "laps.parquet"
+    # The corpus is keyed by country slug, so "Lusail" resolves to "qatar" through
+    # the same helper radio_runner builds this path with. Writing "qatar" here would
+    # be a second copy of that mapping.
+    rcm_path = (
+        root / "processed" / "race_radios" / "2025" / resolve_gp_slug("Lusail") / "rcm.parquet"
+    )
+    _skip_unless_present(
+        laps_path,
+        rcm_path,
+        root / "models" / "overtake_probability" / "model_config.json",
+        root / "models" / "safety_car_probability" / "feature_list_v1.json",
+        root / "processed" / "circuit_clustering" / "circuit_clusters_k4.parquet",
+        root / "processed" / "sc_labeled" / "sc_labeled_2023_2025.parquet",
+    )
+
+    from langchain_core.messages import AIMessage
+
+    from src.agents.race_situation_agent import (
+        RaceSituationAgent,
+        run_race_situation_agent_from_state,
+    )
     from src.agents.strategy_orchestrator import _to_rcm_event
     from src.simulation.race_state_manager import RaceStateManager
+
+    class _StubReactAgent:
+        """A compiled graph that answers without calling a model.
+
+        Returns:
+            The one shape ``_run_core`` reads back: a ``messages`` list whose last
+            entry carries ``.content``. Holding no ToolMessage is deliberate, since
+            ``_parse_tool_outputs`` then returns its no-answer defaults
+            (``overtake_prob=None``, ``sc_prob_3lap=0.0``) and the override has to
+            supply every value the assertions check.
+        """
+
+        def invoke(self, _payload: dict) -> dict:
+            return {"messages": [AIMessage(content="stubbed: no tool calls")]}
+
+    monkeypatch.setattr(
+        RaceSituationAgent, "get_react_agent", lambda self, *args, **kwargs: _StubReactAgent()
+    )
 
     laps = pd.read_parquet(laps_path)
     rcms = pd.read_parquet(rcm_path)
@@ -66,7 +151,11 @@ def test_qatar_2025_v7_pia_sc_override():
 
     rsm = RaceStateManager(laps, "PIA", "McLaren", gp_name="Lusail", year=2025)
     lap_state = rsm.get_lap_state(7)
-    lap_state["rcm_events"] = [_to_rcm_event(e) for e in sc_lap7]
+    # The corpus column is `lap_number`; _to_rcm_event reads `lap`, so a raw row
+    # would build an RCMEvent carrying lap 0. The production producers already map
+    # it (src/nlp/radio_runner.py:640,668), and this is the only caller handing
+    # _to_rcm_event a row straight off the parquet.
+    lap_state["rcm_events"] = [_to_rcm_event({**e, "lap": int(e["lap_number"])}) for e in sc_lap7]
 
     out = run_race_situation_agent_from_state(lap_state, laps)
     assert out.sc_currently_active is True


### PR DESCRIPTION
## What

`test_qatar_2025_v7_pia_sc_override` has never executed. Its skip guard probed a file that is on no machine, so the skip read as a pass. Repointed at the file that exists, and it now runs and asserts.

Closes #1172.

## Why

The guard probed `data/raw/2025/Lusail/rcm.parquet`. That path has never held anything: `data/.gitignore:1-2` ignores `/raw` and `/processed`, so neither it nor the real file could ever have been committed, and `git log --all --diff-filter=A` over `*rcm.parquet` is empty. The corpus file is `data/processed/race_radios/2025/qatar/rcm.parquet`, 10.2K, 66 rows by 13 columns, whose lap 7 SafetyCar row carries `message` "SAFETY CAR DEPLOYED" and `session_key` 9850.

Two paths were and-ed into one skip message, "Qatar 2025 parquets not available in this environment". `laps.parquet` resolves (100.7K), so on a machine holding the dataset that message asserted something false about the file that was present and said nothing about the one that was not. `git blame` puts the probe at 2026-05-15.

## How

### `tests/infra/test_smoke.py`

Both paths resolve against `get_data_root()`, called inside the test. That is the anchor the production code reads through and `F1_STRAT_DATA_ROOT` can move, so a probe cannot hit a tree the code under test misses. Nine test files already use it and `tests/eval/test_alert_llm_golden.py:16-21` records the reason.

The slug comes from `resolve_gp_slug("Lusail")`, which returns `qatar` and is already covered by `tests/infra/test_gp_slugs.py:40-49`. Production builds the same path through it at `src/nlp/radio_runner.py:282` and `src/f1_strat_manager/data_cache.py:566-568`, so a literal `"qatar"` here would be a second copy of that mapping.

`test_race_state_manager_melbourne` moves to the same anchor. It shared the module-level `ROOT`, so moving one test and not the other would let `F1_STRAT_DATA_ROOT` point two tests in one file at two different trees.

One skip per path, naming the file. The list also covers what importing the agent pulls in: `CFG = RaceSituationConfig()` is module level (`src/agents/race_situation_agent.py:309`) and loads both LightGBM models, both calibrators, `circuit_clusters_k4.parquet` and `sc_labeled_2023_2025.parquet`. Without those the import raised where a skip is the honest answer, and `skip_no_tire_models` from `tests/conftest.py` names the wrong artefact for this agent.

The injected event now gets `lap` from the parquet's `lap_number`. `_to_rcm_event` reads `lap`, so a raw row built an `RCMEvent` carrying lap 0. The production producers already map it (`src/nlp/radio_runner.py:640,668`); this test was the only caller handing it a row straight off the parquet.

The ReAct round trip is stubbed. `_run_core` computes the override at lines 1819 and 1837 and constructs the output at 1852-1861, with `threat_level` derived in `__post_init__` inside that constructor, so the three assertions read the forced values and never the model's. Everything they depend on still runs for real: the Lusail parquet through `RaceStateManager`, the Qatar row through `_to_rcm_event`, the classifier, `_neutralization_from_rcm`, the override arithmetic and the band.

### `tests/cli/test_provider_precedence.py`

Drops `test_both_providers_are_still_accepted`. Measurements under Checks.

## Why the assertions were not touched

`threat_level == "HIGH"` looked like it might describe a path that no longer exists, since #450 measured the HIGH band firing 0 times in 1420 real 2025 laps. It does not. That measurement is about the raw model probability reaching `high_sc`, and this path never consults it: `sc_currently_active` is the first disjunct of the HIGH band (`src/agents/race_situation_agent.py:383-388`) and the forced `sc_prob_3lap=1.0` clears `high_sc=0.0864` on its own. Two independent sufficient conditions, both checked by constructing the dataclass against the live `CFG`. `overtake_prob` is forced to 0.0 under a neutralisation and cannot lower the band, because the ladder is a top-down OR with no subtractive term.

## Why the LLM call is stubbed rather than left live

Repointing the path alone does not make the test pass. It reaches `react_agent.invoke` and raises `openai.APIConnectionError` after 45 s unless a backend is listening on localhost:1234, measured on a machine with none. `LLM_MAX_RETRIES` is 5 (`src/agents/_shared_defaults.py:36`), so the budget is six attempts. The `timeout=120` never engages because the port refuses; it would if the port were filtered instead, making the budget about 12 minutes.

It would also have been the first test in this suite to reach a real LLM client. Nothing under `tests/` invokes one today. `get_react_agent` reads `os.environ` directly, so a shell exporting `F1_LLM_PROVIDER=openai` with a key would spend credits on every run of the suite, with no dotenv involved.

A reachability skip was rejected. On a machine where LM Studio is not running by default it would skip every time, which is this same issue again with a truer message and the same coverage, none. The `llm` marker is declared in `pyproject.toml` and used nowhere; if a live variant is ever wanted, that is its first real use and needs an explicit opt-in rather than a probe.

## Out of scope

The `setfit` entry in `test_dependency_imports` cannot fail on the condition it guards: the package is installed (1.1.3, alongside transformers 5.13.1) and its bare import is broken by the transformers major, which is exactly what it skips on. Production imports it through a shim at `src/agents/radio_agent.py:311-320`. Needs its own issue.

No guard exists for this defect class. `tests/test_construction_artefacts_are_downloadable.py` covers the opposite direction, a consumer reading a file the download patterns do not pull (#798, #1130, #1146). A static sweep asserting that every data path in `tests/` resolves wherever the dataset is present would have caught this probe on 2026-05-15.

The suite carries two anchors and this change does not unify them. After it, 10 test files reach data through `get_data_root()` and 74 still anchor on `Path(__file__)`, of which somewhere under 54 use that anchor to build a data path (54 is an upper bound: the count matches any file mentioning a data directory, and skip-reason strings containing `data/` inflate it). Only this file's two tests move here.

## Checks

Full suite on the parent commit and on this branch, same machine. The two runs overlapped for the first 12 minutes, so the wall times are inflated and neither is a quiet-machine figure.

| | passed | skipped | wall |
|---|---|---|---|
| `0507ff92` before | 1429 | 5 | 958.56s |
| this branch after | 1428 | 4 | 941.74s |

1429 minus the 2 deleted parametrisations plus the 1 test that now runs is 1428, and the skip count drops by the Qatar entry.

Skips before, all five:

```
tests/infra/test_dep_imports.py:381  setfit     (installed, import broken by transformers 5.13.1)
tests/infra/test_dep_imports.py:381  pydub      (absent)
tests/infra/test_dep_imports.py:381  edge_tts   (absent)
tests/infra/test_dep_imports.py:381  streamlit  (absent)
tests/infra/test_smoke.py:56         Qatar 2025 parquets not available in this environment
```

Skips after, the same four dependency entries and no fifth:

```
tests/infra/test_dep_imports.py:381  setfit
tests/infra/test_dep_imports.py:381  pydub
tests/infra/test_dep_imports.py:381  edge_tts
tests/infra/test_dep_imports.py:381  streamlit
```

### Seen red before green

Forcing `_neutralization_from_rcm` to report `NONE`, which is the pre-override world this test guards, makes it fail. The mutation was proved to apply before the run rather than assumed, since a mutation that silently fails to apply is a second green run in disguise:

```
[mutant] original _neutralization_from_rcm([SC DEPLOYED]) -> <Neutralization.SC: 'SC'>
[mutant] mutated  _neutralization_from_rcm([SC DEPLOYED]) -> <Neutralization.NONE: 'NONE'>

E  AssertionError: assert False is True
E   +  where False = RaceSituationOutput(overtake_prob=None, sc_prob_3lap=0.0,
E        threat_level='LOW', ..., sc_currently_active=False).sc_currently_active
1 failed in 1.48s
```

The stub returns no ToolMessage, so `_parse_tool_outputs` yields its no-answer defaults (`overtake_prob=None`, `sc_prob_3lap=0.0`) and every value the three assertions check has to come from the override. That is what makes the red above reachable at all.

### The deleted assertion

Measured by mutating the CLI source in memory rather than judged by reading:

| mutation | `[openai]` | `[lmstudio]` | sibling test |
|---|---|---|---|
| reintroduce #805, `default="lmstudio"` | green | green | red |
| delete `choices=["lmstudio", "openai"]` | red | green | n/a |

It stayed green on the bug its own file exists for, and on the one regression it could plausibly catch it caught half, because `"lmstudio"` survives in the comment at `scripts/run_simulation_cli.py:2166`. Its docstring claimed "passing it must keep working" while the body checked for a substring in a source slice and never passed the flag. The two remaining tests in that file both go red on #805 and are untouched.

Also run: `ruff format --check` and `ruff check` clean on both files.
