### PR TITLE
fix(simulation): default the replay engine to no sleep between laps

### DIFF
--- a/src/simulation/replay_engine.py
+++ b/src/simulation/replay_engine.py
@@ -42,7 +42,8 @@ class RaceReplayEngine:
     Attributes:
         rsm:         The underlying ``RaceStateManager``.
         total_laps:  Number of laps in the race.
-        interval:    Seconds to sleep between lap emissions (0 for batch).
+        interval:    Seconds to sleep between lap emissions, 0 for batch and
+                     the default. Only the interactive surfaces raise it.
     """
 
     def __init__(
@@ -50,7 +51,7 @@ class RaceReplayEngine:
         race_dir: str | Path,
         driver_code: str,
         team: str,
-        interval_seconds: float = 3.0,
+        interval_seconds: float = 0.0,
     ) -> None:
         """Load race data and initialise the state manager.
 
@@ -62,8 +63,14 @@ class RaceReplayEngine:
                               ``"NOR"``).
             team:             Our driver's team name, must match the Team
                               column in the laps parquet exactly.
-            interval_seconds: Seconds to sleep between lap emissions.
-                              Pass ``0.0`` for batch/test mode (no sleep).
+            interval_seconds: Seconds to sleep between lap emissions. Defaults
+                              to no sleep, so a caller that does not ask for
+                              pacing runs at full speed. The interactive
+                              surfaces ask for it explicitly: both CLIs pass
+                              ``args.interval`` and the arcade passes
+                              ``StrategyRequest.interval_s``. A caller that
+                              forgets the argument pays nothing, which is the
+                              direction that fails safe (#1202).
         """
         race_dir = Path(race_dir)
 

--- a/tests/simulation/test_replay_interval_default.py
+++ b/tests/simulation/test_replay_interval_default.py
@@ -61,18 +61,36 @@ def _race_dir(tmp_path: Path) -> Path:
 
 
 def _sleep_recorder(monkeypatch) -> list[float]:
-    """Replace the engine module's `time.sleep` with a recorder and return its log.
+    """Record the sleeps issued by THIS thread, leaving every other thread untouched.
 
-    Patching the module rather than `time` itself keeps the rest of the process, pytest
-    included, on the real function.
+    `replay_engine.time` is the `time` module itself, not a per-module copy, so patching
+    its `sleep` attribute patches the whole process. Background threads that earlier
+    tests left running then land in the recorder: draining a six-lap replay collected
+    2142 calls of 0.016 s from a 60 Hz poll loop this guard has nothing to do with, which
+    turned the assertion into a report on the rest of the suite.
+
+    Filtering on the thread id keeps the guard about the engine, and forwarding the other
+    threads to the real function keeps them paced rather than spinning.
 
     Returns:
-        A list that receives one entry per sleep call, holding the seconds requested.
+        A list that receives one entry per sleep call made on the calling thread, holding
+        the seconds requested.
     """
+    import threading
+
     from src.simulation import replay_engine
 
+    real_sleep = replay_engine.time.sleep
+    caller = threading.get_ident()
     slept: list[float] = []
-    monkeypatch.setattr(replay_engine.time, "sleep", slept.append)
+
+    def recording_sleep(seconds: float) -> None:
+        if threading.get_ident() == caller:
+            slept.append(seconds)
+            return
+        real_sleep(seconds)
+
+    monkeypatch.setattr(replay_engine.time, "sleep", recording_sleep)
     return slept
 
 

--- a/tests/simulation/test_replay_interval_default.py
+++ b/tests/simulation/test_replay_interval_default.py
@@ -1,0 +1,138 @@
+"""A caller that does not ask for pacing must not pay for it (#1202).
+
+`RaceReplayEngine.replay()` sleeps `interval_seconds` after every yielded lap. That
+default used to be 3.0, and three test sites built the engine without the argument and
+then drove 49 laps to reach lap 50, so each one paid 147 s of pure sleeping. Together
+they were 441 s, 40.2% of an 18m17s local suite, and two of the three were reported
+under `setup` rather than `call`, which is why reading the durations table for slow
+tests walked straight past them.
+
+The guard asserts the EFFECT, that no sleeping happens, rather than the value of the
+default. A test pinning `interval_seconds == 0.0` would stay green if `replay()` grew a
+second delay somewhere else, and it would say nothing about what a caller actually pays.
+
+`test_a_caller_that_asks_for_pacing_still_gets_it` is here so the first test cannot pass
+vacuously: it proves the recorder sees sleeping when sleeping happens.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+_TOTAL_LAPS = 6
+
+
+def _race_dir(tmp_path: Path) -> Path:
+    """Write the smallest `laps.parquet` the engine will load, and return its directory.
+
+    Hermetic on purpose: the defect this guards is about wall-clock cost, so gating it
+    on `data/` would leave it skipped on CI, which is the environment least likely to
+    notice a delay creeping back in.
+
+    Returns:
+        A race directory the engine can construct from, holding one clean stint for a
+        single driver over ``_TOTAL_LAPS`` laps.
+    """
+    rows = [
+        {
+            "Driver": "NOR",
+            "DriverNumber": "4",
+            "LapNumber": lap,
+            "LapTime_s": 90.0,
+            "LapTime": pd.Timedelta(seconds=90),
+            "Time": pd.Timedelta(seconds=90 * lap),
+            "TrackStatus": "1",
+            "Position": 1,
+            "Compound": "MEDIUM",
+            "TyreLife": lap,
+            "Stint": 1,
+            "PitInTime": pd.NaT,
+            "Team": "McLaren",
+        }
+        for lap in range(1, _TOTAL_LAPS + 1)
+    ]
+    race_dir = tmp_path / "Melbourne"
+    race_dir.mkdir()
+    pd.DataFrame(rows).to_parquet(race_dir / "laps.parquet")
+    return race_dir
+
+
+def _sleep_recorder(monkeypatch) -> list[float]:
+    """Replace the engine module's `time.sleep` with a recorder and return its log.
+
+    Patching the module rather than `time` itself keeps the rest of the process, pytest
+    included, on the real function.
+
+    Returns:
+        A list that receives one entry per sleep call, holding the seconds requested.
+    """
+    from src.simulation import replay_engine
+
+    slept: list[float] = []
+    monkeypatch.setattr(replay_engine.time, "sleep", slept.append)
+    return slept
+
+
+def test_the_default_engine_does_not_sleep_between_laps(tmp_path, monkeypatch):
+    """Constructing without `interval_seconds` and draining the replay sleeps zero times."""
+    from src.simulation.replay_engine import RaceReplayEngine
+
+    slept = _sleep_recorder(monkeypatch)
+    engine = RaceReplayEngine(_race_dir(tmp_path), driver_code="NOR", team="McLaren")
+
+    emitted = list(engine.replay())
+
+    assert len(emitted) == _TOTAL_LAPS, "the replay must still emit every lap"
+    assert slept == [], (
+        f"the default engine slept {sum(slept)} s across {len(slept)} calls; "
+        "a caller that does not ask for pacing must not pay for it (#1202)"
+    )
+
+
+def test_a_caller_that_asks_for_pacing_still_gets_it(tmp_path, monkeypatch):
+    """The recorder is not blind: an explicit interval sleeps once per lap."""
+    from src.simulation.replay_engine import RaceReplayEngine
+
+    slept = _sleep_recorder(monkeypatch)
+    engine = RaceReplayEngine(
+        _race_dir(tmp_path), driver_code="NOR", team="McLaren", interval_seconds=0.25
+    )
+
+    list(engine.replay())
+
+    assert slept == [0.25] * _TOTAL_LAPS
+
+
+@pytest.mark.parametrize(
+    ("module_path", "symbol"),
+    [
+        ("scripts.run_simulation_cli", "--interval"),
+        ("src.simulation.__main__", "--interval"),
+    ],
+)
+def test_the_interactive_clis_still_default_to_no_sleep(module_path, symbol):
+    """The pacing decision belongs to the CLI flag, and both flags default to 0.0.
+
+    Read from the source rather than by parsing arguments, so the check costs nothing and
+    does not import the agent stack. If either default ever moves off 0.0, the engine's
+    own default is no longer the only thing keeping a batch run fast.
+    """
+    import ast
+    import textwrap
+
+    path = Path(__file__).parents[2] / (module_path.replace(".", "/") + ".py")
+    tree = ast.parse(textwrap.dedent(path.read_text(encoding="utf-8")))
+
+    defaults = [
+        keyword.value.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and any(isinstance(arg, ast.Constant) and arg.value == symbol for arg in node.args)
+        for keyword in node.keywords
+        if keyword.arg == "default" and isinstance(keyword.value, ast.Constant)
+    ]
+
+    assert defaults == [0.0], f"{module_path} declares {symbol} with defaults {defaults}"


### PR DESCRIPTION
## What

`RaceReplayEngine` defaulted to sleeping 3 seconds after every yielded lap. Three test sites built it without passing the argument, so each paid 147 s of pure sleeping. The default is now `0.0`. The local suite goes from **18m17s to 8m41s**.

## Why

`src/simulation/replay_engine.py` declared `interval_seconds: float = 3.0`, and `replay()` sleeps that long after each lap. These three sites construct the engine with no argument and then consume 49 laps to reach lap 50:

| Site | Before | After |
|---|---|---|
| `tests/audit/test_race_situation_hardening.py:149` | 147.61 s (setup) | 0.19 s |
| `tests/mc/test_undercut_targets_are_on_track.py:63` | 148.65 s (setup) | 1.78 s |
| `tests/mc/test_undercut_targets_are_on_track.py:123` | 147.64 s (call) | 2.51 s |

441 s, 40.2% of the run. Two of the three are reported under `setup`, not `call`, which is why reading the durations table for slow tests walks past them.

Nothing shipped receives the `3.0`. Both CLIs declare `--interval` with `default=0.0` and pass `args.interval` through (`scripts/run_simulation_cli.py:2180`, `src/simulation/__main__.py:185`); the arcade passes `StrategyRequest.interval_s`, whose dataclass default is `0.0`; `decision_modes.py:580`, the telemetry simulator, `gen_inputs.py:139` and the eight other test sites all pass `0` explicitly. The change touches no shipped behaviour and fails in the safe direction: a caller that forgets the argument pays nothing.

## How

- `src/simulation/replay_engine.py`: default `3.0` to `0.0`, plus the two docstrings that described the old behaviour.
- `tests/simulation/test_replay_interval_default.py`: a new guard, 4 tests, hermetic so CI covers it rather than skipping it.

The guard asserts the **effect**, not the constant. A test pinning `interval_seconds == 0.0` would stay green if `replay()` grew a delay somewhere else and would say nothing about what a caller pays. It records calls to the engine module's `time.sleep`, drains a six-lap replay built in `tmp_path`, and asserts zero sleeps. A companion test passes `interval_seconds=0.25` and asserts six sleeps so the first cannot pass vacuously. A third reads both argparse declarations through the AST and asserts they still default to `0.0`, because once the engine stops sleeping those flags are the only thing left holding the pacing decision.

### The second commit fixes the guard itself

The first version patched `replay_engine.time.sleep`, with a docstring claiming that patching the module rather than `time` left the rest of the process alone. That is wrong: `replay_engine.time` is the `time` module object, so the patch applied process-wide, and the daemon threads that `tests/surfaces/` starts and never joins landed in the recorder. In the full suite the guard collected 2142 calls of 0.016 s from a 60 Hz poll loop, against a replay that can sleep at most six times.

It passed alone, passed on CI, and failed only in the full local run, which is the signature in #1203. `0e0f8d1` records only the sleeps issued on the calling thread and forwards the rest to the real function, so other threads stay paced rather than spinning.

## Checks

| Check | Result |
|---|---|
| full local suite, after | **1455 passed, 4 skipped, 0 failed in 521.38s (8m41s)**, was `2 failed, 1447 passed, 4 skipped in 1097.54s (18m17s)` |
| the two affected files | 444.3 s to 4.90 s |
| guard RED against the defect | reverting the default to `3.0` fails with `AssertionError: the default engine slept 18.0 s across 6 calls`, both before and after the thread filter, so the filter did not blind it |
| pollution reproduced and fixed | naive recorder fails in 10.59 s next to `test_arcade_stream_server.py` and `test_arcade_wire_contract.py`; the same three pass in 10.01 s with the filter |
| `uvx ruff@0.16.6 check .` | All checks passed |
| `uvx ruff@0.16.6 format --check .` | 388 files already formatted |
| `uv run mypy src/rag/` | no issues in 3 source files |
| CI | 19 checks, 0 failing |

## Out of scope

- Parallelism and a marker for the golden re-derivations, tracked in #1204. Measured: over the same set, serial 560.54 s against 323.65 s with `-n auto --dist=loadfile` on 20 workers, only 1.73x because `tests/eval/test_registry_golden.py` is 226.7 s on its own.
- The order-dependent arcade guards in #1203. They passed in both post-fix full runs, so they are intermittent rather than deterministic; the evidence and a 10 s reproduction of a related pollution mechanism are in a comment there.

What remains of the suite is the five golden re-derivations: `test_calibration_flags_pit_coverage_drift` 158.4 s, `test_decision_modes` 78.3 s, `test_ml_recompute_golden` 63.6 s, `test_mc_measured_tables` 59.6 s, `test_cli_no_llm_smoke` 25.4 s. Those re-derive committed figures from real data and are the point of the suite, so #1204 gives them a marker rather than trimming them.

Closes #1202
