### PR TITLE
fix(eval): finalize 2025 penalty lifecycle evidence

### DIFF
--- a/documents/audits/MEASURE_724_stop_purpose.json
+++ b/documents/audits/MEASURE_724_stop_purpose.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-09-08T12:59:07+00:00",
+  "generated_at": "2026-09-08T13:20:07+00:00",
   "year": 2025,
   "races": 24,
   "raw_lap_rows": 26692,
@@ -20,17 +20,17 @@
     "pit_entries": 841,
     "in_715_sample": 573,
     "labels": {
-      "PENALTY_SERVICE": 2,
+      "PENALTY_SERVICE": 4,
       "REGULATION_REQUIRED_STOP": 34,
       "STRATEGIC_TYRE_CHANGE": 707,
-      "UNKNOWN": 98
+      "UNKNOWN": 96
     },
     "cohorts": {
       "mixed": 11,
-      "penalty_only": 2,
+      "penalty_only": 4,
       "regulation_forced": 33,
       "strategic_candidate": 697,
-      "unknown": 98
+      "unknown": 96
     },
     "telemetry_set_change": {
       "confirmed": 709,
@@ -66,6 +66,594 @@
     "source_conflicts": 1,
     "decision_comparable": 0
   },
+  "penalty_lifecycle_summary": {
+    "ambiguous": 1,
+    "resolved": 1,
+    "resolved_with_conflict": 1,
+    "served_without_pit_assignment": 20,
+    "unresolved": 29
+  },
+  "penalty_lifecycle": [
+    {
+      "penalty_id": "9693:5:5s:1",
+      "session_key": 9693,
+      "driver_number": 5,
+      "penalty_type": "5s",
+      "awarded_evidence_id": "bfc12eea5c6b03dd",
+      "served_evidence_id": "ef96419ec2647d3c",
+      "candidate_event_ids": [],
+      "status": "served_without_pit_assignment",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9693:12:5s:1",
+      "session_key": 9693,
+      "driver_number": 12,
+      "penalty_type": "5s",
+      "awarded_evidence_id": "09931726a765fb0c",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9839:10:5s:1",
+      "session_key": 9839,
+      "driver_number": 10,
+      "penalty_type": "5s",
+      "awarded_evidence_id": "c4ab5cfeb583a8f2",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9839:18:5s:1",
+      "session_key": 9839,
+      "driver_number": 18,
+      "penalty_type": "5s",
+      "awarded_evidence_id": "dd64c317d62986c3",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9839:22:5s:1",
+      "session_key": 9839,
+      "driver_number": 22,
+      "penalty_type": "5s",
+      "awarded_evidence_id": "0d4f2ef78c1ce0cf",
+      "served_evidence_id": "04953257922c3ec3",
+      "candidate_event_ids": [],
+      "status": "served_without_pit_assignment",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9839:23:5s:1",
+      "session_key": 9839,
+      "driver_number": 23,
+      "penalty_type": "5s",
+      "awarded_evidence_id": "3359e5d3e18cfc25",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9839:30:5s:1",
+      "session_key": 9839,
+      "driver_number": 30,
+      "penalty_type": "5s",
+      "awarded_evidence_id": "6220c2f89779185e",
+      "served_evidence_id": "712a6ced685d854d",
+      "candidate_event_ids": [],
+      "status": "served_without_pit_assignment",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9839:87:5s:1",
+      "session_key": 9839,
+      "driver_number": 87,
+      "penalty_type": "5s",
+      "awarded_evidence_id": "a904ef2b7aa04dcc",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9850:18:5s:1",
+      "session_key": 9850,
+      "driver_number": 18,
+      "penalty_type": "5s",
+      "awarded_evidence_id": "47199a513b61c597",
+      "served_evidence_id": "c92fe25261200466",
+      "candidate_event_ids": [],
+      "status": "served_without_pit_assignment",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9850:31:5s:1",
+      "session_key": 9850,
+      "driver_number": 31,
+      "penalty_type": "5s",
+      "awarded_evidence_id": "93316ee732fda71a",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9850:31:other:1",
+      "session_key": 9850,
+      "driver_number": 31,
+      "penalty_type": "other",
+      "awarded_evidence_id": "3ed4254dcf2ab099",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9850:87:stop_go:1",
+      "session_key": 9850,
+      "driver_number": 87,
+      "penalty_type": "stop_go",
+      "awarded_evidence_id": "85a32a1061ad8467",
+      "served_evidence_id": "827af7d7abf9046c",
+      "candidate_event_ids": [
+        "2025:9850:87:40:3",
+        "2025:9850:87:41:4"
+      ],
+      "status": "ambiguous",
+      "review_note": "multiple compatible entries; no nearest-entry guess"
+    },
+    {
+      "penalty_id": "9858:12:5s:1",
+      "session_key": 9858,
+      "driver_number": 12,
+      "penalty_type": "5s",
+      "awarded_evidence_id": "627c4b5a3c3e480f",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9858:23:5s:1",
+      "session_key": 9858,
+      "driver_number": 23,
+      "penalty_type": "5s",
+      "awarded_evidence_id": "ae432305596bb32f",
+      "served_evidence_id": "cf64e15e36d4b686",
+      "candidate_event_ids": [],
+      "status": "served_without_pit_assignment",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9869:22:10s:1",
+      "session_key": 9869,
+      "driver_number": 22,
+      "penalty_type": "10s",
+      "awarded_evidence_id": "66a1f7149ca8bd96",
+      "served_evidence_id": "6eaa1fe7e490776a",
+      "candidate_event_ids": [],
+      "status": "served_without_pit_assignment",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9869:22:10s:2",
+      "session_key": 9869,
+      "driver_number": 22,
+      "penalty_type": "10s",
+      "awarded_evidence_id": "4d49a49de1d8cec1",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9869:22:other:1",
+      "session_key": 9869,
+      "driver_number": 22,
+      "penalty_type": "other",
+      "awarded_evidence_id": "11608e09b24395d5",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9869:44:5s:1",
+      "session_key": 9869,
+      "driver_number": 44,
+      "penalty_type": "5s",
+      "awarded_evidence_id": "b30be86d95d91d37",
+      "served_evidence_id": "6261ae6d9bad4979",
+      "candidate_event_ids": [],
+      "status": "served_without_pit_assignment",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9869:81:10s:1",
+      "session_key": 9869,
+      "driver_number": 81,
+      "penalty_type": "10s",
+      "awarded_evidence_id": "10242d065d090f91",
+      "served_evidence_id": "5ad7a710429d7433",
+      "candidate_event_ids": [],
+      "status": "served_without_pit_assignment",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9877:44:10s:1",
+      "session_key": 9877,
+      "driver_number": 44,
+      "penalty_type": "10s",
+      "awarded_evidence_id": "8c1cee3fac61036c",
+      "served_evidence_id": "d13197f3808589f0",
+      "candidate_event_ids": [],
+      "status": "served_without_pit_assignment",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9877:55:5s:1",
+      "session_key": 9877,
+      "driver_number": 55,
+      "penalty_type": "5s",
+      "awarded_evidence_id": "f7f9b57c72b56eab",
+      "served_evidence_id": "97c234f9cc178d82",
+      "candidate_event_ids": [],
+      "status": "served_without_pit_assignment",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9877:55:drive_through:1",
+      "session_key": 9877,
+      "driver_number": 55,
+      "penalty_type": "drive_through",
+      "awarded_evidence_id": "d71e8cf3d9451da8",
+      "served_evidence_id": "74c2ee01d180a8d7",
+      "candidate_event_ids": [
+        "2025:9877:55:56:3"
+      ],
+      "status": "resolved",
+      "review_note": "one compatible entry between award and served confirmation"
+    },
+    {
+      "penalty_id": "9904:14:5s:1",
+      "session_key": 9904,
+      "driver_number": 14,
+      "penalty_type": "5s",
+      "awarded_evidence_id": "ac1ba4e9065fc4de",
+      "served_evidence_id": "3702f89bf3980030",
+      "candidate_event_ids": [],
+      "status": "served_without_pit_assignment",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9904:23:10s:1",
+      "session_key": 9904,
+      "driver_number": 23,
+      "penalty_type": "10s",
+      "awarded_evidence_id": "15de0f17aeb73f60",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9904:81:5s:1",
+      "session_key": 9904,
+      "driver_number": 81,
+      "penalty_type": "5s",
+      "awarded_evidence_id": "24efcc297d0497ae",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9912:12:5s:1",
+      "session_key": 9912,
+      "driver_number": 12,
+      "penalty_type": "5s",
+      "awarded_evidence_id": "3d9617d476edaa45",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9912:31:5s:1",
+      "session_key": 9912,
+      "driver_number": 31,
+      "penalty_type": "5s",
+      "awarded_evidence_id": "73d38704ff4dac2d",
+      "served_evidence_id": "d35fabe337d955a2",
+      "candidate_event_ids": [],
+      "status": "served_without_pit_assignment",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9912:87:10s:1",
+      "session_key": 9912,
+      "driver_number": 87,
+      "penalty_type": "10s",
+      "awarded_evidence_id": "c39823fa3794c964",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9920:12:10s:1",
+      "session_key": 9920,
+      "driver_number": 12,
+      "penalty_type": "10s",
+      "awarded_evidence_id": "f4b62a399fd18fcd",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9920:12:5s:1",
+      "session_key": 9920,
+      "driver_number": 12,
+      "penalty_type": "5s",
+      "awarded_evidence_id": "811bf40e1f4589a4",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9920:55:10s:1",
+      "session_key": 9920,
+      "driver_number": 55,
+      "penalty_type": "10s",
+      "awarded_evidence_id": "5e2160d4fc43f720",
+      "served_evidence_id": "3dd1637a04e85780",
+      "candidate_event_ids": [],
+      "status": "served_without_pit_assignment",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9928:10:10s:1",
+      "session_key": 9928,
+      "driver_number": 10,
+      "penalty_type": "10s",
+      "awarded_evidence_id": "29efad2a25fc33d3",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9928:16:5s:1",
+      "session_key": 9928,
+      "driver_number": 16,
+      "penalty_type": "5s",
+      "awarded_evidence_id": "a0efc7f3cf43c126",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9928:27:5s:1",
+      "session_key": 9928,
+      "driver_number": 27,
+      "penalty_type": "5s",
+      "awarded_evidence_id": "f4aaca16d13cceb0",
+      "served_evidence_id": "82d8afa308a65bb1",
+      "candidate_event_ids": [],
+      "status": "served_without_pit_assignment",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9947:22:10s:1",
+      "session_key": 9947,
+      "driver_number": 22,
+      "penalty_type": "10s",
+      "awarded_evidence_id": "323db645b60932b8",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9947:81:10s:1",
+      "session_key": 9947,
+      "driver_number": 81,
+      "penalty_type": "10s",
+      "awarded_evidence_id": "e2b9b9f68fe72ebc",
+      "served_evidence_id": "36268d113c2ce625",
+      "candidate_event_ids": [],
+      "status": "served_without_pit_assignment",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9955:22:10s:1",
+      "session_key": 9955,
+      "driver_number": 22,
+      "penalty_type": "10s",
+      "awarded_evidence_id": "249ac3fe2199a01d",
+      "served_evidence_id": "8d8fdf4f274918de",
+      "candidate_event_ids": [],
+      "status": "served_without_pit_assignment",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9955:43:5s:1",
+      "session_key": 9955,
+      "driver_number": 43,
+      "penalty_type": "5s",
+      "awarded_evidence_id": "bb3fb371c7ab7c5a",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9963:18:10s:1",
+      "session_key": 9963,
+      "driver_number": 18,
+      "penalty_type": "10s",
+      "awarded_evidence_id": "2b40a556518856a4",
+      "served_evidence_id": "23eda2d7adf7961d",
+      "candidate_event_ids": [],
+      "status": "served_without_pit_assignment",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9971:1:10s:1",
+      "session_key": 9971,
+      "driver_number": 1,
+      "penalty_type": "10s",
+      "awarded_evidence_id": "9a2bb3e3dc7d728f",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9971:23:10s:1",
+      "session_key": 9971,
+      "driver_number": 23,
+      "penalty_type": "10s",
+      "awarded_evidence_id": "90f97c965c57262e",
+      "served_evidence_id": "0e9343c1e1ea1d3a",
+      "candidate_event_ids": [],
+      "status": "served_without_pit_assignment",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9971:87:10s:1",
+      "session_key": 9971,
+      "driver_number": 87,
+      "penalty_type": "10s",
+      "awarded_evidence_id": "96eb3693cb308df9",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "9979:63:drive_through:1",
+      "session_key": 9979,
+      "driver_number": 63,
+      "penalty_type": "drive_through",
+      "awarded_evidence_id": "9baaa9f4bba1ed46",
+      "served_evidence_id": "a76f84a2a64e51da",
+      "candidate_event_ids": [
+        "2025:9979:63:53:1"
+      ],
+      "status": "resolved_with_conflict",
+      "review_note": "one compatible entry between award and served confirmation"
+    },
+    {
+      "penalty_id": "9998:7:10s:1",
+      "session_key": 9998,
+      "driver_number": 7,
+      "penalty_type": "10s",
+      "awarded_evidence_id": "d8b56dd958f4f863",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "10014:4:5s:1",
+      "session_key": 10014,
+      "driver_number": 4,
+      "penalty_type": "5s",
+      "awarded_evidence_id": "598153d126dcf362",
+      "served_evidence_id": "cfc17cb136d753c2",
+      "candidate_event_ids": [],
+      "status": "served_without_pit_assignment",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "10014:7:5s:1",
+      "session_key": 10014,
+      "driver_number": 7,
+      "penalty_type": "5s",
+      "awarded_evidence_id": "75293b420b7aaac1",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "10014:30:10s:1",
+      "session_key": 10014,
+      "driver_number": 30,
+      "penalty_type": "10s",
+      "awarded_evidence_id": "b2fe028d795a86dd",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "10014:30:5s:1",
+      "session_key": 10014,
+      "driver_number": 30,
+      "penalty_type": "5s",
+      "awarded_evidence_id": "3438c265b472468e",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "10014:55:10s:1",
+      "session_key": 10014,
+      "driver_number": 55,
+      "penalty_type": "10s",
+      "awarded_evidence_id": "b282f5cecff3b8d5",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "10022:1:5s:1",
+      "session_key": 10022,
+      "driver_number": 1,
+      "penalty_type": "5s",
+      "awarded_evidence_id": "198f9f3eeb53449c",
+      "served_evidence_id": "13a840e0db86180b",
+      "candidate_event_ids": [],
+      "status": "served_without_pit_assignment",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "10022:30:10s:1",
+      "session_key": 10022,
+      "driver_number": 30,
+      "penalty_type": "10s",
+      "awarded_evidence_id": "2e132d26cf6b671f",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    },
+    {
+      "penalty_id": "10033:22:5s:1",
+      "session_key": 10033,
+      "driver_number": 22,
+      "penalty_type": "5s",
+      "awarded_evidence_id": "2342c54bf289c547",
+      "served_evidence_id": null,
+      "candidate_event_ids": [],
+      "status": "unresolved",
+      "review_note": "time penalty may be served during a tyre stop or added to the result"
+    }
+  ],
   "evidence": [
     {
       "evidence_id": "008c99ddbe543ade",
@@ -1552,7 +2140,7 @@
       "car_numbers": [
         87
       ],
-      "penalty_type": "10s",
+      "penalty_type": "stop_go",
       "phase": "served",
       "forced_entry": false
     },
@@ -1589,7 +2177,7 @@
       "car_numbers": [
         87
       ],
-      "penalty_type": "10s",
+      "penalty_type": "stop_go",
       "phase": "awarded",
       "forced_entry": false
     },
