### PR TITLE
perf(arcade): merge a driver's telemetry once and slice it per lap

### DIFF
--- a/docs/pages/arcade-dashboard.md
+++ b/docs/pages/arcade-dashboard.md
@@ -152,7 +152,7 @@ Every one of these is additive (the Qt dashboard ignores them and is unaffected)
 | `arcade.global_t_min` / `.location` | the session-time origin, and FastF1's authoritative Location for resolving the race directory |
 | `schema_version` / `seq` | the payload version, and a strictly increasing sequence per message SENT, which is what lets two consumers on independent timers agree on a frame |
 
-Bumping `CACHE_VERSION` to v12 came with these; the first launch of a given GP after upgrading rebuilds its session pickle.
+The fields above arrived across several releases rather than with one bump, and the telemetry span carries its own `schema_version` for that reason. What holds for all of them is the mechanism: whenever `CACHE_VERSION` moves, the first launch of a given GP after upgrading rebuilds its session pickle.
 
 ## Extension points
 

--- a/documents/research/PITWALL_SPRINT4_SOURCES.md
+++ b/documents/research/PITWALL_SPRINT4_SOURCES.md
@@ -83,9 +83,12 @@ which is one additive field from a producer that exists, not a pipeline.
 
 ## 5. Cache and environment facts a sprint-4 session will hit
 
-- `CACHE_VERSION` is **v12**. First launch per GP rebuilds (< 3 min, no re-download).
-- `data/` is a **curated** download: only 2025/Melbourne has raw laps. Anything scoring across
-  races needs `data_cache.ensure_race()`.
+- `CACHE_VERSION` was **v12** when this page was written and is v17 since #1121. First launch per
+  GP after a bump rebuilds, with no re-download: 55 s for Lusail 2025 on 2026-09-04, 254 s for
+  Melbourne on 2026-08-20, both with FastF1's own cache already warm.
+- `data/` was a **curated** download carrying raw laps for 2025/Melbourne alone. `data/raw/2025/`
+  holds all 24 race folders since the prefetch work, so `data_cache.ensure_race()` is what fills a
+  race that is still missing rather than what every cross-race script has to call.
 - The orchestrator imports on a clean install since #883; `tests/agents` runs **236 tests** where
   it used to skip two thirds of them.
 - The submodule's lite CI installs neither pandas nor fastmcp, so its strategy tests **skip

--- a/src/arcade/config.py
+++ b/src/arcade/config.py
@@ -229,7 +229,8 @@ ARCADE_CACHE_DIR: Final[Path] = get_data_root() / "cache" / "arcade"
 # forever from the commit that writes it and can never see the NEXT change that forgets to
 # bump. A golden test keyed to the version COULD catch part of it (pin a small rebuilt
 # session's frames against a fixture and require the version to move when they do), and is
-# not written because rebuilding a session costs 254 s. Until it is, the obligation lives
+# not written because rebuilding a session is slow: 254 s for Melbourne on 2026-08-20 and
+# 55 to 80 s for Lusail on 2026-09-04, both with FastF1's own cache already warm. Until it is, the obligation lives
 # here: if the bytes a rebuild would produce differ from the bytes on disk, this string moves
 # in the SAME commit, or the fix reaches nobody who already has a pickle.
 # v15: a NaN Rainfall sample now pickles as None instead of "WET" (#1087). The bytes differ only
@@ -241,7 +242,14 @@ ARCADE_CACHE_DIR: Final[Path] = get_data_root() / "cache" / "arcade"
 # back byte-identical (Lusail, Monaco, Las Vegas, zero rows touched) and Melbourne moves 162 rows
 # across 5 drivers, taking unknown ages from 5 to 167. A pickle of a healthy race is unchanged, so
 # holding the version would have shipped the fix to everyone except the races that need it.
