### PR TITLE
fix(tests): read arcade guard source from disk

### DIFF
--- a/tests/surfaces/test_arcade_columnar_frames.py
+++ b/tests/surfaces/test_arcade_columnar_frames.py
@@ -184,6 +184,7 @@ def test_the_loader_fills_every_column_exactly_once() -> None:
     real argument from a mention of one.
     """
     import ast
+
     source_path = Path(__file__).resolve().parents[2] / "src" / "arcade" / "data.py"
     tree = ast.parse(source_path.read_text(encoding="utf-8"))
     method = next(

--- a/tests/surfaces/test_arcade_columnar_frames.py
+++ b/tests/surfaces/test_arcade_columnar_frames.py
@@ -19,6 +19,7 @@ frame that went in at index `i`, field by field.
 from __future__ import annotations
 
 import pickle
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -183,15 +184,16 @@ def test_the_loader_fills_every_column_exactly_once() -> None:
     real argument from a mention of one.
     """
     import ast
-    import inspect
-    import textwrap
-
-    from src.arcade.data import SessionLoader
-
-    source = textwrap.dedent(inspect.getsource(SessionLoader._resample_driver))
+    source_path = Path(__file__).resolve().parents[2] / "src" / "arcade" / "data.py"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    method = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "_resample_driver"
+    )
     calls = [
         node
-        for node in ast.walk(ast.parse(source))
+        for node in ast.walk(method)
         if isinstance(node, ast.Call)
         and isinstance(node.func, ast.Name)
         and node.func.id == "DriverFrames"


### PR DESCRIPTION
## Qué cambia\n\nCorrige la parte reproducible de #1203, el fallo por el que dos guards del arcade podían depender del orden de ejecución de los tests. El guard que comprueba que _resample_driver rellena todas las columnas ya no inspecciona el atributo vivo, que otro test podría sustituir; analiza directamente src/arcade/data.py.\n\nLa segunda anomalía del issue, relacionada con hilos de tests que sobreviven, sigue sin reproducirse de forma determinista y no se fuerza un cierre inventando una explicación.\n\n## Verificación\n\n- 3 regresiones directas pasadas.\n- 583 tests de 	ests/surfaces pasados.\n- Ruff y diff --check correctos.