### PR TITLE
fix(agents): preserve unknown circuit cluster sentinel

### DIFF
--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -524,7 +524,7 @@ class PaceAgent:
         # `circuit_cluster` is keyed by the parquet slug; the replay path queries with the
         # metadata name. Miami 2025 missed and took the default, which happens to be its
         # real cluster - a coincidence, not correctness (PR3_GP_KEYSPACE_SWEEP.md).
-        cluster = self.circuit_cluster.get(resolve_gp_key(self.circuit_cluster, gp_name), 1)
+        cluster = self.circuit_cluster.get(resolve_gp_key(self.circuit_cluster, gp_name), -1)
         return c_id, t_id, cluster
 
     def _compute_derived(

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -1567,10 +1567,10 @@ class TireAgent:
             # within a cluster), and a race's own mean is a per-race number that
             # happens to have the same units.
             "cluster_mean_lap_s": TireAgentConfig._TRAINED_CLUSTER_MEAN_LAP_S.get(
-                self.cfg.cluster_for(gp_name, 0), 0.0
+                self.cfg.cluster_for(gp_name, -1), 0.0
             ),
             "total_laps": int(session.total_laps),
-            "cluster_id": self.cfg.cluster_for(gp_name, 0),
+            "cluster_id": self.cfg.cluster_for(gp_name, -1),
             "team_id": _encode_team_id(self.cfg.team_id_map, stint_state.get("team", "Unknown")),
             "year": stint_state.get("year", 2025),
             "AirTemp": float(_weather.get("AirTemp", DEFAULT_AIR_TEMP_C)),
@@ -1650,10 +1650,10 @@ class TireAgent:
             # above: this race's own mean lap time is a different quantity wearing the
             # same units.
             "cluster_mean_lap_s": TireAgentConfig._TRAINED_CLUSTER_MEAN_LAP_S.get(
-                self.cfg.cluster_for(gp_name, 0), 0.0
+                self.cfg.cluster_for(gp_name, -1), 0.0
             ),
             "total_laps": total_laps,
-            "cluster_id": self.cfg.cluster_for(gp_name, 0),
+            "cluster_id": self.cfg.cluster_for(gp_name, -1),
             "team_id": _encode_team_id(self.cfg.team_id_map, team),
             "year": year,
             # reading_or_default, not .get(key, default): the producers report an

--- a/tests/agents/test_unknown_circuit_cluster.py
+++ b/tests/agents/test_unknown_circuit_cluster.py
@@ -1,0 +1,36 @@
+"""Unknown circuit names keep the training-time cluster sentinel."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent.parent
+
+
+def test_pace_unknown_circuit_does_not_become_a_real_cluster():
+    """N06's categorical encoding must preserve -1 for an unresolved circuit."""
+    from src.agents.pace_agent import PaceAgent
+
+    agent = object.__new__(PaceAgent)
+    agent.compound_id = {"SOFT": 1}
+    agent.circuit_cluster = {"Monaco": 2}
+    agent.team_id = {"McLaren": 4}
+
+    assert agent._encode_categorical("SOFT", "McLaren", "Unknown GP")[2] == -1
+
+
+def test_tire_unknown_circuit_preserves_the_explicit_fallback():
+    """N26's resolver lets its caller choose the non-trained fallback."""
+    from src.agents.tire_agent import TireAgentConfig
+
+    config = object.__new__(TireAgentConfig)
+    config.circuit_cluster_map = {"Monaco": 2}
+
+    assert config.cluster_for("Unknown GP", -1) == -1
+
+
+def test_tire_adapters_pass_the_unknown_sentinel():
+    """Both N26 adapters must pass -1 rather than the real cluster 0."""
+    source = (ROOT / "src" / "agents" / "tire_agent.py").read_text(encoding="utf-8")
+
+    assert source.count("cluster_for(gp_name, -1)") == 4

--- a/tests/agents/test_unknown_circuit_cluster.py
+++ b/tests/agents/test_unknown_circuit_cluster.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
+from tests.conftest import HAS_TIRE_MODELS
+
 ROOT = Path(__file__).parent.parent.parent
 
 
@@ -19,6 +23,8 @@ def test_pace_unknown_circuit_does_not_become_a_real_cluster():
     assert agent._encode_categorical("SOFT", "McLaren", "Unknown GP")[2] == -1
 
 
+@pytest.mark.data
+@pytest.mark.skipif(not HAS_TIRE_MODELS, reason="tire model artefacts absent")
 def test_tire_unknown_circuit_preserves_the_explicit_fallback():
     """N26's resolver lets its caller choose the non-trained fallback."""
     from src.agents.tire_agent import TireAgentConfig


### PR DESCRIPTION
## Qué cambia\n\nCorrige #1207, el bug por el que un nombre de circuito no reconocido se convertía en el cluster 0 o 1, que son clusters reales para los modelos. Pace y tire conservan ahora el sentinel -1 usado durante el entrenamiento.\n\nNo cambia las familias de clustering que usa cada modelo. Eso pertenece a #1206, el problema distinto de que los mapas de ritmo y neumáticos no coinciden en 7 de 24 circuitos y que requiere una decisión de modelado.\n\n## Verificación\n\n- 3 pruebas nuevas sobre resolutores y ambos adaptadores.\n- 7 pruebas de datos relacionadas pasadas.\n- 1429 pruebas pasadas, 4 omitidas por extras opcionales.\n- Ruff y diff --check correctos.