### PR TITLE
ci: align telemetry stack with uv

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - ./src/telemetry/backend:/app/backend
       - ./src:/app/src:ro
       - ./data:/app/data:ro
+      - ./data/cache/fastf1:/app/data/cache/fastf1:rw
       - ./data/rag:/app/data/rag:rw
       - backend_cache:/root/.cache
     command: uvicorn backend.main:app --host 0.0.0.0 --port 8000 --reload

--- a/docs/DOCUMENTATION_FRESHNESS.md
+++ b/docs/DOCUMENTATION_FRESHNESS.md
@@ -1,0 +1,36 @@
+# Documentation freshness queue
+
+Updated 2026-09-09 during the telemetry dependency migration.
+
+This register separates live instructions from historical migration material.
+The live entries must be updated before starting new feature work. Historical
+entries stay available for provenance, but must not be used as current setup
+instructions.
+
+## Live documentation updated in this worktree
+
+| File | Finding addressed |
+| --- | --- |
+| `docs/pages/setup.md` | Docker now documents Python 3.11, the pinned uv binary, the frozen dependency layer, CPU PyTorch on Linux, and writable cache mounts. |
+| `docs/pages/ci-cd.md` | The parent and telemetry CI workflows are now described separately, including the lightweight uv group. |
+| `docs/llms.txt` | React is now the active post-race webapp and Streamlit is marked as legacy. |
+| `src/telemetry/README.md` | Versions and local commands now match `pyproject.toml`, `uv.lock`, and the current runtime. |
+| `src/telemetry/webapp/README.md` | The current `webapp/` directory and port 8501 are documented. |
+| `src/telemetry/docs/instructions/INSTALL_INSTRUCTIONS.md` | The retired voice and pip guide was replaced with the current uv-based setup. |
+
+## Historical documentation to label and retain
+
+| File or area | Reason |
+| --- | --- |
+| `src/telemetry/docs/telemetry-architecture.md` | Describes the pre-cutover Streamlit architecture and old repository tree. |
+| `src/telemetry/docs/multimodal-implementation.md` | Contains the former Streamlit execution path. |
+| `src/telemetry/docs/audits/AUDIT_P1_BACKEND.md` | Snapshot audit from July 2026. Its packaging findings are superseded by this migration. |
+| `src/telemetry/docs/migration/**` | Migration decisions and design history. Preserve the original claims and dates. |
+| `src/telemetry/docs/archived/**` | Archived implementation plans. Do not convert them into live instructions. |
+
+## Validation gate
+
+After the live pages are updated, search again for active references to
+`pip install`, `openai-whisper`, the removed `frontend/` tree, and the old
+backend Docker flow. Any remaining match must either be current or explicitly
+inside a historical document.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # F1 StratLab
 