@@ -14445,12 +15033,12 @@
       "telemetry_set_change": "unknown",
       "tyre_change_resolved": "unknown",
       "source_conflict": false,
-      "primary_label": "UNKNOWN",
+      "primary_label": "PENALTY_SERVICE",
       "secondary_label": null,
-      "penalty_type": "10s",
+      "penalty_type": "stop_go",
       "penalty_served": "unknown",
       "regulation_constraint": "none",
-      "timing_discretion": "unknown",
+      "timing_discretion": "forced_window",
       "decision_comparable": false,
       "mixed_purpose": false,
       "evidence_level": "corroborated",
@@ -14460,8 +15048,8 @@
         "85a32a1061ad8467"
       ],
       "in_715_sample": true,
-      "comparison_cohort": "unknown",
-      "review_note": "manual review required"
+      "comparison_cohort": "penalty_only",
+      "review_note": ""
     },
     {
       "event_id": "2025:9850:87:41:4",
@@ -14501,12 +15089,12 @@
       "telemetry_set_change": "unknown",
       "tyre_change_resolved": "unknown",
       "source_conflict": false,
-      "primary_label": "UNKNOWN",
+      "primary_label": "PENALTY_SERVICE",
       "secondary_label": null,
-      "penalty_type": "10s",
+      "penalty_type": "stop_go",
       "penalty_served": "unknown",
       "regulation_constraint": "none",
-      "timing_discretion": "unknown",
+      "timing_discretion": "forced_window",
       "decision_comparable": false,
       "mixed_purpose": false,
       "evidence_level": "corroborated",
@@ -14516,8 +15104,8 @@
         "85a32a1061ad8467"
       ],
       "in_715_sample": true,
