### PR TITLE
perf(tests): declare pytest-xdist and mark the last unmarked golden re-derivation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,14 @@ dev = [
     "pytest>=9.0.3",
     "pytest-cov>=4.1.0",
     "pytest-asyncio>=0.21.0",
+    # Parallel runner, opt-in per run rather than in addopts: a single failing
+    # test reads better serially. Measured on 20 logical cores, three legs back
+    # to back: the whole suite serially is 628.7 s, `-m "not data"` serially is
+    # 115.6 s, and `-m "not data" -n auto --dist=loadfile` is 61.5 s. So the
+    # marker does most of the work and xdist is worth 1.88x on top of it. The
+    # gain stays far under the core count because with loadfile no run can go
+    # below its slowest single FILE.
+    "pytest-xdist>=3.6.0",
     "black>=26.3.1",
     "ruff>=0.16.6",
     "mypy>=1.0.0",

--- a/tests/mc/test_mc_measured_tables.py
+++ b/tests/mc/test_mc_measured_tables.py
@@ -196,6 +196,11 @@ def test_the_neutralisation_rate_is_keyed_by_circuit_slugs_agents_can_query(tabl
 # ---------------------------------------------------------------------------
 
 
+# `data` as well as the two skipifs: the skipifs decide whether this CAN run, the
+# marker is what lets a save-loop run opt out with `-m "not data"` on a box where
+# it CAN. It is 86 s, and it was the only one of the five golden re-derivations
+# the marker did not already cover.
+@pytest.mark.data
 @_skip_no_raw
 @_skip_no_undercut
 def test_the_committed_tables_match_a_fresh_measurement():

--- a/uv.lock
+++ b/uv.lock
@@ -1115,6 +1115,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1215,6 +1224,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -1259,6 +1269,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-multipart", specifier = ">=0.0.31" },
     { name = "pytorch-lightning", specifier = ">=2.0.0" },
@@ -4169,6 +4180,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Declares `pytest-xdist` in the `dev` extra and adds the one missing `@pytest.mark.data`, so a save-loop run drops from 628.7 s to 61.5 s.

## Why

Two levers from #1204, both measured there and neither applied. One of them turned out to be mostly done.

`pytest-xdist` was not in `pyproject.toml` and `addopts` carries no `-n`, so `-n auto` was simply unavailable on a clean checkout.

The marker half was smaller than the issue describes. It asks to mark "the five golden re-derivations"; four of them already carry `@pytest.mark.data`, and `-m "not data"` deselected 65 of 1462 tests before this change. The only one that escaped was `test_the_committed_tables_match_a_fresh_measurement` (86 s), which carries two `skipif`s but no marker. Those are different jobs: the skipifs decide whether the test *can* run, the marker is what lets a developer skip it on a box where it can.

## How

- `pyproject.toml`: `pytest-xdist>=3.6.0` in the `dev` extra, plus `uv.lock` re-resolved. CI runs `uv sync --frozen`, so the lock had to move with it. Deliberately not added to `addopts`, because a single failing test reads better serially.
- `tests/mc/test_mc_measured_tables.py:199`: `@pytest.mark.data` on the function, not on the module. The other eleven tests in that file are structural invariants whose docstring says they run everywhere including a CI runner with no data, so marking the module would have taken them out too.

## Checks

Three legs, back to back on 20 logical cores, on this branch:

| leg | wall | result |
|---|---|---|
| whole suite, serial | 628.7 s | 1458 passed, 4 skipped |
| `-m "not data"`, serial | 115.6 s | 1392 passed, 4 skipped, 66 deselected |
| `-m "not data" -n auto --dist=loadfile` | 61.5 s | 1392 passed, 4 skipped |

The marker is the larger share and xdist is 1.88x on top of it. That is above the 1.73x in the issue because that leg still included `tests/eval/test_registry_golden.py`, 226.7 s on its own, which with `--dist=loadfile` is the floor of the run; deselecting it lowers the floor. The prior session measured the full serial suite at 521 s against 628.7 s here, so the ratios between today's three legs are the reliable part, not the absolute seconds.

Selection verified both directions: the five named golden tests go from 4-of-5 to 5-of-5 deselected under `-m "not data"`, and the eleven structural tests in the touched file stay selected (11/12 collected under the filter). `pytest tests/mc/test_mc_measured_tables.py` is 12 passed in 126.7 s. `ruff check` and `ruff format --check` clean. `uv sync --all-extras --frozen --dry-run` resolves.

## Out of scope

No new test. A guard here would assert that pytest's own marker selection works, which is a test written to prove its own change is fine. The real guard is `uv sync --frozen` in CI, which fails if `uv.lock` drifts from `pyproject.toml`.

The issue's ordering note is satisfied: #1202 landed in `594422dd`.

Closes #1204