### PR TITLE
fix(nlp): match repeated penalty confirmations by reason

### DIFF
--- a/documents/audits/MEASURE_724_stop_purpose.json
+++ b/documents/audits/MEASURE_724_stop_purpose.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-09-08T17:15:26+00:00",
+  "generated_at": "2026-09-08T18:12:34+00:00",
   "year": 2025,
   "races": 24,
   "raw_lap_rows": 26692,
@@ -226,9 +226,9 @@
       "driver_number": 22,
       "penalty_type": "10s",
       "awarded_evidence_id": "66a1f7149ca8bd96",
-      "served_evidence_id": "6eaa1fe7e490776a",
+      "served_evidence_id": null,
       "candidate_event_ids": [],
-      "status": "served_without_pit_assignment",
+      "status": "unresolved",
       "review_note": "time penalty may be served during a tyre stop or added to the result"
     },
     {
@@ -237,9 +237,9 @@
       "driver_number": 22,
       "penalty_type": "10s",
       "awarded_evidence_id": "4d49a49de1d8cec1",
-      "served_evidence_id": null,
+      "served_evidence_id": "6eaa1fe7e490776a",
       "candidate_event_ids": [],
-      "status": "unresolved",
+      "status": "served_without_pit_assignment",
       "review_note": "time penalty may be served during a tyre stop or added to the result"
     },
     {

--- a/documents/audits/MEASURE_724_stop_purpose.md
+++ b/documents/audits/MEASURE_724_stop_purpose.md
@@ -4,7 +4,7 @@ This is a retrospective evidence inventory for the decision-layer work.
 It does not change the scorer and it does not treat the team's observed
 pit entry as proof that the team's decision was optimal.
 
-- generated `2026-09-08T17:15:26+00:00`
+- generated `2026-09-08T18:12:34+00:00`
 - races: 24
 - RAW lap rows: 26692
 - PitInTime entries: 841

--- a/src/strategy/eval/stop_purpose.py
+++ b/src/strategy/eval/stop_purpose.py
@@ -8,6 +8,7 @@ separate and deliberately leaves unresolved cases visible for review.
 from __future__ import annotations
 
 import hashlib
+import re
 from collections.abc import Iterable
 from dataclasses import asdict, dataclass
 from typing import Any
@@ -401,6 +402,13 @@ def _timestamp(value: str | None) -> pd.Timestamp:
     return pd.to_datetime(value, utc=True, errors="coerce")
 
 
+def _penalty_reason(message: str) -> str:
+    """Return the official reason suffix used to distinguish repeated penalties."""
+    normalised = " ".join(message.upper().split())
+    match = re.search(r"\bFOR CAR\s+\d+\s*(?:\([^)]+\))?\s*-\s*(.+)$", normalised)
+    return "" if match is None else match.group(1).strip(" .")
+
+
 def build_penalty_lifecycle(
     records: Iterable[StopPurposeRecord], evidence: Iterable[RCMEvidence]
 ) -> list[PenaltyLifecycle]:
@@ -429,19 +437,38 @@ def build_penalty_lifecycle(
         driver_records = records_by_driver.get((session_key, driver_number), [])
         for sequence, award in enumerate(awards, start=1):
             award_timestamp = _timestamp(award.date)
-            served_item = next(
-                (
+            eligible_served = [
+                item
+                for item in served
+                if item.evidence_id not in used_served
+                and (
+                    pd.isna(award_timestamp)
+                    or pd.isna(_timestamp(item.date))
+                    or _timestamp(item.date) >= award_timestamp
+                )
+            ]
+            award_reason = _penalty_reason(award.message)
+            if award_reason:
+                contextual_served = [
                     item
-                    for item in served
-                    if item.evidence_id not in used_served
-                    and (
-                        pd.isna(award_timestamp)
-                        or pd.isna(_timestamp(item.date))
-                        or _timestamp(item.date) >= award_timestamp
-                    )
-                ),
-                None,
-            )
+                    for item in eligible_served
+                    if _penalty_reason(item.message) == award_reason
+                ]
+                if len(contextual_served) == 1:
+                    served_item = contextual_served[0]
+                elif (
+                    not contextual_served
+                    and len(eligible_served) == 1
+                    and not _penalty_reason(eligible_served[0].message)
+                ):
+                    # Some official confirmations omit the reason. A sole
+                    # reason-less confirmation is still safe to pair; multiple
+                    # candidates remain unresolved rather than guessed.
+                    served_item = eligible_served[0]
+                else:
+                    served_item = None
+            else:
+                served_item = eligible_served[0] if len(eligible_served) == 1 else None
             if served_item is not None:
                 used_served.add(served_item.evidence_id)
 

--- a/tests/eval/test_stop_purpose.py
+++ b/tests/eval/test_stop_purpose.py
@@ -239,6 +239,61 @@ def test_penalty_lifecycle_resolves_russell_to_the_compatible_entry_only() -> No
     assert lifecycle.served_evidence_id is not None
 
 
+def test_repeated_same_type_penalties_keep_their_lifecycle_context() -> None:
+    rcm = _rcm(
+        session_key=[9869, 9869, 9869],
+        lap_number=[12, 33, 50],
+        date=[
+            "2025-11-09T17:21:01Z",
+            "2025-11-09T17:47:45Z",
+            "2025-11-09T18:08:36Z",
+        ],
+        message=[
+            "FIA STEWARDS: 10 SECOND TIME PENALTY FOR CAR 22 (TSU) - CAUSING A COLLISION",
+            "FIA STEWARDS: 10 SECOND TIME PENALTY FOR CAR 22 (TSU) - "
+            "FAILING TO SERVE TIME PENALTY CORRECTLY",
+            "FIA STEWARDS: PENALTY SERVED - 10 SECOND TIME PENALTY FOR CAR 22 (TSU) - "
+            "FAILING TO SERVE TIME PENALTY CORRECTLY",
+        ],
+    )
+    evidence = [parse_rcm_message(row) for _, row in rcm.iterrows()]
+    evidence = [item for item in evidence if item is not None]
+
+    lifecycles = build_penalty_lifecycle([], evidence)
+
+    assert len(lifecycles) == 2
+    assert lifecycles[0].served_evidence_id is None
+    assert lifecycles[1].served_evidence_id == evidence[2].evidence_id
+
+
+@pytest.mark.data
+@pytest.mark.skipif(
+    not (
+        ROOT / "data" / "processed" / "stop_purpose" / "2025" / "openf1_rcm" / "9869.json"
+    ).is_file(),
+    reason="São Paulo RCM cache absent",
+)
+def test_sao_paulo_repeated_tsunoda_penalties_keep_distinct_lifecycles() -> None:
+    cache = ROOT / "data" / "processed" / "stop_purpose" / "2025" / "openf1_rcm" / "9869.json"
+    rows = json.loads(cache.read_text(encoding="utf-8"))
+    evidence = [parse_rcm_message(row) for row in rows]
+    evidence = [item for item in evidence if item is not None]
+    lifecycles = build_penalty_lifecycle([], evidence)
+    tsunoda = [
+        item for item in lifecycles if item.driver_number == 22 and item.penalty_type == "10s"
+    ]
+    messages = {item.evidence_id: item.message for item in evidence}
+
+    assert len(tsunoda) == 2
+    collision, service_failure = tsunoda
+    assert "CAUSING A COLLISION" in messages[collision.awarded_evidence_id]
+    assert collision.served_evidence_id is None
+    assert (
+        "FAILING TO SERVE TIME PENALTY CORRECTLY" in messages[service_failure.awarded_evidence_id]
+    )
+    assert service_failure.served_evidence_id is not None
+
+
 def test_drive_through_evidence_wins_over_conflicting_telemetry() -> None:
     laps = _laps(
         DriverNumber=["63", "63"],


### PR DESCRIPTION
Keeps repeated penalties for the same car and penalty type tied to the reason stated by race control. Adds synthetic and cached Sao Paulo regressions for Tsunoda two 10-second penalties. Regenerates the 2025 evidence inventory; the main counts are unchanged, but the served confirmation is no longer assigned to the wrong award. No scorer or legacy event-label behaviour changes. Refs #1222.