-CACHE_VERSION: Final[str] = "v16"  # + the shared lap-boundary sample sorts stably (#1069)
+# v17: the per-driver channels are merged once and then sliced per lap, so `dist` is FastF1's
+# own continuous race distance instead of a sum of per-lap distances (#1121). The bytes move and
+# the version moves with them: measured on Lusail 2025, x and y shift by up to 3.9 and 7.0 mm on
+# about 195,000 frames, `dist` by up to 12.2 m as a per-car offset, `rel_dist` by up to 0.00057.
+# The served order changes on 87 of 129,084 frames, all of them adjacent cars within 3 m of each
+# other, with the leader unchanged and every crossing, lap number, compound, tyre age, gear, DRS
+# code, brake, speed and throttle identical to v16.
+CACHE_VERSION: Final[str] = "v17"  # + the shared lap-boundary sample sorts stably (#1069)
 
 # --- Multiprocessing pool -------------------------------------------------
 # Serial. The reason recorded here used to be a hang: Windows spawn plus pickling
@@ -251,10 +259,13 @@ CACHE_VERSION: Final[str] = "v16"  # + the shared lap-boundary sample sorts stab
 # re-run it either, so treat the hang as unexplained rather than as the reason.
 #
 # What actually keeps this at 1 is that raising it has never been measured as a
-# win, and the work a pool would spread is FastF1's per-lap telemetry loop, which
-# is 93% of a cold build and which #1121 removes outright rather than
-# parallelises. Raise this only alongside a timed cold build, never on the
-# strength of the core count.
+# win, and the work a pool would spread is the per-driver extraction, which #1121
+# already cut by about 70%: a Lusail 2025 build with FastF1's cache warm went from
+# 270.4 s to 80.0 s back to back on one machine, and from 148.2 s to 55.0 s on the
+# same machine under a lighter load earlier the same day. The 93% share quoted here
+# before was Suzuka with FastF1 warm as well; on a first-ever build, where FastF1's
+# own download and parse are most of the wall clock, the loop was about 42%. Raise
+# this only alongside a timed cold build, never on the strength of the core count.
 POOL_SIZE: Final[int] = 1
 
 

--- a/src/arcade/data.py
+++ b/src/arcade/data.py
@@ -326,19 +326,21 @@ def _nearest_sample(t: np.ndarray, timeline: np.ndarray) -> np.ndarray:
 
 # The eight forward gears plus neutral, and the validity test is ONE-SIDED because
 # 0 is a real reading rather than a sentinel: `session.car_data` for Melbourne 2025
-# carries 202,509 of them across the 20 drivers, and the PITWALL GEAR lane's [0, 9]
+# carries 315,550 of them across the 20 drivers, and the PITWALL GEAR lane's [0, 9]
 # range renders it.
 #
-# **None of them reaches a replay, and that is a property of the DATA, not a filter
-# here.** Every one of those 202,509 samples falls OUTSIDE every lap window: the
-# cars are stationary in the garage and on the grid, before lap 1 starts at 00:56:06
-# session time, while the laps run to 02:19:37. `_process_driver_data` reads
-# `lap.get_telemetry()`, so it only ever sees samples inside a lap, and across all
-# 1,059 laps of this race not one carries gear 0. Measured 2026-08-26 (#1094).
+# **Most of them never reach a replay, and that is a property of the DATA rather
+# than of a filter here.** The cars are stationary in the garage and on the grid,
+# outside every lap window, so the extraction never sees those samples. What does
+# reach a replay is a car stationary INSIDE a lap: Melbourne 2025 serves 1,400
+# gear-0 samples, 862 of them HAD's entire lap 1 and 506 of them DOO's.
 #