-> F1 StratLab is an open-source (Apache-2.0) multi-agent AI system that turns public Formula 1 telemetry (FastF1, OpenF1) and FIA regulations into real-time race-strategy recommendations. It combines seven ML predictors (lap-time delta, tire degradation, overtake, safety car, pit duration, undercut, circuit clustering), an NLP pipeline over team radio, a RAG layer over FIA rules, and a LangGraph orchestrator (N31). Built as a Final-Degree Project (TFG) by Víctor Vega Sobral for the 2022–2025 regulation era. Three delivery surfaces from one codebase: a headless CLI, a PySide6 arcade (2D replay + dashboards), and a Streamlit web app. The pages below link to the raw Markdown so AI systems can read the prose directly.
+> F1 StratLab is an open-source (Apache-2.0) multi-agent AI system that turns public Formula 1 telemetry (FastF1, OpenF1) and FIA regulations into real-time race-strategy recommendations. It combines seven ML predictors (lap-time delta, tire degradation, overtake, safety car, pit duration, undercut, circuit clustering), an NLP pipeline over team radio, a RAG layer over FIA rules, and a LangGraph orchestrator (N31). Built as a Final-Degree Project (TFG) by Víctor Vega Sobral for the 2022–2025 regulation era. Three delivery surfaces from one codebase: a headless CLI, a PySide6 arcade (2D replay + dashboards), and a React webapp for post-race analysis. The former Streamlit webapp is a legacy reference only. The pages below link to the raw Markdown so AI systems can read the prose directly.
 
 ## Start here
 - [Welcome](https://docs.f1stratlab.com/pages/home.md): What F1 StratLab is and how the layers connect.
@@ -14,7 +14,7 @@
 - [Agents API reference](https://docs.f1stratlab.com/pages/agents-api.md): Entry points, feature vectors, and Pydantic output schemas.
 
 ## Surfaces
-- [Backend API](https://docs.f1stratlab.com/pages/backend-api.md): FastAPI routers + FastMCP — telemetry, chat, voice, strategy.
+- [Backend API](https://docs.f1stratlab.com/pages/backend-api.md): FastAPI routers + FastMCP for telemetry, chat, and strategy. Voice is a legacy surface.
 - [Streamlit frontend (legacy)](https://docs.f1stratlab.com/pages/streamlit.md): Retired Streamlit app, kept for historical reference; the React web app replaced it.
 - [Arcade quick start](https://docs.f1stratlab.com/pages/arcade-quick-start.md): One-command launch of the three-window arcade.
 - [Dashboard architecture (legacy)](https://docs.f1stratlab.com/pages/arcade-dashboard.md): Retired PySide6 dashboard, kept for historical reference; PITWALL replaced it.

--- a/docs/pages/ci-cd.md
+++ b/docs/pages/ci-cd.md
@@ -46,14 +46,23 @@ Eight workflows live under `.github/workflows/`. They run independently, on diff
 
 ### `.github/workflows/ci.yml`
 
-Triggered on push to `main`, `dev`, `test`, `feat/**`, `fix/**`, `docs/**`, and on pull request targeting `main` or `dev`. Four jobs run in parallel on `ubuntu-latest`:
+Triggered on push to `main`, `dev`, `test`, `feat/**`, `fix/**`, `docs/**`, and on pull request targeting `main` or `dev`. Five jobs run in parallel on `ubuntu-latest`:
 
 - `test`, path-filter gated on `src/**`, `tests/**`, `pyproject.toml`, `uv.lock` (via `dorny/paths-filter@v4`; skips entirely on a docs-only or unrelated diff). When triggered: `uv sync --all-extras --frozen` (Python 3.12), a "collected-count floor" check (`pytest --co -q` must collect at least 40 nodes, guarding against a refactor silently gutting the suite), then `uv run pytest -v --cov=src --cov-report=term-missing`.
 - `lint`, always runs, no `uv sync` needed. `uvx ruff@$RUFF_VERSION check .` and `uvx ruff@$RUFF_VERSION format --check .` as ephemeral tools, so it skips installing the whole ML/torch stack just to lint style. The version comes from the `RUFF_VERSION` variable at the top of the workflow, pinned because an unpinned `uvx ruff` resolves the newest release at run time and can turn every branch red without a commit.
 - `typecheck`, same path-filter gate as `test`. `uv sync --extra dev --frozen` then `uv run mypy src/rag/`. Narrow scope: only production-ready typed modules are checked. Caches `.mypy_cache/` keyed on `pyproject.toml` + `src/rag/**`.
-- `pip-audit`, always runs, no path filter. Exports the locked dependency set (`uv export --frozen --all-extras`) and runs `pip-audit` against it for same-day CVE alerts, independent of whether the diff touches `uv.lock`. Advisory (`continue-on-error: true`) while baselining.
+- `pip-audit`, always runs, no path filter. Exports the locked dependency set with `uv export --frozen --no-emit-project --all-extras --no-hashes` and runs the pinned `pip-audit` tool against it for same-day CVE alerts, independent of whether the diff touches `uv.lock`. Advisory (`continue-on-error: true`) while baselining.
 
 The jobs are deliberately decoupled. A red `lint` does not stop `test` from running. `test` and `typecheck` both checkout with `fetch-depth: 0` **before** the paths-filter step, because the filter falls back to `git diff` on `push` events and needs full history.
+
+### `src/telemetry/.github/workflows/ci.yml`
+
+The telemetry submodule has its own CI in the `F1_Telemetry_Manager` repository.
+It uses `astral-sh/setup-uv@v7` with Python 3.11, pins uv to `0.9.13`, and
+caches the submodule `uv.lock`. The lint and test jobs install only the
+lightweight `ci` dependency group with `uv sync --frozen --only-group ci --no-install-project`, then run Ruff and pytest through `uv run --frozen --no-sync`. The full runtime is reserved for Docker, where the backend image
+syncs the project dependencies from the same lockfile. The parent CI checks the
+gitlink but does not replace the submodule workflow.
 
 ### `.github/workflows/release-please.yml`
 

--- a/docs/pages/setup.md
+++ b/docs/pages/setup.md
@@ -150,19 +150,27 @@ Same two services, with paths relative to `src/telemetry/` instead of the repo r
 
 The webapp Dockerfile has two stages:
 
-1. **node-builder**: `npm ci && npm run build` of the Vite + React SPA
+1. **bun-builder**: `bun install --frozen-lockfile && bun run build` of the Vite + React SPA
 2. **nginx**: serves the built assets and reverse-proxies `/api` to the backend service
 
 ### Backend Dockerfile
 
-The backend Dockerfile installs `setuptools` and `wheel` first (needed by `openai-whisper` for `pkg_resources`), then installs all requirements with `--no-build-isolation`.
+The backend image uses Python 3.11 and copies the pinned `uv` binary from the
+official uv image. It copies `pyproject.toml` and `uv.lock` before the backend
+source so Docker can reuse the dependency layer. The dependency layer runs
+`uv sync --frozen --no-dev --no-install-project` and uses CPU PyTorch wheels on
+Linux. The container puts `/app/.venv/bin` on `PATH`, so the Compose command
+and the image command execute the locked `uvicorn` installation.
+
+The host data directory remains read-only, except for the nested
+`data/cache/fastf1` mount used by FastF1. The RAG directory remains writable.
 
 ## Building the RAG index
 
 Before using the RAG Agent (N30), build the Qdrant vector index:
 
 ```bash
-python scripts/build_rag_index.py
+uv run python scripts/build_rag_index.py
 ```
 
 This processes FIA Sporting Regulations PDFs and stores embeddings in `data/rag/`.


### PR DESCRIPTION
Update the parent Compose and documentation after the telemetry submodule migrated to uv on main. Keep F1 StratLab on dev and preserve the read-only data contract with writable FastF1 and RAG cache mounts. Local verification passed: 1436 parent tests, 106 telemetry tests, Ruff, Compose config, backend health, no_llm SSE simulation, and Docker image builds.