-      "comparison_cohort": "unknown",
-      "review_note": "manual review required"
+      "comparison_cohort": "penalty_only",
+      "review_note": ""
     },
     {
       "event_id": "2025:9850:5:7:1",

--- a/documents/audits/MEASURE_724_stop_purpose.md
+++ b/documents/audits/MEASURE_724_stop_purpose.md
@@ -4,7 +4,7 @@ This is a retrospective evidence inventory for the decision-layer work.
 It does not change the scorer and it does not treat the team's observed
 pit entry as proof that the team's decision was optimal.
 
-- generated `2026-09-08T12:59:07+00:00`
+- generated `2026-09-08T13:20:07+00:00`
 - races: 24
 - RAW lap rows: 26692
 - PitInTime entries: 841
@@ -12,7 +12,7 @@ pit entry as proof that the team's decision was optimal.
 - complete OpenF1 RCM rows: 2216
 - filtered local RCM rows: 1534
 - messages containing `PENALTY`: 77
-- penalty announcements / served confirmations: 77 / 23
+- penalty-text messages / served confirmations: 77 / 23
 - penalty-text messages classified as generic collisions: 22
 - non-null `LapStartDate` rows: 0
 - tyre metadata repair: 2 races, 308 ages made unknown
@@ -24,10 +24,10 @@ pit entry as proof that the team's decision was optimal.
 
 | primary label | entries |
 | --- | ---: |
-| `PENALTY_SERVICE` | 2 |
+| `PENALTY_SERVICE` | 4 |
 | `REGULATION_REQUIRED_STOP` | 34 |
 | `STRATEGIC_TYRE_CHANGE` | 707 |
-| `UNKNOWN` | 98 |
+| `UNKNOWN` | 96 |
 
 | telemetry set-change signal | entries |
 | --- | ---: |
@@ -40,6 +40,21 @@ telemetry set-change signal (compound change or age reset) after the pit
 entry, but that is only telemetry evidence. It does not prove the entry was
 strategic. Same-compound entries can mount a used set, and a drive-through
 can leave contradictory stint metadata.
+
+## Penalty lifecycle
+
+| status | penalties |
+| --- | ---: |
+| `ambiguous` | 1 |
+| `resolved` | 1 |
+| `resolved_with_conflict` | 1 |
+| `served_without_pit_assignment` | 20 |
+| `unresolved` | 29 |
+
+A served confirmation is retained as historical evidence. It is only linked
+to a pit entry when the award, car, temporal window, and service constraints
+leave a compatible candidate. Otherwise the lifecycle remains unresolved or
+ambiguous and cannot affect the comparable no-call denominator.
 
 ## Measurement contract
 
@@ -55,13 +70,13 @@ review, not confirmed ground truth.
 - The local RCM parquet is the filtered runtime mirror; the complete pass uses
   cached OpenF1 race-control rows and keeps the local mirror only for coverage
   comparison.
-- RAW `LapStartDate` is empty. OpenF1 lap starts reconstruct approximate UTC for the
-  835/841 entries;
-  entries. OpenF1 documents `date_start` as approximate; the remaining entries
-  stay explicitly unanchored and are not silently approximated.
+- RAW `LapStartDate` is empty. OpenF1 lap starts reconstruct approximate UTC for
+  835/841 entries; OpenF1 documents `date_start` as approximate.
+  The remaining entries stay explicitly unanchored and are not silently
+  approximated.
 - Absence of a local message means no evidence in this corpus, not no penalty.
-- The classifier's generic event category is not a sanction ledger; a future
-  parser must preserve awarded, served, cancelled, investigated, and unresolved
+- The generic event category is not a sanction ledger; the lifecycle output
+  preserves awarded, served, investigated, no-further-action, and unresolved
   states separately.
 
 ## Adjudication check

--- a/scripts/measure_stop_purpose.py
+++ b/scripts/measure_stop_purpose.py
@@ -11,6 +11,7 @@ import argparse
 import hashlib
 import json
 from collections import Counter
+from dataclasses import asdict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -21,7 +22,11 @@ from src.data_extraction.openf1.radio_dataset_builder import OPENF1_BASE, build_
 from src.f1_strat_manager.rcm_events import RCMEvent, classify_rcm_event
 from src.f1_strat_manager.tyre_stint_repair import repair_tyre_stints
 from src.strategy.eval.decision_modes import SAMPLED_RACES
-from src.strategy.eval.stop_purpose import build_stop_purpose_records, parse_rcm_message
+from src.strategy.eval.stop_purpose import (
+    build_penalty_lifecycle,
+    build_stop_purpose_records,
+    parse_rcm_message,
+)
 
 ROOT = Path(__file__).resolve().parents[1]
 RAW_ROOT = ROOT / "data" / "raw" / "2025"
@@ -214,7 +219,7 @@ def _render_markdown(payload: dict[str, Any]) -> str:
         f"- complete OpenF1 RCM rows: {payload['rcm_rows']}",
         f"- filtered local RCM rows: {payload['local_rcm_rows']}",
         f"- messages containing `PENALTY`: {payload['penalty_messages']}",
-        f"- penalty announcements / served confirmations: {payload['penalty_messages']} / "
+        f"- penalty-text messages / served confirmations: {payload['penalty_messages']} / "
         f"{payload['penalty_served_messages']}",
         f"- penalty-text messages classified as generic collisions: {payload['penalty_as_collision']}",
         f"- non-null `LapStartDate` rows: {payload['lap_start_date_nonnull']}",
@@ -248,6 +253,24 @@ def _render_markdown(payload: dict[str, Any]) -> str:
             "strategic. Same-compound entries can mount a used set, and a drive-through",
             "can leave contradictory stint metadata.",
             "",
+            "## Penalty lifecycle",
+            "",
+            "| status | penalties |",
+            "| --- | ---: |",
+        ]
+    )
+    lines.extend(
+        f"| `{status}` | {count} |"
+        for status, count in payload["penalty_lifecycle_summary"].items()
+    )
+    lines.extend(
+        [
+            "",
+            "A served confirmation is retained as historical evidence. It is only linked",
+            "to a pit entry when the award, car, temporal window, and service constraints",
+            "leave a compatible candidate. Otherwise the lifecycle remains unresolved or",
+            "ambiguous and cannot affect the comparable no-call denominator.",
+            "",
             "## Measurement contract",
             "",
             "Each entry receives one primary label and keeps secondary causes, evidence IDs,",
@@ -262,14 +285,14 @@ def _render_markdown(payload: dict[str, Any]) -> str:
             "- The local RCM parquet is the filtered runtime mirror; the complete pass uses",
             "  cached OpenF1 race-control rows and keeps the local mirror only for coverage",
             "  comparison.",
-            "- RAW `LapStartDate` is empty. OpenF1 lap starts reconstruct approximate UTC for the",
+            "- RAW `LapStartDate` is empty. OpenF1 lap starts reconstruct approximate UTC for",
             f"  {summary['timestamp_alignment'].get('anchored_openf1_lap_approximate', 0)}"
-            f"/{summary['pit_entries']} entries;",
-            "  entries. OpenF1 documents `date_start` as approximate; the remaining entries",
-            "  stay explicitly unanchored and are not silently approximated.",
+            f"/{summary['pit_entries']} entries; OpenF1 documents `date_start` as approximate.",
+            "  The remaining entries stay explicitly unanchored and are not silently",
+            "  approximated.",
             "- Absence of a local message means no evidence in this corpus, not no penalty.",
-            "- The classifier's generic event category is not a sanction ledger; a future",
-            "  parser must preserve awarded, served, cancelled, investigated, and unresolved",
+            "- The generic event category is not a sanction ledger; the lifecycle output",
+            "  preserves awarded, served, investigated, no-further-action, and unresolved",
             "  states separately.",
             "",
             "## Adjudication check",
@@ -352,6 +375,7 @@ def main(*, refresh: bool = False) -> None:
     penalty_messages = 0
     penalty_as_collision = 0
     evidence: dict[str, dict[str, Any]] = {}
+    evidence_objects = {}
     for frame in complete_rcm_by_session.values():
         penalty_messages += int(
             frame["message"].astype(str).str.contains("PENALTY", case=False).sum()
@@ -373,6 +397,7 @@ def main(*, refresh: bool = False) -> None:
                 penalty_as_collision += classified == "CAR_COLLISION"
             parsed = parse_rcm_message(row)
             if parsed is not None:
+                evidence_objects[parsed.evidence_id] = parsed
                 evidence[parsed.evidence_id] = {
                     "evidence_id": parsed.evidence_id,
                     "session_key": parsed.session_key,
@@ -384,6 +409,8 @@ def main(*, refresh: bool = False) -> None:
                     "phase": parsed.phase,
                     "forced_entry": parsed.forced_entry,
                 }
+
+    penalty_lifecycles = build_penalty_lifecycle(records, evidence_objects.values())
 
     payload = {
         "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
@@ -406,6 +433,10 @@ def main(*, refresh: bool = False) -> None:
         "lap_start_date_nonnull": lap_start_date_nonnull,
         "repair": dict(repair_counts),
         "summary": summary,
+        "penalty_lifecycle_summary": dict(
+            sorted(Counter(item.status for item in penalty_lifecycles).items())
+        ),
+        "penalty_lifecycle": [asdict(item) for item in penalty_lifecycles],
         "evidence": sorted(evidence.values(), key=lambda item: item["evidence_id"]),
         "records": [record.as_dict() for record in records],
     }

--- a/src/strategy/eval/stop_purpose.py
+++ b/src/strategy/eval/stop_purpose.py
@@ -52,6 +52,21 @@ class RCMEvidence:
 
 
 @dataclass(frozen=True)
+class PenaltyLifecycle:
+    """One penalty state sequence and its conservative pit-entry candidates."""
+
+    penalty_id: str
+    session_key: int | None
+    driver_number: int
+    penalty_type: str
+    awarded_evidence_id: str
+    served_evidence_id: str | None
+    candidate_event_ids: tuple[str, ...]
+    status: str
+    review_note: str
+
+
+@dataclass(frozen=True)
 class StopPurposeRecord:
     """One observed pit entry and the evidence currently attached to it."""
 
@@ -191,10 +206,10 @@ def _message_id(session_key: int | None, date: Any, message: str) -> str:
 
 
 def _penalty_type(message: str) -> str:
-    upper = message.upper().replace("-", " ")
+    upper = message.upper().replace("-", " ").replace("/", " ")
     if "DRIVE THROUGH" in upper:
         return "drive_through"
-    if "STOP AND GO" in upper or "STOP & GO" in upper:
+    if "STOP AND GO" in upper or "STOP & GO" in upper or "STOP GO" in upper:
         return "stop_go"
     match = _SECONDS_PATTERN.search(upper)
     if match:
@@ -400,6 +415,107 @@ def _evidence_timing(evidence: Iterable[RCMEvidence], pit_lap: int, pit_in_utc: 
     if before:
         return "pre_entry"
     return "unknown"
+
+
+def _timestamp(value: str | None) -> pd.Timestamp:
+    return pd.to_datetime(value, utc=True, errors="coerce")
+
+
+def build_penalty_lifecycle(
+    records: Iterable[StopPurposeRecord], evidence: Iterable[RCMEvidence]
+) -> list[PenaltyLifecycle]:
+    """Pair penalty announcements with confirmations without guessing a stop."""
+    records_by_driver: dict[tuple[int | None, int], list[StopPurposeRecord]] = {}
+    for record in records:
+        records_by_driver.setdefault((record.session_key, record.driver_number), []).append(record)
+
+    grouped: dict[tuple[int | None, int, str], dict[str, list[RCMEvidence]]] = {}
+    for item in evidence:
+        if item.penalty_type == "unknown" or not item.car_numbers:
+            continue
+        for driver_number in item.car_numbers:
+            key = (item.session_key, driver_number, item.penalty_type)
+            grouped.setdefault(key, {"awarded": [], "served": []})
+            if item.phase == "awarded":
+                grouped[key]["awarded"].append(item)
+            elif item.phase == "served":
+                grouped[key]["served"].append(item)
+
+    lifecycles: list[PenaltyLifecycle] = []
+    for (session_key, driver_number, penalty_type), phases in sorted(grouped.items()):
+        awards = sorted(phases["awarded"], key=lambda item: (item.rcm_lap or 0, item.date or ""))
+        served = sorted(phases["served"], key=lambda item: (item.rcm_lap or 0, item.date or ""))
+        used_served: set[str] = set()
+        driver_records = records_by_driver.get((session_key, driver_number), [])
+        for sequence, award in enumerate(awards, start=1):
+            award_timestamp = _timestamp(award.date)
+            served_item = next(
+                (
+                    item
+                    for item in served
+                    if item.evidence_id not in used_served
+                    and (
+                        pd.isna(award_timestamp)
+                        or pd.isna(_timestamp(item.date))
+                        or _timestamp(item.date) >= award_timestamp
+                    )
+                ),
+                None,
+            )
+            if served_item is not None:
+                used_served.add(served_item.evidence_id)
+
+            candidates = []
+            for record in driver_records:
+                if penalty_type not in {"drive_through", "stop_go"}:
+                    continue
+                if (
+                    award.rcm_lap is not None
+                    and not award.rcm_lap <= record.pit_in_lap <= award.rcm_lap + 3
+                ):
+                    continue
+                pit_timestamp = _timestamp(record.pit_in_utc)
+                if pd.notna(award_timestamp) and pd.notna(pit_timestamp):
+                    if pit_timestamp < award_timestamp - pd.Timedelta(seconds=60):
+                        continue
+                    if served_item is not None:
+                        served_timestamp = _timestamp(served_item.date)
+                        if pd.notna(
+                            served_timestamp
+                        ) and pit_timestamp > served_timestamp + pd.Timedelta(seconds=60):
+                            continue
+                candidates.append(record)
+
+            if penalty_type not in {"drive_through", "stop_go"}:
+                status = "served_without_pit_assignment" if served_item else "unresolved"
+                note = "time penalty may be served during a tyre stop or added to the result"
+            elif len(candidates) == 1 and served_item is not None:
+                status = "resolved_with_conflict" if candidates[0].source_conflict else "resolved"
+                note = "one compatible entry between award and served confirmation"
+            elif len(candidates) > 1:
+                status = "ambiguous"
+                note = "multiple compatible entries; no nearest-entry guess"
+            elif len(candidates) == 1:
+                status = "candidate_without_confirmation"
+                note = "compatible entry found but no served confirmation in the feed"
+            else:
+                status = "unresolved"
+                note = "no compatible entry can be established from the available evidence"
+
+            lifecycles.append(
+                PenaltyLifecycle(
+                    penalty_id=f"{session_key}:{driver_number}:{penalty_type}:{sequence}",
+                    session_key=session_key,
+                    driver_number=driver_number,
+                    penalty_type=penalty_type,
+                    awarded_evidence_id=award.evidence_id,
+                    served_evidence_id=None if served_item is None else served_item.evidence_id,
+                    candidate_event_ids=tuple(record.event_id for record in candidates),
+                    status=status,
+                    review_note=note,
+                )
+            )
+    return lifecycles
 
 
 def _labels(

--- a/tests/eval/test_stop_purpose.py
+++ b/tests/eval/test_stop_purpose.py
@@ -13,6 +13,7 @@ from src.strategy.eval.stop_purpose import (
     PENALTY_SERVICE,
     STRATEGIC_TYRE_CHANGE,
     UNKNOWN,
+    build_penalty_lifecycle,
     build_stop_purpose_records,
     parse_rcm_message,
 )
@@ -55,9 +56,19 @@ def test_penalty_parser_extracts_car_and_distinguishes_investigation() -> None:
     assert penalty.car_numbers == (63,)
     assert penalty.penalty_type == "drive_through"
     assert penalty.phase == "awarded"
+    stop_go = parse_rcm_message(
+        {
+            "session_key": 1,
+            "lap_number": 40,
+            "date": "2025-04-01T12:00:00Z",
+            "message": "10 SECOND STOP/GO PENALTY FOR CAR 87 (BEA)",
+        }
+    )
     assert investigation is not None
     assert investigation.penalty_type == "unknown"
     assert investigation.phase == "under_investigation"
+    assert stop_go is not None
+    assert stop_go.penalty_type == "stop_go"
 
 
 def test_openf1_manifest_pins_payload_and_date_range() -> None:
@@ -171,6 +182,61 @@ def test_late_penalty_confirmation_is_not_attached_to_a_later_stop() -> None:
         (68, STRATEGIC_TYRE_CHANGE),
     ]
     assert all(record.penalty_type == "none" for record in records)
+
+
+def test_penalty_lifecycle_resolves_russell_to_the_compatible_entry_only() -> None:
+    laps = _laps(
+        DriverNumber=["63"] * 6,
+        Driver=["RUS"] * 6,
+        LapNumber=[53, 54, 62, 63, 68, 69],
+        LapStartTime=[100, 200, 300, 400, 500, 600],
+        PitInTime=[210, None, 1310, None, 1510, None],
+        PitOutTime=[None, 230, None, 1330, None, 1530],
+        Compound=["HARD", "MEDIUM", "MEDIUM", "MEDIUM", "MEDIUM", "HARD"],
+        TyreLife=[53, 1, 9, 10, 15, 1],
+        Stint=[1, 2, 2, 2, 2, 3],
+        TrackStatus=["1"] * 6,
+    )
+    rcm = _rcm(
+        session_key=[9979, 9979],
+        lap_number=[53, 78],
+        date=["2025-05-25T14:11:10Z", "2025-05-25T14:45:40Z"],
+        message=[
+            "FIA STEWARDS: DRIVE THROUGH PENALTY FOR CAR 63 (RUS)",
+            "PENALTY SERVED - DRIVE THROUGH PENALTY FOR CAR 63 (RUS)",
+        ],
+    )
+    openf1_laps = pd.DataFrame(
+        {
+            "driver_number": [63] * 6,
+            "lap_number": [53, 54, 62, 63, 68, 69],
+            "date_start": [
+                "2025-05-25T14:13:00Z",
+                "2025-05-25T14:14:00Z",
+                "2025-05-25T14:25:00Z",
+                "2025-05-25T14:26:00Z",
+                "2025-05-25T14:33:00Z",
+                "2025-05-25T14:34:00Z",
+            ],
+        }
+    )
+    records = build_stop_purpose_records(
+        laps,
+        rcm,
+        year=2025,
+        race="Monaco",
+        session_key=9979,
+        meeting_key=1261,
+        sample_stops=set(),
+        openf1_laps=openf1_laps,
+    )
+    evidence = [parse_rcm_message(row) for _, row in rcm.iterrows()]
+
+    [lifecycle] = build_penalty_lifecycle(records, [item for item in evidence if item is not None])
+
+    assert lifecycle.status == "resolved_with_conflict"
+    assert lifecycle.candidate_event_ids == ("2025:9979:63:53:1",)
+    assert lifecycle.served_evidence_id is not None
 
 
 def test_drive_through_evidence_wins_over_conflicting_telemetry() -> None:


### PR DESCRIPTION
## Summary

- qualify OpenF1 temporal anchors as approximate and keep six missing anchors explicit
- add cache provenance for 48 public OpenF1 responses
- add a penalty lifecycle ledger for awarded, served, unresolved, ambiguous, and conflict states
- prevent late PENALTY SERVED confirmations from attaching to unrelated later stops
- keep the deterministic decision scorer unchanged

## Verified result

- 24 2025 sessions
- 841 unique PitInTime entries
- 2,216 complete OpenF1 race-control rows versus 1,534 filtered local rows
- 77 penalty-text messages and 23 served confirmations
- 835/841 approximate OpenF1 lap anchors; 6 explicitly missing
- penalty lifecycle: 1 resolved, 1 resolved with telemetry conflict, 1 ambiguous, 20 served without pit assignment, 29 unresolved
- 709 telemetry set-change signals, 11 mixed-purpose entries, 98 unresolved-purpose entries

## Verification

- 8 stop-purpose unit tests passed
- 1 real 2025 inventory test passed
- 48 cached responses refreshed with HTTP 200 and recorded in the ignored cache manifest
- Ruff and diff checks passed

The remaining issue is manual adjudication of the ambiguous and unresolved cohorts before recalculating the comparable missed-pit-call denominator. No production behaviour or LLM path changes.