-# So a replay of this race legitimately serves no neutral frame. Do NOT widen the
-# predicate below to `< 1` on the strength of that: the reading is real, other
-# sessions can put a stationary car inside a lap window, and one-sided is the rule.
+# Do NOT widen the predicate below to `< 1`: the reading is real, a stationary car
+# inside a lap window is exactly the case that produces it, and one-sided is the
+# rule. An earlier version of this comment said no lap of the race carried gear 0
+# and put the session between 00:56:06 and 02:19:37. Both came from the pickle
+# labelled Melbourne that held Suzuka (#1119), whose race is 1h23 long against
+# Melbourne's 1h43. Re-measured on both extraction paths 2026-09-04 (#1094, #1121).
 def _concat_sorted_by_time(arrays: dict[str, list[np.ndarray]]) -> dict[str, np.ndarray]:
     """Flatten the per-lap arrays into one time-ordered block per channel.
 
@@ -432,18 +434,60 @@ def _drop_impossible_gears(gears: np.ndarray) -> np.ndarray:
     return repaired.ffill().bfill().to_numpy()
 
 
+def _merge_driver_channels(laps_driver) -> "fastf1.core.Telemetry | None":
+    """Position and car data for one driver, merged and integrated ONCE (#1121).
+
+    `Lap.get_telemetry()` does this per lap, and 5.29 s of the 6.6 s a driver
+    costs is the `add_driver_ahead()` it runs 57 times to produce `DriverAhead`
+    and `DistanceToDriverAhead`, two channels `_process_driver_data` never
+    reads. Doing the merge once and skipping that call is where the saving is.
+
+    Returns None when a driver has no usable position or car data, which the
+    caller treats the same way it treats an empty lap set.
+
+    --- WHERE TO CHANGE IF THIS CHANGES ---
+    The per-lap windows are still cut afterwards by `slice_by_lap`, so
+    `_concat_sorted_by_time` keeps its boundary ties and `_nearest_sample`
+    keeps its `<=` tie-break. Switching to `Laps.get_telemetry()` would drop
+    both: it interpolates an edge sample only at the driver's first lap start
+    and last lap end, so no sample sits on an internal lap line, the lap
+    increments up to eleven frames off, and 754 of 1,063 crossings move.
+    Measured on Lusail 2025: 5,343 of 129,084 served frames change the
+    leaderboard order and 736 change the leader.
+    """
+    try:
+        pos = laps_driver.get_pos_data(pad=1, pad_side="both")
+        car = laps_driver.get_car_data(pad=1, pad_side="both").add_distance()
+        merged = pos.merge_channels(car)
+    except (KeyError, ValueError, AttributeError):
+        return None
+    if merged is None or merged.empty:
+        return None
+    return merged
+
+
 def _process_driver_data(args: tuple) -> dict | None:
-    """Module-level worker: iterate a driver's laps and flatten telemetry.
+    """Module-level worker: flatten one driver's telemetry, lap by lap.
 
     Must stay at module scope so `multiprocessing.Pool` can pickle it by
-    qualified name on Windows spawn. Mirrors the reference per-driver loop
-    but actually increments the race-distance accumulator each lap."""
+    qualified name on Windows spawn.
+
+    The channels are merged once for the whole driver and then sliced per lap,
+    so `dist` is FastF1's own continuous race distance rather than a sum of
+    per-lap distances. The old accumulator dropped the span between a lap's
+    last sample and the line crossing, and re-deriving it over once-integrated
+    windows was measured and is worse: it reorders 106 served frames against
+    continuous distance's 87, and moves the leader on the grid frames."""
 
     driver_no, session, driver_code = args
     _enable_fastf1_cache()
 
     laps_driver = session.laps.pick_drivers(driver_no)
     if laps_driver.empty:
+        return None
+
+    merged = _merge_driver_channels(laps_driver)
+    if merged is None:
         return None
 
     arrays: dict[str, list[np.ndarray]] = {
@@ -463,12 +507,11 @@ def _process_driver_data(args: tuple) -> dict | None:
             "tyre_life",
         )
     }
-    total_dist_so_far = 0.0
     max_lap = 0
 
     for _, lap in laps_driver.iterlaps():
         try:
-            tel = lap.get_telemetry()
+            tel = merged.slice_by_lap(lap, interpolate_edges=True)
         except (KeyError, ValueError, AttributeError):
             continue
         if tel is None or tel.empty:
@@ -487,15 +530,17 @@ def _process_driver_data(args: tuple) -> dict | None:
         thr = tel["Throttle"].to_numpy().astype(float) if "Throttle" in tel.columns else np.zeros(n)
         brk = tel["Brake"].to_numpy().astype(float) if "Brake" in tel.columns else np.zeros(n)
 
