### PR TITLE
docs(ci): remove retired voice extra references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,11 @@ env:
 #   - `lint` does NOT call `uv sync`. Ruff is the only tool it needs, so
 #     `uvx ruff` runs it as an ephemeral tool — skips installing the full
 #     ML/torch stack just to lint Python style.
-#   - `typecheck` calls `uv sync --extra dev` (mypy lives in the dev extra)
-#     but skips `--all-extras` since the `voice` extra is irrelevant to
-#     `src/rag/`. It also caches `.mypy_cache/` so incremental runs only
+#   - `typecheck` calls `uv sync --extra dev` (mypy lives in the only declared
+#     extra). It also caches `.mypy_cache/` so incremental runs only
 #     re-check files whose hash actually changed.
-#   - `test` keeps `uv sync --all-extras` because the test suite touches
-#     voice / streamlit / arcade paths that need every extra installed.
+#   - `test` keeps `uv sync --all-extras` so the full optional test surface is
+#     installed, including the arcade and compatibility probes.
 
 jobs:
   test:

--- a/tests/infra/test_dep_imports.py
+++ b/tests/infra/test_dep_imports.py
@@ -17,9 +17,9 @@ introduce:
   ``bool_`` alias). Grows whenever an upstream bump breaks something
   real.
 
-Every test uses ``pytest.importorskip`` so a missing optional extra
-(voice, ffmpeg-python, dev tools) does not turn the suite red on minimal
-environments — it just skips. The CI ``test`` job installs
+Every test uses ``pytest.importorskip`` so a missing optional dependency
+(ffmpeg-python or a development tool) does not turn the suite red on minimal
+environments; it just skips. The CI ``test`` job installs
 ``--all-extras`` so all of these run there.
 """
 
@@ -369,7 +369,8 @@ def test_dependency_imports(module_name):
 
     Captures install-time breakage (missing wheels, ABI mismatches,
     binary conflicts) that a behavioural test would never reach. Skips
-    cleanly when an optional extra (voice, computer vision) is absent
+    cleanly when an optional dependency (for example, a computer-vision
+    package) is absent
     from the environment, or when an upstream package is installable
     but raises at import time on the current Python (the setfit /
     frozendict / Python 3.10 trio is a recurring offender).


### PR DESCRIPTION
## Qué cambia\n\nCorrige #1189, las explicaciones de CI y del test de dependencias que todavía hablaban de una extra oice retirada. El proyecto solo declara ahora dev; se mantiene el comportamiento de instalación y de los skips.\n\n## Verificación\n\n- 57 tests de dependencias pasados, 4 skips opcionales conocidos.\n- Ruff check y format check correctos para Python.\n- YAML revisado como configuración de Actions, no como Python.\n- Diff --check correcto.