### PR TITLE
fix(llm): share LM Studio host across clients

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,10 +15,9 @@ F1_LLM_PROVIDER=openai
 OPENAI_API_KEY=sk-your-key-here
 
 # --- LM Studio (only when F1_LLM_PROVIDER=lmstudio) ---
-# Host running the LM Studio server, read by the telemetry backend
-# (src/telemetry/backend/services/chatbot/llm_service.py:26). The port is fixed at
-# 1234. Both compose files already set it to host.docker.internal so a container
-# reaches the server on the host.
+# Host running the LM Studio server, read by the backend and all agent clients.
+# The port is fixed at 1234. Both compose files already set it to
+# host.docker.internal so a container reaches the server on the host.
 # LM_STUDIO_HOST=localhost
 
 # --- Model per layer (optional) ---

--- a/src/agents/README.md
+++ b/src/agents/README.md
@@ -202,4 +202,9 @@ Both defaults live in `src/agents/_shared_defaults.py`, resolved by `subagent_mo
 `orchestrator_model()` at the moment a client is built, so setting either variable after import
 still takes effect. `OrchestratorCFG.model_name` overrides the second one for a single process.
 
+When `F1_LLM_PROVIDER=lmstudio`, every agent client also resolves its endpoint at build time from
+`LM_STUDIO_HOST` through `lm_studio_base_url()`. The default host is `localhost` and the port is
+1234; compose sets the host to `host.docker.internal` so the container reaches LM Studio on the
+host.
+
 Notebooks default to `local-model` (LM Studio). Switch to the OpenAI model IDs above when deploying via FastAPI.

--- a/src/agents/_shared_defaults.py
+++ b/src/agents/_shared_defaults.py
@@ -129,6 +129,8 @@ DEFAULT_TRACK_TEMP_C: float = 34.7
 # synthesis and runs a stronger one.
 _DEFAULT_SUBAGENT_MODEL: str = "gpt-4.1-mini"
 _DEFAULT_ORCHESTRATOR_MODEL: str = "gpt-5.4-mini"
+_DEFAULT_LM_STUDIO_HOST: str = "localhost"
+_LM_STUDIO_PORT: int = 1234
 
 
 def subagent_model() -> str:
@@ -151,3 +153,13 @@ def orchestrator_model() -> str:
         prose and the sub-agents only fill a small structured output.
     """
     return os.environ.get("F1_LLM_MODEL_ORCHESTRATOR", _DEFAULT_ORCHESTRATOR_MODEL)
+
+
+def lm_studio_base_url() -> str:
+    """Return the LM Studio URL shared by every local LLM client.
+
+    ``LM_STUDIO_HOST`` is read at call time so compose can point container clients
+    at the host without changing the Python modules.
+    """
+    host = os.environ.get("LM_STUDIO_HOST") or _DEFAULT_LM_STUDIO_HOST
+    return f"http://{host}:{_LM_STUDIO_PORT}/v1"

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -43,6 +43,7 @@ from src.strategy.inference.guard_rails import (
 from src.agents._shared_defaults import (
     DEFAULT_TOTAL_LAPS,
     LLM_MAX_RETRIES,
+    lm_studio_base_url,
     subagent_model,
 )
 from src.agents.race_state_builder import UNKNOWN_TYRE_LIFE
@@ -1374,7 +1375,7 @@ class PitStrategyAgent:
         self,
         provider: str = None,
         model_name: str = None,
-        base_url: str = 'http://localhost:1234/v1',
+        base_url: str | None = None,
         api_key: str = 'lm-studio',
     ):
         """Return the LangGraph ReAct agent, creating it on the first call (lazy).
@@ -1387,7 +1388,7 @@ class PitStrategyAgent:
             provider: 'lmstudio' (default) or 'openai'.
             model_name: Model identifier for ChatOpenAI. Defaults to
                 ``subagent_model()``, which reads ``F1_LLM_MODEL_AGENTS``.
-            base_url: Base URL for LM Studio (ignored when provider='openai').
+            base_url: Optional base URL for LM Studio. Defaults to ``LM_STUDIO_HOST``.
             api_key: API key; 'lm-studio' for local server.
 
         Returns:
@@ -1414,7 +1415,7 @@ class PitStrategyAgent:
 
         if provider == 'lmstudio':
             llm = ChatOpenAI(
-                base_url=base_url,
+                base_url=base_url or lm_studio_base_url(),
                 api_key=api_key,
                 model=model_name,
                 temperature=0,

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -34,6 +34,7 @@ from src.agents._shared_defaults import (
     DEFAULT_TOTAL_LAPS,
     DEFAULT_TRACK_TEMP_C,
     LLM_MAX_RETRIES,
+    lm_studio_base_url,
     reading_or_default,
     subagent_model,
 )
@@ -1516,7 +1517,7 @@ class RaceSituationAgent:
         self,
         provider: str = None,
         model_name: str = None,
-        base_url: str = "http://localhost:1234/v1",
+        base_url: str | None = None,
         api_key: str = "lm-studio",
     ):
         """Return the LangGraph ReAct agent, creating it on the first call (lazy).
@@ -1528,7 +1529,7 @@ class RaceSituationAgent:
             provider: 'lmstudio' (default) or 'openai'.
             model_name: Model identifier for ChatOpenAI. Defaults to
                 ``subagent_model()``, which reads ``F1_LLM_MODEL_AGENTS``.
-            base_url: Base URL for LM Studio (ignored when provider='openai').
+            base_url: Optional base URL for LM Studio. Defaults to ``LM_STUDIO_HOST``.
             api_key: API key; use 'lm-studio' for local server.
 
         Returns:
@@ -1556,7 +1557,7 @@ class RaceSituationAgent:
         if provider == "lmstudio":
             llm = ChatOpenAI(
                 model=model_name,
-                base_url=base_url,
+                base_url=base_url or lm_studio_base_url(),
                 api_key=api_key,
                 temperature=0,
                 timeout=120,

--- a/src/agents/radio_agent.py
+++ b/src/agents/radio_agent.py
@@ -143,7 +143,7 @@ from src.f1_strat_manager.rcm_events import (  # noqa: E402
     classify_rcm_event as _classify_rcm_event,
 )
 
-from src.agents._shared_defaults import LLM_MAX_RETRIES, subagent_model
+from src.agents._shared_defaults import LLM_MAX_RETRIES, lm_studio_base_url, subagent_model
 
 
 
@@ -819,7 +819,7 @@ def _get_radio_llm():
         else:
             base_llm = ChatOpenAI(
                 model=model_name,
-                base_url="http://localhost:1234/v1",
+                base_url=lm_studio_base_url(),
                 api_key="lm-studio",
                 temperature=0.0,
                 model_kwargs={"parallel_tool_calls": False},

--- a/src/agents/rag_agent.py
+++ b/src/agents/rag_agent.py
@@ -48,7 +48,7 @@ from src.rag.retriever import (  # noqa: E402
     query_rag_tool,
 )
 
-from src.agents._shared_defaults import LLM_MAX_RETRIES, subagent_model
+from src.agents._shared_defaults import LLM_MAX_RETRIES, lm_studio_base_url, subagent_model
 
 # ── Optional LangChain / LangGraph imports ─────────────────────────────
 # Probed, not imported. `import langchain_openai` costs 14.3 s measured: it drags
@@ -190,7 +190,7 @@ def get_rag_react_agent():
         else:
             llm = ChatOpenAI(
                 model=model_name,
-                base_url="http://localhost:1234/v1",
+                base_url=lm_studio_base_url(),
                 api_key="lm-studio",
                 temperature=0,
                 model_kwargs={"parallel_tool_calls": False},

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -47,7 +47,7 @@ import numpy as np
 import pandas as pd
 from pydantic import BaseModel, ConfigDict, Field
 
-from src.agents._shared_defaults import LLM_MAX_RETRIES, orchestrator_model
+from src.agents._shared_defaults import LLM_MAX_RETRIES, lm_studio_base_url, orchestrator_model
 
 logger = logging.getLogger(__name__)
 
@@ -146,7 +146,7 @@ class OrchestratorCFG:
     # policy at import. Set it to override for one process; otherwise `orchestrator_model()` wins.
     # `scripts/prompt_ab/_common.py:apply_model_flag` writes it for an A/B run.
     model_name:             str | None = None
-    base_url:               str   = "http://localhost:1234/v1"
+    base_url:               str | None = None
     temperature:            float = 0.0
     n_sim:                  int   = 500
     sc_prob_threshold:      float = 0.30
@@ -205,7 +205,7 @@ def _get_orchestrator_llm():
         else:
             llm = ChatOpenAI(
                 model=model_name,
-                base_url=CFG.base_url,
+                base_url=CFG.base_url or lm_studio_base_url(),
                 api_key="lm-studio",
                 temperature=CFG.temperature,
                 model_kwargs={"parallel_tool_calls": False},

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -38,6 +38,7 @@ from src.agents._shared_defaults import (
     DEFAULT_TOTAL_LAPS,
     DEFAULT_TRACK_TEMP_C,
     LLM_MAX_RETRIES,
+    lm_studio_base_url,
     reading_or_default,
     subagent_model,
 )
@@ -1465,7 +1466,7 @@ class TireAgent:
         self,
         provider: str = None,
         model_name: str = None,
-        base_url: str = "http://localhost:1234/v1",
+        base_url: str | None = None,
         api_key: str = "lm-studio",
     ):
         """Return the LangGraph ReAct agent, creating it on the first call (lazy).
@@ -1477,7 +1478,7 @@ class TireAgent:
             provider: 'lmstudio' (default) or 'openai'.
             model_name: Model identifier for ChatOpenAI. Defaults to
                 ``subagent_model()``, which reads ``F1_LLM_MODEL_AGENTS``.
-            base_url: Base URL for LM Studio (ignored when provider='openai').
+            base_url: Optional base URL for LM Studio. Defaults to ``LM_STUDIO_HOST``.
             api_key: API key; use 'lm-studio' for local server.
 
         Returns:
@@ -1508,7 +1509,7 @@ class TireAgent:
         if provider == "lmstudio":
             llm = ChatOpenAI(
                 model=model_name,
-                base_url=base_url,
+                base_url=base_url or lm_studio_base_url(),
                 api_key=api_key,
                 temperature=0,
                 timeout=120,

--- a/src/strategy/eval/alert_llm.py
+++ b/src/strategy/eval/alert_llm.py
@@ -25,6 +25,7 @@ from dataclasses import asdict, dataclass
 from typing import Any
 
 from src.f1_strat_manager.data_cache import get_data_root
+from src.agents._shared_defaults import lm_studio_base_url
 from src.strategy.eval.nlp import _ALERT_INTENTS, _load_intent_setfit_free
 from src.strategy.eval.report import build_header, write_report
 
@@ -67,7 +68,7 @@ def _make_judge_llm() -> Any:
     if provider == "lmstudio":
         return ChatOpenAI(
             model="local-model",
-            base_url="http://localhost:1234/v1",
+            base_url=lm_studio_base_url(),
             api_key="lm-studio",
             temperature=0,
         )

--- a/tests/agents/test_model_name_is_single_sourced.py
+++ b/tests/agents/test_model_name_is_single_sourced.py
@@ -77,6 +77,17 @@ def test_the_resolvers_read_their_environment_variable(monkeypatch: pytest.Monke
     assert orchestrator_model() == "sentinel-orchestrator"
 
 
+def test_lm_studio_url_reads_the_shared_host_at_call_time(monkeypatch: pytest.MonkeyPatch):
+    """Compose's host override reaches clients built after the environment changes."""
+    from src.agents._shared_defaults import lm_studio_base_url
+
+    monkeypatch.setenv("LM_STUDIO_HOST", "host.docker.internal")
+    assert lm_studio_base_url() == "http://host.docker.internal:1234/v1"
+
+    monkeypatch.setenv("LM_STUDIO_HOST", "127.0.0.1")
+    assert lm_studio_base_url() == "http://127.0.0.1:1234/v1"
+
+
 @pytest.mark.parametrize("module", _LLM_MODULES)
 def test_the_module_never_hardcodes_its_model(module: str):
     """Both provider branches pass a name; neither restates a model id."""
@@ -93,6 +104,41 @@ def test_the_module_never_hardcodes_its_model(module: str):
             f"it through subagent_model() / orchestrator_model() in "
             f"src.agents._shared_defaults, so the policy moves in one place."
         )
+
+
+def test_lm_studio_clients_never_hardcode_their_base_url():
+    """Every local client resolves its host instead of freezing localhost."""
+    modules = (*_LLM_MODULES,)
+    for module in modules:
+        tree = ast.parse((AGENTS / module).read_text(encoding="utf-8"))
+        values = [
+            kw.value
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "ChatOpenAI"
+            for kw in node.keywords
+            if kw.arg == "base_url"
+        ]
+        assert values, f"{module} has no explicit LM Studio base_url"
+        assert all(not isinstance(value, ast.Constant) for value in values), (
+            f"{module} freezes a literal LM Studio base_url; use "
+            "lm_studio_base_url() so compose can reach the host"
+        )
+
+    alert_tree = ast.parse(
+        (ROOT / "src" / "strategy" / "eval" / "alert_llm.py").read_text(encoding="utf-8")
+    )
+    alert_values = [
+        kw.value
+        for node in ast.walk(alert_tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "ChatOpenAI"
+        for kw in node.keywords
+        if kw.arg == "base_url"
+    ]
+    assert alert_values and all(not isinstance(value, ast.Constant) for value in alert_values)
 
 
 @pytest.mark.data
@@ -114,10 +160,13 @@ def test_every_layer_sends_the_model_the_resolver_returns(monkeypatch: pytest.Mo
     import langchain_openai
 
     sent: list[str] = []
+    urls: list[str] = []
 
     class _Recorder:
         def __init__(self, **kwargs):
             sent.append(kwargs.get("model"))
+            if "base_url" in kwargs:
+                urls.append(kwargs["base_url"])
 
         def with_structured_output(self, *args, **kwargs):
             return self
@@ -128,6 +177,7 @@ def test_every_layer_sends_the_model_the_resolver_returns(monkeypatch: pytest.Mo
     monkeypatch.setattr(langchain_openai, "ChatOpenAI", _Recorder)
     monkeypatch.setattr(langchain.agents, "create_agent", lambda *a, **k: object())
     monkeypatch.setenv("F1_LLM_PROVIDER", "lmstudio")
+    monkeypatch.setenv("LM_STUDIO_HOST", "host.docker.internal")
     monkeypatch.setenv("F1_LLM_MODEL_AGENTS", "sentinel-agents")
     monkeypatch.setenv("F1_LLM_MODEL_ORCHESTRATOR", "sentinel-orchestrator")
 
@@ -154,15 +204,21 @@ def test_every_layer_sends_the_model_the_resolver_returns(monkeypatch: pytest.Mo
         ("rag", lambda: (setattr(rag_agent, "_rag_agent", None), rag_agent.get_rag_react_agent())),
     ):
         sent.clear()
+        urls.clear()
         build()
         assert sent and set(sent) == {"sentinel-agents"}, (
             f"{name} sent {sorted(set(sent))}, not the sub-agent resolver's value. A "
             f"model_name that is declared but never read is exactly the #264 defect."
         )
+        assert set(urls) == {"http://host.docker.internal:1234/v1"}, (
+            f"{name} sent {sorted(set(urls))}, not the compose host"
+        )
 
     sent.clear()
+    urls.clear()
     monkeypatch.setattr(strategy_orchestrator, "_orchestrator_llm", None)
     strategy_orchestrator._get_orchestrator_llm()
     assert set(sent) == {"sentinel-orchestrator"}, (
         f"the orchestrator sent {sorted(set(sent))}, not the Layer 3 resolver's value"
     )
+    assert set(urls) == {"http://host.docker.internal:1234/v1"}


### PR DESCRIPTION
## Qué cambia\n\nCorrige #1211, el fallo por el que los agentes intentaban conectar con localhost:1234 dentro del contenedor mientras el chat usaba el host correcto. Todos los clientes locales, incluido el juez de alertas, resuelven ahora la URL mediante LM_STUDIO_HOST en el momento de construir el cliente.\n\nSe mantiene el override explícito de ase_url en los tres agentes que ya lo aceptaban. El puerto sigue siendo 1234 y compose conserva host.docker.internal.\n\n## Verificación\n\n- 11 tests específicos, incluidos los seis módulos de agentes y el juez de alertas.\n- 25 tests relacionados pasados.\n- Ruff, diff --check y documentación actualizada.\n- No se cambia el proveedor por defecto, que pertenece a #1210, la decisión separada sobre qué superficie debe arrancar con cada proveedor.