-        d_lap = (
-            tel["Distance"].to_numpy().astype(float) if "Distance" in tel.columns else np.zeros(n)
-        )
+        # Continuous already: `add_distance()` integrated the whole driver span
+        # once, so the window carries race distance rather than lap distance and
+        # there is nothing to accumulate.
+        #
         # FastF1's `RelativeDistance` is deliberately NOT collected. The
         # resampler stopped consuming it when the fraction became a
         # derivation over the driver's own distance; extracting it was
         # three lines of work per lap per driver feeding nothing.
-        race_dist = total_dist_so_far + d_lap
-        total_dist_so_far += float(d_lap[-1]) if n else 0.0
+        race_dist = (
+            tel["Distance"].to_numpy().astype(float) if "Distance" in tel.columns else np.zeros(n)
+        )
 
         lap_no = int(lap.LapNumber) if not pd.isna(lap.LapNumber) else 0
         max_lap = max(max_lap, lap_no)
@@ -673,10 +718,12 @@ class SessionLoader:
     def _process_all_drivers(
         self, session: Any, driver_nums: list, driver_codes: dict
     ) -> list[dict | None]:
-        # Serial by default: pickling a fully-loaded FastF1 session across N
-        # Windows spawn workers is heavy and has hung in prior sessions. Set
-        # `pool_size > 1` explicitly to opt into parallel extraction once the
-        # FastF1 cache is warm.
+        # Serial by default. The hang this comment used to assert is not
+        # established: the load audit went looking and could not reproduce it,
+        # and `config.POOL_SIZE` records the same correction. What is true is
+        # that pickling a fully-loaded FastF1 session across N Windows spawn
+        # workers is heavy and that raising the count has never been measured
+        # as a win. Set `pool_size > 1` explicitly to opt into it.
         args = [(n, session, driver_codes[n]) for n in driver_nums]
         if self.pool_size <= 1:
             return self._process_serial(args)

--- a/tests/surfaces/test_arcade_cache_identity.py
+++ b/tests/surfaces/test_arcade_cache_identity.py
@@ -37,16 +37,6 @@ def test_the_name_is_built_from_what_decides_the_contents(loader: SessionLoader)
     assert path.name == "2025_r03_race.pkl"
 
 
-def test_the_label_cannot_change_where_a_session_is_cached(loader: SessionLoader) -> None:
-    """The defect, stated as the assertion that catches it.
-
-    Two callers asking for the same round under different names must land on the
-    same file. Under the old key they landed on two, and the one that wrote
-    first decided what the other read.
-    """
-    assert loader._cache_path(2025, 3) == loader._cache_path(2025, 3)
-
-
 @pytest.mark.parametrize(("year", "round_"), [(2025, 1), (2025, 3), (2024, 24), (2023, 22)])
 def test_a_different_race_is_a_different_file(
     loader: SessionLoader, year: int, round_: int

--- a/tests/surfaces/test_arcade_telemetry_span.py
+++ b/tests/surfaces/test_arcade_telemetry_span.py
@@ -13,6 +13,7 @@ behaviour: repeated samples, a negative slice, and an unbounded payload.
 
 from __future__ import annotations
 
+import ast
 import math
 from pathlib import Path
 from types import SimpleNamespace
@@ -1016,3 +1017,80 @@ def test_a_shared_lap_boundary_sample_comes_out_lap_ascending():
     assert list(concat["tyre_life"][falls + 1]) == [1.0], "a tyre aged backwards mid-stint"
     # And the compound changes once, rather than flickering back and forth.
     assert int(np.count_nonzero(np.diff(concat["tyre"]) != 0)) == 1
+
+
+# --- #1121: the merge happens once per driver, and CI is the only place that sees it ---
+#
+# The per-lap windows still exist after the merge, so every guard above keeps working
+# under the change AND under a revert to `lap.get_telemetry()`. What a revert moves is
+# the cost (270.4 s against 80.0 s for a Lusail 2025 build) and, for the other revert,
+# the served order. Both are invisible to the assertions in this file: the six guards
+# that read a real pickle skip on every CI runner, and a rebuilt pickle passes them
+# whichever path built it. So the property is asserted on the source instead.
+
+
+def _extraction_ast() -> dict[str, ast.FunctionDef]:
+    """`_process_driver_data` and `_merge_driver_channels`, parsed rather than imported.
+
+    Parsed because the property is about which FastF1 calls appear and how often,
+    which a text search cannot tell from a mention in a comment, and because this
+    has to run where there is no FastF1 cache and no race on disk.
+    """
+    source = Path(__file__).resolve().parents[2] / "src" / "arcade" / "data.py"
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+    wanted = {"_process_driver_data", "_merge_driver_channels"}
+    found = {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name in wanted
+    }
+    missing = wanted - set(found)
+    assert not missing, f"src/arcade/data.py no longer defines {sorted(missing)}"
+    return found
+
+
+def _called_attrs(node: ast.AST) -> list[str]:
+    return [
+        call.func.attr
+        for call in ast.walk(node)
+        if isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute)
+    ]
+
+
+def test_the_extraction_never_asks_for_the_driver_ahead_channel():
+    """`DriverAhead` costs 5.29 s of the 6.6 s a driver used to take and nothing reads it.
+
+    `Lap.get_telemetry()` and `Laps.get_telemetry()` both call `add_driver_ahead()`
+    internally, which is why neither of them appears here either.
+    """
+    functions = _extraction_ast()
+    for name, node in functions.items():
+        called = _called_attrs(node)
+        assert "add_driver_ahead" not in called, f"{name} pays for DriverAhead again"
+        assert "get_telemetry" not in called, (
+            f"{name} calls get_telemetry(), which computes DriverAhead whether it is "
+            "asked per lap or once per driver"
+        )
+
+
+def test_the_merge_happens_once_per_driver_and_the_slicing_per_lap():
+    """The shape of the fix, stated where a revert has to break it.
+
+    A revert to the per-lap call puts `get_telemetry` back inside the `for` (caught
+    above). A jump the other way, to `Laps.get_telemetry()` for the whole driver,
+    drops `slice_by_lap` and with it the boundary sample at every lap line: measured
+    on Lusail 2025 that moves 754 of 1,063 crossings and reorders 5,343 of 129,084
+    served frames, 736 of them at the front.
+    """
+    functions = _extraction_ast()
+    merge_calls = _called_attrs(functions["_merge_driver_channels"])
+    assert merge_calls.count("merge_channels") == 1, "the channels are merged once per driver"
+    assert "add_distance" in merge_calls, "race distance has to be integrated over the whole span"
+
+    loops = [n for n in ast.walk(functions["_process_driver_data"]) if isinstance(n, ast.For)]
+    assert loops, "_process_driver_data no longer iterates the driver's laps"
+    sliced_in_a_loop = any("slice_by_lap" in _called_attrs(loop) for loop in loops)
+    assert sliced_in_a_loop, (
+        "nothing slices the merged frame per lap, so the shared lap-boundary sample "
+        "#1069 orders does not exist"
+    )


### PR DESCRIPTION
## What

`_process_driver_data` merges a driver's position and car channels once and then slices them per lap, instead of calling `lap.get_telemetry()` once per lap. A Lusail 2025 build with FastF1's cache warm goes from 270.4 s to 80.0 s, measured back to back on one machine.

`CACHE_VERSION` moves to v17 in the same commit, because the pickled bytes move.

## Why

`Lap.get_telemetry()` runs `add_driver_ahead()` on every call. Decomposed over the 57 laps of one driver, that is 5.29 s of the 6.6 s the driver costs, against 1.33 s for the merge itself, and it produces `DriverAhead` and `DistanceToDriverAhead`, two channels `_process_driver_data` never reads.

## How

`get_pos_data(pad=1)`, `get_car_data(pad=1).add_distance()`, one `merge_channels`, then the existing per-lap loop over `slice_by_lap(lap, interpolate_edges=True)`. `add_driver_ahead()` is never called. `dist` comes from the once-integrated `Distance` and the per-lap accumulator is gone.

The per-lap windows survive, so the boundary samples FastF1 emits twice at each crossing survive with them, and `_concat_sorted_by_time` and `_nearest_sample`'s `<=` tie-break keep the job #1069 gave them.

Issue #1121 proposed `Laps.get_telemetry()` instead. That was measured and rejected: it interpolates an edge sample only at the driver's first lap start and last lap end, so no sample sits on an internal lap line, the lap increments up to eleven frames off, 754 of 1,063 crossings move, and the served leaderboard order changes on 5,343 of 129,084 frames with the leader changing on 736. Re-deriving the old per-lap accumulator over the once-integrated windows was measured too and is worse than continuous distance: 106 reordered frames against 87, plus a leader change on the grid.

Also fixed, all of them false claims found while measuring this:

- `src/arcade/data.py` said no lap of Melbourne 2025 carries gear 0, stamped "Measured 2026-08-26". It was measured on the pickle labelled Melbourne that held Suzuka (#1119): the session span it quotes is 1h23, Melbourne's race is 1h43. Melbourne has 315,550 gear-0 samples in `car_data`, not 202,509, and the extraction emits 1,400 of them, 862 being HAD's whole lap 1. The one-sided rule the comment states is still right.
- `src/arcade/config.py` said the per-lap loop "is 93% of a cold build and which #1121 removes outright", as a fact about a change that did not exist. The 93% is Suzuka with FastF1 warm; on a first-ever build the loop is about 42%.
- `src/arcade/data.py`'s pool comment still asserted a hang that `config.py` records as unestablished.
- `docs/pages/arcade-dashboard.md` said the v12 bump carried the wire fields listed above it. v12 shipped `official_status` and `has_finished` only; those fields came with v8 and with a change on 2026-08-22 that carried no bump at all.
- `documents/research/PITWALL_SPRINT4_SOURCES.md` said in the present tense that `CACHE_VERSION` is v12 and that only 2025/Melbourne has raw laps. `data/raw/2025/` holds 24 race folders.

Deleted `tests/surfaces/test_arcade_cache_identity.py::test_the_label_cannot_change_where_a_session_is_cached`. It asserted `_cache_path(2025, 3) == _cache_path(2025, 3)` against a pure f-string, which holds for the buggy `gp_name`-keyed version too, so it could not go red on the #1119 bug its docstring names. The three tests around it do catch it.

## Out of scope

#1118 phase 1, the columnar representation, is a separate change and a separate session. The golden test `config.py` declines to write is still not written; it belongs with a hand-built or one-driver fixture rather than a 320 MB pickle, and it would still skip in CI.

## Checks

- Order diff, the decider: 87 of 129,084 served frames (0.067%), all adjacent cars within 3 m, ranked with the real `LeaderboardPanel._rank_drivers` over the real `RaceGapCalculator`. Leader unchanged. Crossings shifted on 0 of 1,063. `lap`, `tyre`, `tyre_life`, `gear`, `drs`, `speed`, `throttle`, `brake` and `active` differ on 0 frames. `x`/`y` up to 3.9/7.0 mm, `dist` up to 12.2 m as a per-car offset, `rel_dist` up to 0.00057.
- The old path rebuilt from a `dev` worktree is byte-identical to the cached v16 pickle, so the baseline is today's code rather than an artefact. Two consecutive builds of the new path are byte-identical to each other.
- The two #1069 guards re-run on the new pickle: lap goes backwards on 0 active frames, nobody parked at the line.
- The six cached races rebuilt at v17 with `f1-prefetch --force`: 6 prepared, 0 skipped, 0 unavailable, 0 failed, 782.6 s. `--force` is needed because `prefetch.py` skips on file presence alone.
- `uv run pytest`: **1433 passed, 4 skipped in 957.51s**. The baseline on `dev` was 1432/4, so the delta is the two new guards minus the deleted one. Same four skips (`setfit`, `pydub`, `edge_tts`, `streamlit`), so the six pickle-reading guards ran rather than skipping on the bumped version.
- The two new guards were watched RED on three mutants, each of which parses: `slice_by_lap` reverted to `lap.get_telemetry()`, the helper replaced by `laps_driver.get_telemetry()`, and `add_driver_ahead()` re-added to the merge.
- `f1-arcade --viewer --year 2025 --round 23 --driver NOR` run for real against the rebuilt pickle: loads from cache in 4.0 s, 20 drivers, 129,084 frames, and the leaderboard renders the full grid with NOR at P3 and the right compounds.
